### PR TITLE
Feat base url he110

### DIFF
--- a/src/dev-externals-mixin.ts
+++ b/src/dev-externals-mixin.ts
@@ -16,10 +16,16 @@ export const devExternalsMixin = {
   },
   configResolved(resolvedConfig) {
     const VALID_ID_PREFIX = `/@id/`;
-    const reg = new RegExp(`${VALID_ID_PREFIX}(${federationBuilder.externals.join('|')})`, 'g');
+    const reg = new RegExp(
+      `(?<quote>["\'])[^\'"]*?${VALID_ID_PREFIX}(${federationBuilder.externals.join(
+        '|'
+      )})\\k<quote>`,
+      'g'
+    );
     resolvedConfig.plugins.push({
       name: 'vite-plugin-ignore-static-import-replace-idprefix',
-      transform: (code) => (reg.test(code) ? code.replace(reg, (m, s1) => s1) : code),
+      transform: (code) =>
+        reg.test(code) ? code.replace(reg, (_m, quote, libName) => quote + libName + quote) : code,
     });
   },
   resolveId: (id) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,17 +38,17 @@ const configureDevServer = async (server: ViteDevServer, params: BuildHelperPara
 
   const op = params.options;
   const dist = path.join(op.workspaceRoot, op.outputPath);
-  server.middlewares.use(serveFromDist(dist));
+  server.middlewares.use(serveFromDist(dist, server.config.base));
 };
 
-const serveFromDist = (dist: string): Connect.NextHandleFunction => {
+const serveFromDist = (dist: string, baseUrl: string): Connect.NextHandleFunction => {
   return (req, res, next) => {
     if (!req.url || req.url.endsWith('/index.html')) {
       next();
       return;
     }
 
-    const file = path.join(dist, req.url);
+    const file = path.join(dist, req.url.replace(baseUrl, ''));
     if (fs.existsSync(file) && fs.lstatSync(file).isFile()) {
       res.setHeader('Access-Control-Allow-Origin', '*');
       res.setHeader('Content-Type', mime.lookup(req.url));


### PR DESCRIPTION
close #14 

The problem has two parts:

1. When base is configured, the address of `remoteEntry.json` does not match. The reason is that [this line of code](https://github.com/module-federation/vite/blob/main/src/index.ts#L51) splices the address directly, but Vite's base doesn't affect the path in dist, so the urls don't match.
2. `baseUrl` is not supported when external imports are replaced [in the plugin](https://github.com/module-federation/vite/blob/main/src/dev-externals-mixin.ts#L22). The reason is that the replacement rule only matches `/@id/${libraryName}`. When `baseUrl` is configured, the import path is: `/${baseUrl}/@id/${libraryName}`. So we need to modify the rule to match the quotes directly.