### PR TITLE
chore: use cjs extension in temporary file

### DIFF
--- a/src/utils/localSharedImportMap_temp.ts
+++ b/src/utils/localSharedImportMap_temp.ts
@@ -13,7 +13,7 @@ export function getLocalSharedImportMapPath_temp() {
 export function writeLocalSharedImportMap_temp(content: string) {
   const localSharedImportMapId = getLocalSharedImportMapPath_temp();
   createFile(
-    localSharedImportMapId + '.js',
+    localSharedImportMapId + '.cjs',
     '\n// Windows temporarily needs this file, https://github.com/module-federation/vite/issues/68\n' +
       content
   );


### PR DESCRIPTION
cjs/esm depends on package.json's type, would be better to use non ambiguous extension.