### PR TITLE
fix: don't try to discover shared item version in case of custom version or invalid package name

### DIFF
--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -159,7 +159,7 @@ describe('normalizeModuleFederationOption', () => {
           scope: 'default',
           version: '1.0.0',
           shareConfig: {
-            requiredVersion: '*',
+            requiredVersion: '^1.0.0',
             singleton: false,
             strictVersion: false,
           },

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -130,7 +130,7 @@ function normalizeShareItem(
         strictVersion?: boolean;
       }
 ): ShareItem {
-  let { version, requiredVersion } = typeof shareItem === 'object' ? shareItem : {};
+  let { version, requiredVersion }: any = typeof shareItem === 'object' ? shareItem : {};
   if (!version) {
     const npmPackage = removePathFromNpmPackage(key);
     if (npmPackage) {

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -319,8 +319,7 @@ export function getNormalizeModuleFederationOptions() {
 
 export function getNormalizeShareItem(key: string) {
   const options = getNormalizeModuleFederationOptions();
-  const sharedKey = removePathFromNpmPackage(key) ?? key;
-  return options.shared[sharedKey];
+  return options.shared[key];
 }
 
 export function normalizeModuleFederationOptions(


### PR DESCRIPTION
Exposing a local share causes lots of errors in console:
```js
Error: Cannot find module '@/package.json'
Require stack:
- /Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at normalizeShareItem (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:296:15)
    at /Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:335:21
    at Array.forEach (<anonymous>)
    at normalizeShared (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:334:25)
    at normalizeModuleFederationOptions (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:379:13)
    at federation (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:1236:17) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs'
  ]
}
Error: Cannot find module '@/package.json'
Require stack:
- /Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at normalizeShareItem (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:296:15)
    at /Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:335:21
    at Array.forEach (<anonymous>)
    at normalizeShared (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:334:25)
    at normalizeModuleFederationOptions (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:379:13)
    at federation (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:1236:17) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs'
  ]
}
Error: Cannot find module '@/package.json'
Require stack:
- /Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at normalizeShareItem (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:296:15)
    at /Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:335:21
    at Array.forEach (<anonymous>)
    at normalizeShared (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:334:25)
    at normalizeModuleFederationOptions (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:379:13)
    at federation (/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs:1236:17) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/mshima/git/jhipster-samples/vite-mf/notification/node_modules/@module-federation/vite/lib/index.cjs'
  ]
}
```