### PR TITLE
fix: issue with multiple init calls in remote

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
     ...addEntry({
       entryName: 'hostInit',
       entryPath: getHostAutoInitPath(),
+      inject: 'html',
     }),
     ...addEntry({
       entryName: 'virtualExposes',

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -153,7 +153,8 @@ export function generateRemoteEntry(options: NormalizedModuleFederationOptions):
  * Inject entry file, automatically init when used as host,
  * and will not inject remoteEntry
  */
-const hostAutoInitModule = new VirtualModule('hostAutoInit');
+export const HOST_AUTO_INIT_TAG = '__H_A_I__';
+const hostAutoInitModule = new VirtualModule('hostAutoInit', HOST_AUTO_INIT_TAG);
 export function writeHostAutoInit() {
   hostAutoInitModule.writeSync(`
     import {init} from "${REMOTE_ENTRY_ID}"


### PR DESCRIPTION
hotfix:
If the remote is configured as `exposes: {".": "./src/main"}`, the remote will automatically call runtime.init(), which may cause intermittent errors in certain network environments.

