### PR TITLE
fix(manifest): public path

### DIFF
--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -67,7 +67,7 @@ const Manifest = (): Plugin[] => {
                   types: { path: '', name: '' },
                   globalName: name,
                   pluginVersion: '0.2.5',
-                  publicPath,
+                  ...(!!getPublicPath ? { publicPath: getPublicPath } : { publicPath }),
                 },
               })
             );
@@ -326,7 +326,7 @@ const Manifest = (): Plugin[] => {
         },
         globalName: name,
         pluginVersion: '0.2.5',
-        ...(!!getPublicPath ? { getPublicPath } : { publicPath }),
+        ...(!!getPublicPath ? { publicPath: getPublicPath } : { publicPath }),
       },
       shared,
       remotes,


### PR DESCRIPTION
The pr fixed some issues.
- The mainifest should generate `publicPath` as key
- `getPublicPath` is not working at dev