### PR TITLE
fix: keep cache inside node_modules by default to avoid problems with prettier and eslint

### DIFF
--- a/src/utils/localSharedImportMap_temp.ts
+++ b/src/utils/localSharedImportMap_temp.ts
@@ -8,7 +8,7 @@ import { packageNameEncode } from './packageNameUtils';
 
 export function getLocalSharedImportMapPath_temp() {
   const { name } = getNormalizeModuleFederationOptions();
-  return path.resolve('.__mf__temp', packageNameEncode(name), 'localSharedImportMap');
+  return path.resolve('node_modules', .__mf__temp', packageNameEncode(name), 'localSharedImportMap');
 }
 export function writeLocalSharedImportMap_temp(content: string) {
   const localSharedImportMapId = getLocalSharedImportMapPath_temp();

--- a/src/utils/localSharedImportMap_temp.ts
+++ b/src/utils/localSharedImportMap_temp.ts
@@ -8,7 +8,7 @@ import { packageNameEncode } from './packageNameUtils';
 
 export function getLocalSharedImportMapPath_temp() {
   const { name } = getNormalizeModuleFederationOptions();
-  return path.resolve('node_modules', .__mf__temp', packageNameEncode(name), 'localSharedImportMap');
+  return path.resolve('node_modules', '.__mf__temp', packageNameEncode(name), 'localSharedImportMap');
 }
 export function writeLocalSharedImportMap_temp(content: string) {
   const localSharedImportMapId = getLocalSharedImportMapPath_temp();

--- a/src/utils/localSharedImportMap_temp.ts
+++ b/src/utils/localSharedImportMap_temp.ts
@@ -8,7 +8,12 @@ import { packageNameEncode } from './packageNameUtils';
 
 export function getLocalSharedImportMapPath_temp() {
   const { name } = getNormalizeModuleFederationOptions();
-  return path.resolve('node_modules', '.__mf__temp', packageNameEncode(name), 'localSharedImportMap');
+  return path.resolve(
+    'node_modules',
+    '.__mf__temp',
+    packageNameEncode(name),
+    'localSharedImportMap'
+  );
 }
 export function writeLocalSharedImportMap_temp(content: string) {
   const localSharedImportMapId = getLocalSharedImportMapPath_temp();


### PR DESCRIPTION

`node_modules` is commonly used as cache folder.
Usually it's eslint and prettier ignored.

Related to https://github.com/module-federation/vite/issues/137