### PR TITLE
fix: changed shareStrategy property to optional in ModuleFederationOptions

### DIFF
--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -250,7 +250,7 @@ export type ModuleFederationOptions = {
   manifest?: ManifestOptions | boolean;
   dev?: boolean | PluginDevOptions;
   dts?: boolean | PluginDtsOptions;
-  shareStrategy: ShareStrategy;
+  shareStrategy?: ShareStrategy;
 };
 
 export interface NormalizedModuleFederationOptions {


### PR DESCRIPTION
`shareStrategy` was implemented as optional but was required in the typing.

Ref: https://github.com/module-federation/vite/pull/105#discussion_r1786523283 