### PR TITLE
fix: sort all shared items to create deterministic builds when hashes are used

### DIFF
--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -40,6 +40,7 @@ export function generateLocalSharedImportMap() {
   return `
     const importMap = {
       ${Array.from(getUsedShares())
+        .sort()
         .map(
           (pkg) => `
         ${JSON.stringify(pkg)}: async () => {


### PR DESCRIPTION
When using hashes for the remoteEntry file in the plugin, the hashes are sometimes different because the order of the `usedShared` object is different. This causes builds to be non-deterministic when in fact nothing has changed. For example:

```
// vite.config.ts for a host app
defineConfig(() => ({
   // ..rest
   plugins: [
     federation({
       name: "host-app",
       manifest: true,
       filename: "remoteEntry.[hash].js",
       shared: {
          // a bunch of packages,
       }
```
     
During 2 builds for the exact same source, the remoteEntry and hostInit may have different hashes because the remoteEntry may differ in the ordering of the `usedShared` keys:

```
# build 1 outputs remoteEntry.abcdefg.js:
const usedShared = {
   'some-library-a': { /* config */ },
   'some-library-b': { /* config */ },
}


# build 2 outputs remoteEntry.xyzlmnop.js:
const usedShared = {
   'some-library-b': { /* config */ },
   'some-library-a': { /* config */ }
}
```

It's a bit hard to reproduce in a toy app since I think the cause is the async hooks across a large number of files in our application, but this simple one-liner ought to fix it.