### PR TITLE
Refactor federation init he110

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { Connect, ViteDevServer } from 'vite';
 import { devExternalsMixin } from './dev-externals-mixin';
 import { filterExternals } from './externals-skip-list';
 
-export const federation = async (params: BuildHelperParams) => {
+export const federation = (params: BuildHelperParams) => {
   return {
     name: '@module-federation/vite', // required, will show up in warnings and errors
     async options(o: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,13 @@ import { filterExternals } from './externals-skip-list';
 
 export const federation = (params: BuildHelperParams) => {
   return {
+    ...devExternalsMixin,
     name: '@module-federation/vite', // required, will show up in warnings and errors
-    async options(o: unknown) {
+    async config(...args) {
       await federationBuilder.init(params);
+      devExternalsMixin.config(...args);
+    },
+    options(o: unknown) {
       o!['external'] = filterExternals(federationBuilder.externals);
     },
     async closeBundle() {
@@ -23,7 +27,6 @@ export const federation = (params: BuildHelperParams) => {
     transformIndexHtml(html: string) {
       return html.replace(/type="module"/g, 'type="module-shim"');
     },
-    ...devExternalsMixin,
   };
 };
 


### PR DESCRIPTION
Reference https://github.com/module-federation/vite/issues/8#issuecomment-1620914897.

Fixed the vite module parsing error caused by the error call timing.

close: #8 
