### PR TITLE
feat: support manifest's query params

### DIFF
--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -43,7 +43,9 @@ const Manifest = (): Plugin[] => {
             next();
             return;
           }
-          if (req.url === (viteConfig.base + mfManifestName).replace(/^\/?/, '/')) {
+          if (
+            req.url?.replace(/\?.*/, '') === (viteConfig.base + mfManifestName).replace(/^\/?/, '/')
+          ) {
             res.setHeader('Content-Type', 'application/json');
             res.setHeader('Access-Control-Allow-Origin', '*');
             res.end(


### PR DESCRIPTION
### Problem
My host application uses parametrized manifest URLs (`mf-manifest.json?v=1.2.3`) for caching reasons

Current implementation fails to load manifests with query params in dev mode (returns HTML instead of JSON)

### Solution
Ignore all query parameters when loading `mf-manifest.json`

### Testing
✅ Versioned manifests (`?v=1.2.3`)
✅ Standard manifests (no params)
✅ Both development and production modes

### Impact
Enables proper manifest loading during development