### PR TITLE
fix: add shareScope attribute to usedRemotes in virtualRemoteEntry

### DIFF
--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -96,7 +96,7 @@ export function generateLocalSharedImportMap() {
                   name: ${JSON.stringify(remote.name)},
                   type: ${JSON.stringify(remote.type)},
                   entry: ${JSON.stringify(remote.entry)},
-                  shareScope: ${JSON.stringify(remote.shareScope) ?? "default"},
+                  shareScope: ${JSON.stringify(remote.shareScope) ?? 'default'},
                 }
           `;
         })

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -96,6 +96,7 @@ export function generateLocalSharedImportMap() {
                   name: ${JSON.stringify(remote.name)},
                   type: ${JSON.stringify(remote.type)},
                   entry: ${JSON.stringify(remote.entry)},
+                  shareScope: ${JSON.stringify(remote.shareScope) ?? "default"},
                 }
           `;
         })


### PR DESCRIPTION
Without this attribute, share scope isolation does not work as every remote will fall back to the 'default' share scope.