### PR TITLE
fix: remove default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,4 +280,3 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
 }
 
 export { federation };
-export default federation


### PR DESCRIPTION
default export  is not really needed and a bad practice in general to have both named and default exports of the same module.


Also this is causing number of warnings during build