### PR TITLE
feat: expose plugin options to other plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
     {
       name: 'module-federation-vite',
       enforce: 'post',
+      // @ts-expect-error used to expose plugin options
+      _options: options,
       config(config, { command: _command }: { command: string }) {
         // TODO: singleton
         (config.resolve as any).alias.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,8 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
     {
       name: 'module-federation-vite',
       enforce: 'post',
-      // @ts-expect-error used to expose plugin options
+      // @ts-expect-error
+      // used to expose plugin options: https://github.com/rolldown/rolldown/discussions/2577#discussioncomment-11137593
       _options: options,
       config(config, { command: _command }: { command: string }) {
         // TODO: singleton


### PR DESCRIPTION
expose plugin option to other plugins without headache, now plugin authors can get user configuration : 

![Screenshot 2024-11-04 at 02 18 26](https://github.com/user-attachments/assets/696cee97-de40-4919-839a-2563b912aa24)

related discussion: https://github.com/rolldown/rolldown/discussions/2577#discussioncomment-11137593