### PR TITLE
fix: prevent multiple processing of await plugin output

### DIFF
--- a/src/plugins/pluginDevProxyModuleTopLevelAwait.ts
+++ b/src/plugins/pluginDevProxyModuleTopLevelAwait.ts
@@ -8,10 +8,15 @@ import { Plugin } from 'vite';
 
 export function PluginDevProxyModuleTopLevelAwait(): Plugin {
   const filterFunction = createFilter();
+  const processedFlag = '/* already-processed-by-dev-proxy-module-top-level-await */';
+
   return {
     name: 'dev-proxy-module-top-level-await',
     apply: 'serve',
     transform(code: string, id: string): { code: string; map: any } | null {
+      if (code.includes(processedFlag)) {
+        return null;
+      }
       if (!code.includes('/*mf top-level-await placeholder replacement mf*/')) {
         return null;
       }
@@ -90,8 +95,9 @@ export function PluginDevProxyModuleTopLevelAwait(): Plugin {
           }
         },
       });
+      const transformedCode = magicString.toString();
       return {
-        code: magicString.toString(),
+        code: `${processedFlag}\n${transformedCode}`,
         map: magicString.generateMap({ hires: true }),
       };
     },


### PR DESCRIPTION
I ran into an edge case recently during some experimentation.

If you try running multiple module federation plugin instances in 1 vite config, the top await rewriter plugin will try to process itself multiple times. Around the 3rd time it created a duplicate const and the AST parse failed.

This is a simple fix that prevents that edge case.

This is part of a series of PR's to upstream my R&D.