### PR TITLE
feat: Alpha release workflows

### DIFF
--- a/.github/workflows/release-plugin-alpha.yml
+++ b/.github/workflows/release-plugin-alpha.yml
@@ -1,4 +1,4 @@
-name: Release @module-federation/vite
+name: Release @module-federation/vite alpha from monorepo
 
 on:
   - workflow_dispatch

--- a/.github/workflows/release-plugin-alpha.yml
+++ b/.github/workflows/release-plugin-alpha.yml
@@ -35,6 +35,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: ./packages/module-federation-vite
-        run: npm publish --access public --tag alpha-1
+        run: npm publish --access public --tag 2.0.0-alpha-1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-plugin-alpha.yml
+++ b/.github/workflows/release-plugin-alpha.yml
@@ -1,0 +1,40 @@
+name: Release @module-federation/vite
+
+on:
+  - workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: monorepo
+
+      - name: PNPM Install
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.14.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23.5.0
+          cache: 'pnpm'
+          registry-url: https://registry.npmjs.org/
+
+      - run: corepack enable
+
+      - name: Install NPM Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: ./packages/module-federation-vite
+        run: pnpm run build
+
+      - name: Publish to npm
+        working-directory: ./packages/module-federation-vite
+        run: npm publish --access public --tag alpha-1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-runtime-alpha.yml
+++ b/.github/workflows/release-runtime-alpha.yml
@@ -35,6 +35,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: ./packages/module-federation-vite-runtime
-        run: npm publish --access public --tag alpha-1
+        run: npm publish --access public --tag 2.0.0-alpha-1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-runtime-alpha.yml
+++ b/.github/workflows/release-runtime-alpha.yml
@@ -1,0 +1,40 @@
+name: Release @module-federation/vite-runtime
+
+on:
+  - workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: monorepo
+
+      - name: PNPM Install
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.14.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23.5.0
+          cache: 'pnpm'
+          registry-url: https://registry.npmjs.org/
+
+      - run: corepack enable
+
+      - name: Install NPM Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: ./packages/module-federation-vite-runtime
+        run: pnpm run build
+
+      - name: Publish to npm
+        working-directory: ./packages/module-federation-vite-runtime
+        run: npm publish --access public --tag alpha-1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-runtime-alpha.yml
+++ b/.github/workflows/release-runtime-alpha.yml
@@ -1,4 +1,4 @@
-name: Release @module-federation/vite-runtime
+name: Release @module-federation/vite-runtime alpha from monorepo
 
 on:
   - workflow_dispatch

--- a/packages/module-federation-vite/package.json
+++ b/packages/module-federation-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/vite",
-  "version": "1.2.5",
+  "version": "2.0.0-alpha-1",
   "description": "Vite plugin for Module Federation",
   "type": "module",
   "source": "src/index.ts",


### PR DESCRIPTION
Before continuing, I would like to get a release of the runtime as-is under an alpha tag to check that everything works.

After this, I still need to investigate how to allow the main vite plugin to consume the new runtime from the workspace for local development while consuming the npm package when published.  That seems to be what [pnpm deploy](https://pnpm.io/cli/deploy) is for.

For now, publishing the actual plugin as alpha-2 has no actual changes yet, and probably unnecessary, but I do want to get the runtime published to npm.  Once it's up, I will test it with the `implementation` property to make sure everything works.