### PR TITLE
feat: add remotePlugin option to control shared module bundling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { VIRTUAL_EXPOSES } from './virtualModules/virtualExposes';
 
 function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
   const options = normalizeModuleFederationOptions(mfUserOptions);
-  const { name, remotes, shared, filename } = options;
+  const { name, remotes, shared, filename, remotePlugin } = options;
   if (!name) throw new Error('name is required');
 
   return [
@@ -47,11 +47,13 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
       entryPath: REMOTE_ENTRY_ID,
       fileName: filename,
     }),
-    ...addEntry({
-      entryName: 'hostInit',
-      entryPath: getHostAutoInitPath(),
-      inject: 'html',
-    }),
+    ...(remotePlugin
+      ? []
+      : addEntry({
+          entryName: 'hostInit',
+          entryPath: getHostAutoInitPath(),
+          inject: 'html',
+        })),
     ...addEntry({
       entryName: 'virtualExposes',
       entryPath: VIRTUAL_EXPOSES,

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,5 +1,8 @@
 import { Plugin, UserConfig } from 'vite';
-import { NormalizedShared } from '../utils/normalizeModuleFederationOptions';
+import {
+  NormalizedShared,
+  getNormalizeModuleFederationOptions,
+} from '../utils/normalizeModuleFederationOptions';
 import { PromiseStore } from '../utils/PromiseStore';
 import VirtualModule from '../utils/VirtualModule';
 import {

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -273,6 +273,10 @@ export type ModuleFederationOptions = {
   filename?: string;
   library?: any;
   name: string;
+  /**
+   * When true, prevents shared modules from being bundled into remotes
+   * and makes them rely on host-provided shared modules at runtime
+   */
   // remoteType?: string;
   remotes?: Record<string, string | RemoteObjectConfig> | undefined;
   runtime?: any;
@@ -301,6 +305,11 @@ export type ModuleFederationOptions = {
   shareStrategy?: ShareStrategy;
   ignoreOrigin?: boolean;
   virtualModuleDir?: string;
+  /**
+   * When true, prevents shared modules from being bundled into remotes
+   * and makes them rely on host-provided shared modules at runtime
+   */
+  remotePlugin?: boolean;
 };
 
 export interface NormalizedModuleFederationOptions {
@@ -308,6 +317,11 @@ export interface NormalizedModuleFederationOptions {
   filename: string;
   library: any;
   name: string;
+  /**
+   * When true, prevents shared modules from being bundled into remotes
+   * and makes them rely on host-provided shared modules at runtime
+   */
+  remotePlugin: boolean;
   // remoteType: string;
   remotes: Record<string, RemoteObjectConfig>;
   runtime: any;
@@ -393,6 +407,7 @@ export function normalizeModuleFederationOptions(
   return (config = {
     exposes: normalizeExposes(options.exposes),
     filename: options.filename || 'remoteEntry-[hash]',
+    remotePlugin: options.remotePlugin ?? false,
     library: normalizeLibrary(options.library),
     name: options.name,
     // remoteType: options.remoteType,

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -38,7 +38,7 @@ export function getLoadShareModulePath(pkg: string): string {
 }
 export function writeLoadShareModule(pkg: string, shareItem: ShareItem, command: string) {
   loadShareCacheMap[pkg].writeSync(`
-    
+
     ;() => import(${JSON.stringify(getPreBuildLibImportId(pkg))}).catch(() => {});
     // dev uses dynamic import to separate chunks
     ${command !== 'build' ? `;() => import(${JSON.stringify(pkg)}).catch(() => {});` : ''}


### PR DESCRIPTION
- Introduces new `remotePlugin` option to prevent shared modules from being bundled into remotes
- When enabled, remotes will rely on host-provided shared modules at runtime
- Updates related virtual modules and plugin logic to respect the new option
- Conditionally skips hostInit entry addition when remotePlugin is true
---

I am opening this up as a draft PR for discussion on what this should be named, or how it should be allowed to be configured.

Fundamentally my use case is I use MF as a glorified `requirejs` module loader *without iframes or new web pages*.

I have a plugin system where all shared deps are on the host app, as if it was an electron app shell. Thus I have to prevent double bundling of those dependencies... It is also a huge performance bloat to load 5-6 large libraries in every single plugin (remote bundle).

This is part of a series of PR's to upstream my R&D.