### PR TITLE
feat: Add a dev option to always read origin from config

### DIFF
--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -60,8 +60,11 @@ export default function (): Plugin {
             typeof viteConfig.server?.host === 'string' && viteConfig.server.host !== '0.0.0.0'
               ? viteConfig.server.host
               : 'localhost';
+          const originFromConfig = `//${host}:${viteConfig.server?.port}`;
+          const alwaysReadOriginFromConfig =
+            typeof options.dev === 'object' && options.dev.alwaysReadOriginFromConfig;
           return `
-          const origin = window ? window.origin : "//${host}:${viteConfig.server?.port}"
+          const origin = ${alwaysReadOriginFromConfig ? '' : 'window ? window.origin : '}"${originFromConfig}"
           const remoteEntryPromise = await import(origin + "${viteConfig.base + options.filename}")
           // __tla only serves as a hack for vite-plugin-top-level-await. 
           Promise.resolve(remoteEntryPromise)

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -60,11 +60,11 @@ export default function (): Plugin {
             typeof viteConfig.server?.host === 'string' && viteConfig.server.host !== '0.0.0.0'
               ? viteConfig.server.host
               : 'localhost';
-          const originFromConfig = `//${host}:${viteConfig.server?.port}`;
+          const origin = `//${host}:${viteConfig.server?.port}`;
           const alwaysReadOriginFromConfig =
             typeof options.dev === 'object' && options.dev.alwaysReadOriginFromConfig;
           return `
-          const origin = ${alwaysReadOriginFromConfig ? '' : 'window ? window.origin : '}"${originFromConfig}"
+          const origin = ${alwaysReadOriginFromConfig ? '' : 'window ? window.origin : '}"${origin}"
           const remoteEntryPromise = await import(origin + "${viteConfig.base + options.filename}")
           // __tla only serves as a hack for vite-plugin-top-level-await. 
           Promise.resolve(remoteEntryPromise)

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -302,6 +302,7 @@ interface PluginDevOptions {
   disableLiveReload?: boolean;
   disableHotTypesReload?: boolean;
   disableDynamicRemoteTypeHints?: boolean;
+  alwaysReadOriginFromConfig?: boolean;
 }
 
 interface PluginDtsOptions {


### PR DESCRIPTION
Hello everyone! Thank you for your great work on this project!

This PR adds a dev option named `alwaysReadOriginFromConfig: boolean` to make sure the origin is never read from `window.origin` in dev mode.

**Why is it even needed?**
When working in the "prod-like" dev environment*, the vite dev server is serving its content via localhost but the web application is accessed via a deployed proxy (think of it as an app deployed to a public domain that loads its content from localhost). 

When the proposed above option is enabled, it ensures that all assets are consistently fetched from one origin rather than from two (localhost and the origin of the proxy) and the module federation will work as expected. It's hard to come up with an example in this repository but I could give it a try if it would help to illustrate the use case. 

*"Prod-like" dev environment -- an environment that provides access to other services like auth, APIs, etc. in the same way as it works in prod.

Please let me know if you have any concerns or you need more details. I'm happy to add docs, test, etc. if needed. Thank you!
