### PR TITLE
fix: Remote virtual module path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   normalizeModuleFederationOptions
 } from './utils/normalizeModuleFederationOptions';
 import normalizeOptimizeDepsPlugin from './utils/normalizeOptimizeDeps';
-import { getHostAutoInitImportId, getHostAutoInitPath, getLocalSharedImportMapPath, getWrapRemoteEntryImportId, getWrapRemoteEntryPath, initVirtualModules, REMOTE_ENTRY_ID } from './virtualModules';
+import { getHostAutoInitImportId, getHostAutoInitPath, getLocalSharedImportMapPath, initVirtualModules, REMOTE_ENTRY_ID } from './virtualModules';
 
 function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
   const options = normalizeModuleFederationOptions(mfUserOptions);
@@ -23,7 +23,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
     normalizeOptimizeDepsPlugin,
     ...addEntry({
       entryName: 'remoteEntry',
-      entryPath: getWrapRemoteEntryPath(),
+      entryPath: REMOTE_ENTRY_ID,
       fileName: filename,
     }),
     ...addEntry({
@@ -33,7 +33,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
     pluginProxyRemoteEntry(),
     pluginProxyRemotes(options),
     ...pluginModuleParseEnd(((id: string) => {
-      return id.includes(getHostAutoInitImportId()) || id.includes(getWrapRemoteEntryImportId()) || id.includes(REMOTE_ENTRY_ID) || id.includes(getLocalSharedImportMapPath())
+      return id.includes(getHostAutoInitImportId()) || id.includes(REMOTE_ENTRY_ID) || id.includes(getLocalSharedImportMapPath())
     })),
     ...proxySharedModule({
       shared,

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -9,6 +9,7 @@ interface AddEntryOptions {
 }
 
 const addEntry = ({ entryName, entryPath, fileName }: AddEntryOptions): Plugin[] => {
+  const devEntryPath = entryPath.startsWith("virtual:mf") ? "/@id/" + entryPath : entryPath
   let entryFiles: string[] = [];
   let htmlFilePath: string;
 
@@ -19,7 +20,7 @@ const addEntry = ({ entryName, entryPath, fileName }: AddEntryOptions): Plugin[]
       configureServer(server) {
         server.httpServer?.once?.('listening', () => {
           const { port } = server.config.server;
-          fetch(path.join(`http://localhost:${port}`, `${entryPath}`)).catch(e => { })
+          fetch(path.join(`http://localhost:${port}`, `${devEntryPath}`)).catch(e => { })
         });
         server.middlewares.use((req, res, next) => {
           if (!fileName) {
@@ -27,7 +28,7 @@ const addEntry = ({ entryName, entryPath, fileName }: AddEntryOptions): Plugin[]
             return
           }
           if (req.url && req.url.startsWith(fileName.replace(/^\/?/, '/'))) {
-            req.url = entryPath;
+            req.url = devEntryPath;
           }
           next();
         });
@@ -36,7 +37,7 @@ const addEntry = ({ entryName, entryPath, fileName }: AddEntryOptions): Plugin[]
         return c.replace(
           '<head>',
           `<head><script type="module" src=${JSON.stringify(
-            entryPath.replace(/.+?\:([/\\])[/\\]?/, '$1').replace(/\\\\?/g, '/')
+            devEntryPath.replace(/.+?\:([/\\])[/\\]?/, '$1').replace(/\\\\?/g, '/')
           )}></script>`
         );
       },

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -1,11 +1,11 @@
-import { writeHostAutoInit, writeWrapRemoteEntry } from "./virtualRemoteEntry";
+import { writeHostAutoInit } from "./virtualRemoteEntry";
 import { writeRemote } from "./virtualRemotes";
 import { writeLocalSharedImportMap } from "./virtualShared_preBuild";
 
 export {
   generateRemoteEntry, getHostAutoInitImportId,
-  getHostAutoInitPath, getWrapRemoteEntryImportId,
-  getWrapRemoteEntryPath, REMOTE_ENTRY_ID
+  getHostAutoInitPath,
+  REMOTE_ENTRY_ID
 } from "./virtualRemoteEntry";
 
 export {
@@ -18,7 +18,6 @@ export {
 
 export function initVirtualModules() {
   writeLocalSharedImportMap()
-  writeWrapRemoteEntry()
   writeHostAutoInit()
   writeRemote()
 }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2,7 +2,7 @@ import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFeder
 import VirtualModule from '../utils/VirtualModule';
 import { getLocalSharedImportMapPath } from './virtualShared_preBuild';
 
-export const REMOTE_ENTRY_ID = 'REMOTE_ENTRY_ID';
+export const REMOTE_ENTRY_ID = 'virtual:mf-REMOTE_ENTRY_ID';
 export function generateRemoteEntry(options: NormalizedModuleFederationOptions): string {
   const pluginImportNames = options.runtimePlugins.map((p, i) => [
     `$runtimePlugin_${i}`,
@@ -66,20 +66,6 @@ export function generateRemoteEntry(options: NormalizedModuleFederationOptions):
       getExposes as get
   }
   `;
-}
-
-const wrapRemoteEntryModule = new VirtualModule("wrapRemoteEntry")
-export function writeWrapRemoteEntry() {
-  wrapRemoteEntryModule.writeSync(`
-    import {init, get} from "${REMOTE_ENTRY_ID}"
-    export {init, get}
-    `)
-}
-export function getWrapRemoteEntryImportId() {
-  return wrapRemoteEntryModule.getImportId();
-}
-export function getWrapRemoteEntryPath() {
-  return wrapRemoteEntryModule.getPath();
 }
 
 /**


### PR DESCRIPTION
Some people have reported that in some scenarios, the remote virtual module will be used as the host module to initiate a request, so remove the virtual module reference in remoteEntry.js