### PR TITLE
fix: check if html file exists before reading it

### DIFF
--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -119,7 +119,7 @@ const addEntry = ({
           emitFileOptions.fileName = fileName;
         }
         emitFileId = this.emitFile(emitFileOptions);
-        if (htmlFilePath) {
+        if (htmlFilePath && fs.existsSync(htmlFilePath)) {
           const htmlContent = fs.readFileSync(htmlFilePath, 'utf-8');
           const scriptRegex = /<script\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
           let match: RegExpExecArray | null;


### PR DESCRIPTION
In remotes, im not actually making use of `index.html` but the plugin currently assumes it exists b/c its always set due to https://github.com/module-federation/vite/blob/43fa399ab4ea37e6db9d82a72aa954befe3304b1/src/plugins/pluginAddEntry.ts#L96

This is a simple fix for that.