### PR TITLE
fix: getting share item when package is only partially shared (fixes #288)

### DIFF
--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -341,6 +341,7 @@ export function getNormalizeModuleFederationOptions() {
 export function getNormalizeShareItem(key: string) {
   const options = getNormalizeModuleFederationOptions();
   const shareItem =
+    options.shared[key] ||
     options.shared[removePathFromNpmPackage(key)] ||
     options.shared[removePathFromNpmPackage(key) + '/'];
   return shareItem;


### PR DESCRIPTION
Fixes #288 

@gioboa I hope this fix is good. I have no clue how it's supposed to work. I also did not test this change yet, but I think it should work logically wise.