### PR TITLE
fix: use prettier directly in lint-staged

### DIFF
--- a/packages/module-federation-vite/.lintstagedrc
+++ b/packages/module-federation-vite/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-    "*": "pnpx pretty-quick"
+    "./packages/module-federation-vite/src/**/*.ts": "pnpm fmt"
 }


### PR DESCRIPTION
prettier-quick looks at git for what files have changed, but lint-staged is already running in a loose file environment.  However, lint-staged passes a list of all changed files as command arguments.

As such, lint-staged should run prettier directly, as it will receive the list of changed files and restrict what it formats.