### PR TITLE
fix: solve issue with filename !== remoteEntry

### DIFF
--- a/examples/vite-webpack-rspack/host/vite.config.js
+++ b/examples/vite-webpack-rspack/host/vite.config.js
@@ -6,7 +6,7 @@ const mfConfig = {
   name: 'host',
   remotes: {
     remote: {
-      entry: 'http://localhost:4001/remoteEntry.js',
+      entry: 'http://localhost:4001/custom-filename.js',
       type: 'module',
     },
     webpack: {

--- a/examples/vite-webpack-rspack/remote/vite.config.js
+++ b/examples/vite-webpack-rspack/remote/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     react(),
     federation({
       name: 'remote',
-      filename: 'remoteEntry.js',
+      filename: 'custom-filename.js',
       // Modules to expose
       exposes: {
         './Product': './src/Product.jsx',

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -126,7 +126,7 @@ const Manifest = (): Plugin[] => {
         // 遍历打包生成的每个文件
         for (const [fileName, fileData] of Object.entries(bundle)) {
           if (
-            mfOptions.filename.replace(/[\[\]]/g, '_') === fileData.name ||
+            mfOptions.filename.replace(/[\[\]]/g, '_').replace(/\.[^/.]+$/, '') === fileData.name ||
             fileData.name === 'remoteEntry'
           ) {
             remoteEntryFile = fileData.fileName;


### PR DESCRIPTION
If filename !== remoteEntry, the metaData of manifest.json cannot get the correct name because the name of the vite bundle does not contain the suffix