### PR TITLE
Update virtualExposes.ts

### DIFF
--- a/src/virtualModules/virtualExposes.ts
+++ b/src/virtualModules/virtualExposes.ts
@@ -4,23 +4,31 @@ export const VIRTUAL_EXPOSES = 'virtual:mf-exposes';
 export function generateExposes() {
   const options = getNormalizeModuleFederationOptions();
   return `
+    const GLOBAL_KEY = '__MF_SINGLETONS__';
+    const globalObj = typeof globalThis !== 'undefined' ? globalThis : window;
+    globalObj[GLOBAL_KEY] = globalObj[GLOBAL_KEY] || {};
+
     export default {
     ${Object.keys(options.exposes)
       .map((key) => {
+        const singletonKey = JSON.stringify(key);
         return `
-        ${JSON.stringify(key)}: async () => {
-          const importModule = await import(${JSON.stringify(options.exposes[key].import)})
-          const exportModule = {}
-          Object.assign(exportModule, importModule)
-          Object.defineProperty(exportModule, "__esModule", {
-            value: true,
-            enumerable: false
-          })
-          return exportModule
+        ${singletonKey}: async () => {
+          if (!globalObj[GLOBAL_KEY][${singletonKey}]) {
+            const importModule = await import(${JSON.stringify(options.exposes[key].import)});
+            const exportModule = {};
+            Object.assign(exportModule, importModule);
+            Object.defineProperty(exportModule, "__esModule", {
+              value: true,
+              enumerable: false
+            });
+            globalObj[GLOBAL_KEY][${singletonKey}] = exportModule;
+          }
+          return globalObj[GLOBAL_KEY][${singletonKey}];
         }
       `;
       })
       .join(',')}
-  }
+    }
   `;
 }


### PR DESCRIPTION
## **Purpose**
This PR introduces a robust singleton enforcement mechanism for all modules exposed via module federation in this package. The goal is to guarantee that, regardless of how or where an exposed module is imported (host, remote, or multiple remotes), only a single instance of that module is ever created and used within the same global context (e.g., browser window).

## **Background**
Previously, the plugin relied solely on the ES module system and browser module cache to ensure singleton behavior for exposed modules. However, in complex scenarios such as hot module replacement, dynamic imports, or certain micro-frontend setups, there was a risk that a module could be re-executed, resulting in multiple instances of what should be a singleton.

## **Why This Matters**
Prevents duplicate singletons: Ensures that only one instance of critical modules (like HTTP clients, stores, or other stateful objects) exists per global context.
Improves reliability by reducing subtle bugs and inconsistencies that can arise from multiple instances, especially in large or dynamic micro-frontend architectures.
Transparent to consumers: No changes are required in consumer code; the singleton logic is handled automatically by the federation plugin.