### PR TITLE
feat: add ignoreOrigin option

### DIFF
--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -61,7 +61,7 @@ export default function (): Plugin {
               ? viteConfig.server.host
               : 'localhost';
           return `
-          const origin = window ? window.origin : "//${host}:${viteConfig.server?.port}"
+          const origin = (window && ${!options.ignoreOrigin}) ? window.origin : "//${host}:${viteConfig.server?.port}"
           const remoteEntryPromise = await import(origin + "${viteConfig.base + options.filename}")
           // __tla only serves as a hack for vite-plugin-top-level-await. 
           Promise.resolve(remoteEntryPromise)

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -25,6 +25,7 @@ describe('normalizeModuleFederationOption', () => {
       dev: undefined,
       dts: undefined,
       shareStrategy: 'loaded-first',
+      ignoreOrigin: false,
     });
   });
 

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -277,6 +277,7 @@ export type ModuleFederationOptions = {
   dev?: boolean | PluginDevOptions;
   dts?: boolean | PluginDtsOptions;
   shareStrategy?: ShareStrategy;
+  ignoreOrigin?: boolean;
 };
 
 export interface NormalizedModuleFederationOptions {
@@ -296,6 +297,7 @@ export interface NormalizedModuleFederationOptions {
   dts?: boolean | PluginDtsOptions;
   shareStrategy: ShareStrategy;
   getPublicPath?: string;
+  ignoreOrigin?: boolean;
 }
 
 interface PluginDevOptions {
@@ -371,5 +373,6 @@ export function normalizeModuleFederationOptions(
     dts: options.dts,
     getPublicPath: options.getPublicPath,
     shareStrategy: options.shareStrategy || 'version-first',
+    ignoreOrigin: options.ignoreOrigin || false,
   });
 }


### PR DESCRIPTION
I have a use case that I need to run the remote in dev mode but keep attaching it to the host.
This original line
`const origin = window ? window.origin : "//${host}:${viteConfig.server?.port}"`
prevents me from using the remote this way, because it tries to load the remote from the host url.

Adding this new parameter makes it possible to do this use case and keep the original behavior.