### PR TITLE
fix: correctly detect suffix for scoped packages with dots

### DIFF
--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -30,6 +30,22 @@ function getNodeModulesDir() {
   return cachedNodeModulesDir;
 }
 
+function getSuffix(name: string): string {
+  const isScoped = name.startsWith('@');
+  const slashIndex = name.indexOf('/');
+
+  const namespaceEnd = isScoped && slashIndex !== -1 ? slashIndex : -1;
+
+  const dotIndex = name.lastIndexOf('.');
+  const isDotAfterNamespace = dotIndex > namespaceEnd;
+
+  if (isDotAfterNamespace) {
+    return name.slice(dotIndex);
+  }
+
+  return '.js';
+}
+
 const patternMap: {
   [tag: string]: RegExp;
 } = {};
@@ -92,7 +108,7 @@ export default class VirtualModule {
   constructor(name: string, tag: string = '__mf_v__', suffix = '') {
     this.name = name;
     this.tag = tag;
-    this.suffix = suffix || name.split('.').slice(1).pop()?.replace(/(.)/, '.$1') || '.js';
+    this.suffix = suffix || getSuffix(name);
     if (!cacheMap[this.tag]) cacheMap[this.tag] = {};
     cacheMap[this.tag][this.name] = this;
   }

--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFile, writeFileSync } from 'fs';
-import { dirname, join, parse, resolve } from 'pathe';
+import { dirname, join, parse, resolve, basename } from 'pathe';
 import { packageNameDecode, packageNameEncode } from '../utils/packageNameUtils';
 import { getNormalizeModuleFederationOptions } from './normalizeModuleFederationOptions';
 
@@ -30,17 +30,12 @@ function getNodeModulesDir() {
   return cachedNodeModulesDir;
 }
 
-function getSuffix(name: string): string {
-  const isScoped = name.startsWith('@');
-  const slashIndex = name.indexOf('/');
+export function getSuffix(name: string): string {
+  const base = basename(name);
+  const dotIndex = base.lastIndexOf('.');
 
-  const namespaceEnd = isScoped && slashIndex !== -1 ? slashIndex : -1;
-
-  const dotIndex = name.lastIndexOf('.');
-  const isDotAfterNamespace = dotIndex > namespaceEnd;
-
-  if (isDotAfterNamespace) {
-    return name.slice(dotIndex);
+  if (dotIndex > 0 && dotIndex < base.length - 1) {
+    return base.slice(dotIndex);
   }
 
   return '.js';

--- a/src/utils/__tests__/VirtualModule.test.ts
+++ b/src/utils/__tests__/VirtualModule.test.ts
@@ -1,0 +1,39 @@
+import { getSuffix } from '../VirtualModule';
+
+describe('getSuffix', () => {
+  it('returns .js for simple package without extension', () => {
+    expect(getSuffix('react')).toBe('.js');
+  });
+
+  it('returns .js for scoped package without extension', () => {
+    expect(getSuffix('@scope/pkg')).toBe('.js');
+  });
+
+  it('returns .js for scoped package with dots in namespace but no file', () => {
+    expect(getSuffix('@company.name/pkg')).toBe('.js');
+  });
+
+  it('detects correct suffix for file with extension', () => {
+    expect(getSuffix('some/path/to/module.ts')).toBe('.ts');
+  });
+
+  it('detects correct suffix for scoped package with nested file and extension', () => {
+    expect(getSuffix('@scope/pkg/sub/file.jsx')).toBe('.jsx');
+  });
+
+  it('handles scoped package with dots in namespace and extension in file', () => {
+    expect(getSuffix('@company.name/pkg/utils/helper.tsx')).toBe('.tsx');
+  });
+
+  it('returns .js if dot is before namespace', () => {
+    expect(getSuffix('.bin/@scope/pkg')).toBe('.js');
+  });
+
+  it('returns correct suffix when multiple dots after namespace', () => {
+    expect(getSuffix('@scope/pkg/path.to/module.name.mjs')).toBe('.mjs');
+  });
+
+  it('returns correct suffix for deep relative path with scoped namespace', () => {
+    expect(getSuffix('@scope.with.dots/pkg/deep/util.spec.ts')).toBe('.ts');
+  });
+});


### PR DESCRIPTION
Fixes an issue where `VirtualModule` failed to detect the correct suffix for scoped packages that contain dots in the namespace (e.g., `@company.x.y/lib.name`).

This caused the suffix to be incorrectly split from the namespace, resulting in broken imports.

Fixes: https://github.com/module-federation/vite/issues/321
