### PR TITLE
feat: make react hmr works

### DIFF
--- a/examples/vite-vite/vite-remote/vite.config.js
+++ b/examples/vite-vite/vite-remote/vite.config.js
@@ -44,6 +44,8 @@ export default defineConfig({
         '@emotion/styled': { singleton: true },
         '@mui/material': {},
       },
+      // make react hmr works
+      injectEntryCode: react.preambleCode.replace('__BASE__', 'http://localhost:5176/testbase/'),
     }),
     // If you set build.target: "chrome89", you can remove this plugin
     false && topLevelAwait(),

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -277,6 +277,7 @@ export type ModuleFederationOptions = {
   dev?: boolean | PluginDevOptions;
   dts?: boolean | PluginDtsOptions;
   shareStrategy?: ShareStrategy;
+  injectEntryCode?: string;
 };
 
 export interface NormalizedModuleFederationOptions {
@@ -296,6 +297,7 @@ export interface NormalizedModuleFederationOptions {
   dts?: boolean | PluginDtsOptions;
   shareStrategy: ShareStrategy;
   getPublicPath?: string;
+  injectEntryCode?: string;
 }
 
 interface PluginDevOptions {
@@ -371,5 +373,6 @@ export function normalizeModuleFederationOptions(
     dts: options.dts,
     getPublicPath: options.getPublicPath,
     shareStrategy: options.shareStrategy || 'version-first',
+    injectEntryCode: options.injectEntryCode,
   });
 }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -124,6 +124,7 @@ export function generateRemoteEntry(options: NormalizedModuleFederationOptions):
   import {
     initResolve
   } from "${virtualRuntimeInitStatus.getImportId()}"
+  ${options.injectEntryCode || ''}
   const initTokens = {}
   const shareScopeName = ${JSON.stringify(options.shareScope)}
   const mfName = ${JSON.stringify(options.name)}


### PR DESCRIPTION
The remote hmr is not seen at host. The pr intend to fixed it. 

The issue caused by the remote entry is not inject `RefreshRuntime.injectIntoGlobalHook(window)`,the pr add a `injectEntryCode` to do it. 