### PR TITLE
fix: monorepo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,11 @@ import {
   normalizeModuleFederationOptions
 } from './utils/normalizeModuleFederationOptions';
 import normalizeOptimizeDepsPlugin from './utils/normalizeOptimizeDeps';
-import { HOST_AUTO_INIT_PATH, HOST_AUTO_INIT_QUERY_STR, REMOTE_ENTRY_ID, WRAP_REMOTE_ENTRY_PATH, WRAP_REMOTE_ENTRY_QUERY_STR } from './virtualModules/virtualRemoteEntry';
-import { getLocalSharedImportMapPath } from './virtualModules/virtualShared_preBuild';
+import { getHostAutoInitImportId, getHostAutoInitPath, getLocalSharedImportMapPath, getWrapRemoteEntryImportId, getWrapRemoteEntryPath, initVirtualModules, REMOTE_ENTRY_ID } from './virtualModules';
 
 function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
   const options = normalizeModuleFederationOptions(mfUserOptions);
+  initVirtualModules()
   const { name, remotes, shared, filename } = options;
   if (!name) throw new Error("name is required")
 
@@ -23,17 +23,17 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
     normalizeOptimizeDepsPlugin,
     ...addEntry({
       entryName: 'remoteEntry',
-      entryPath: WRAP_REMOTE_ENTRY_PATH,
+      entryPath: getWrapRemoteEntryPath(),
       fileName: filename,
     }),
     ...addEntry({
       entryName: 'hostInit',
-      entryPath: HOST_AUTO_INIT_PATH,
+      entryPath: getHostAutoInitPath(),
     }),
     pluginProxyRemoteEntry(),
     pluginProxyRemotes(options),
     ...pluginModuleParseEnd(((id: string) => {
-      return id.includes(HOST_AUTO_INIT_QUERY_STR) || id.includes(WRAP_REMOTE_ENTRY_QUERY_STR) || id.includes(REMOTE_ENTRY_ID) || id.includes(getLocalSharedImportMapPath())
+      return id.includes(getHostAutoInitImportId()) || id.includes(getWrapRemoteEntryImportId()) || id.includes(REMOTE_ENTRY_ID) || id.includes(getLocalSharedImportMapPath())
     })),
     ...proxySharedModule({
       shared,

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -1,7 +1,7 @@
 import { createFilter } from '@rollup/pluginutils';
 import { Plugin } from 'vite';
 import { getNormalizeModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
-import { generateRemoteEntry, REMOTE_ENTRY_ID } from '../virtualModules/virtualRemoteEntry';
+import { generateRemoteEntry, REMOTE_ENTRY_ID } from '../virtualModules';
 
 const filter: (id: string) => boolean = createFilter();
 

--- a/src/plugins/pluginProxyRemotes.ts
+++ b/src/plugins/pluginProxyRemotes.ts
@@ -1,7 +1,7 @@
 import { createFilter } from "@rollup/pluginutils";
 import { Plugin } from "vite";
 import { NormalizedModuleFederationOptions } from "../utils/normalizeModuleFederationOptions";
-import { generateRemotes, remoteVirtualModule } from "../virtualModules/virtualRemotes";
+import { generateRemotes, remoteVirtualModule } from "../virtualModules";
 const filter: (id: string) => boolean = createFilter();
 
 export default function (options: NormalizedModuleFederationOptions): Plugin {

--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, writeFile, writeFileSync } from "fs";
 import { dirname, join, parse, resolve } from "pathe";
 import { packageNameEncode } from "../utils/packageNameUtils";
+import { getNormalizeModuleFederationOptions } from "./normalizeModuleFederationOptions";
 
 const nodeModulesDir = function findNodeModulesDir(startDir = process.cwd()) {
   let currentDir = startDir;
@@ -38,7 +39,9 @@ export default class VirtualModule {
     return resolve(nodeModulesDir, this.getImportId())
   }
   getImportId() {
-    return `${virtualPackageName}/${packageNameEncode(this.originName)}`
+    const { name } = getNormalizeModuleFederationOptions()
+
+    return `${virtualPackageName}/${packageNameEncode(name)}-${packageNameEncode(this.originName)}`
   }
   writeSync(code: string, force?: boolean) {
     if (!force && this.inited) return

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -1,0 +1,24 @@
+import { writeHostAutoInit, writeWrapRemoteEntry } from "./virtualRemoteEntry";
+import { writeRemote } from "./virtualRemotes";
+import { writeLocalSharedImportMap } from "./virtualShared_preBuild";
+
+export {
+  generateRemoteEntry, getHostAutoInitImportId,
+  getHostAutoInitPath, getWrapRemoteEntryImportId,
+  getWrapRemoteEntryPath, REMOTE_ENTRY_ID
+} from "./virtualRemoteEntry";
+
+export {
+  generateRemotes, remoteVirtualModule
+} from "./virtualRemotes";
+
+export {
+  addShare, generateLocalSharedImportMap, getLoadShareModulePath, getLocalSharedImportMapPath, getPreBuildLibImportId, LOAD_SHARE_TAG, localSharedImportMapModule, PREBUILD_TAG, writeLoadShareModule, writeLocalSharedImportMap, writePreBuildLibPath
+} from "./virtualShared_preBuild";
+
+export function initVirtualModules() {
+  writeLocalSharedImportMap()
+  writeWrapRemoteEntry()
+  writeHostAutoInit()
+  writeRemote()
+}

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -69,21 +69,33 @@ export function generateRemoteEntry(options: NormalizedModuleFederationOptions):
 }
 
 const wrapRemoteEntryModule = new VirtualModule("wrapRemoteEntry")
-wrapRemoteEntryModule.writeSync(`
-import {init, get} from "${REMOTE_ENTRY_ID}"
-export {init, get}
-`)
-export const WRAP_REMOTE_ENTRY_QUERY_STR = wrapRemoteEntryModule.getImportId();
-export const WRAP_REMOTE_ENTRY_PATH = wrapRemoteEntryModule.getPath();
+export function writeWrapRemoteEntry() {
+  wrapRemoteEntryModule.writeSync(`
+    import {init, get} from "${REMOTE_ENTRY_ID}"
+    export {init, get}
+    `)
+}
+export function getWrapRemoteEntryImportId() {
+  return wrapRemoteEntryModule.getImportId();
+}
+export function getWrapRemoteEntryPath() {
+  return wrapRemoteEntryModule.getPath();
+}
 
 /**
  * Inject entry file, automatically init when used as host,
  * and will not inject remoteEntry
  */
 const hostAutoInitModule = new VirtualModule("hostAutoInit")
-hostAutoInitModule.writeSync(`
+export function writeHostAutoInit() {
+  hostAutoInitModule.writeSync(`
     import {init} from "${REMOTE_ENTRY_ID}"
     init()
     `)
-export const HOST_AUTO_INIT_QUERY_STR = hostAutoInitModule.getImportId();
-export const HOST_AUTO_INIT_PATH = hostAutoInitModule.getPath();
+}
+export function getHostAutoInitImportId() {
+  return hostAutoInitModule.getImportId();
+}
+export function getHostAutoInitPath() {
+  return hostAutoInitModule.getPath();
+}

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -1,7 +1,9 @@
 import VirtualModule from "../utils/VirtualModule";
 
 export const remoteVirtualModule = new VirtualModule("remoteModule")
-remoteVirtualModule.writeSync("")
+export function writeRemote() {
+  remoteVirtualModule.writeSync("")
+}
 export function generateRemotes(id: string, command: string): { code: string; map: null; syntheticNamedExports: string } {
   return {
     code: `

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -34,7 +34,6 @@ export function addShare(pkg: string) {
 
 // *** Expose locally provided shared modules here
 export const localSharedImportMapModule = new VirtualModule("localSharedImportMap")
-localSharedImportMapModule.writeSync("")
 export function getLocalSharedImportMapPath() {
   if (process.platform === "win32") {
     return getLocalSharedImportMapPath_windows()


### PR DESCRIPTION
Fixes an extreme monorepo scenario where multiple packages share a node_modules directory and multiple `shared` configurations conflict.
In this [demo](https://github.com/module-federation/vite/issues/40#issuecomment-2317363004), there is no conflict between two shared files.
