### PR TITLE
fix: improve error handling for missing shared modules, closes (#132)

### DIFF
--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -54,6 +54,16 @@ const cacheMap: {
 /**
  * Physically generate files as virtual modules under node_modules/__mf__virtual/*
  */
+export function assertModuleFound(tag: string, str: string = ''): VirtualModule {
+  const module = VirtualModule.findModule(tag, str);
+  if (!module) {
+    throw new Error(
+      `Module Federation shared module '${str}' not found. Please ensure it's installed as a dependency in your package.json.`
+    );
+  }
+  return module;
+}
+
 export default class VirtualModule {
   name: string;
   tag: string;

--- a/src/utils/__tests__/VirtualModule.test.ts
+++ b/src/utils/__tests__/VirtualModule.test.ts
@@ -1,4 +1,4 @@
-import { getSuffix } from '../VirtualModule';
+import { getSuffix, assertModuleFound } from '../VirtualModule';
 
 describe('getSuffix', () => {
   it('returns .js for simple package without extension', () => {
@@ -35,5 +35,18 @@ describe('getSuffix', () => {
 
   it('returns correct suffix for deep relative path with scoped namespace', () => {
     expect(getSuffix('@scope.with.dots/pkg/deep/util.spec.ts')).toBe('.ts');
+  });
+});
+
+describe('assertModuleFound', () => {
+  it('throws an error when module is not found', () => {
+    const tag = '__test_tag__';
+    const str = 'non-existent-module';
+
+    expect(() => {
+      assertModuleFound(tag, str);
+    }).toThrow(
+      `Module Federation shared module '${str}' not found. Please ensure it's installed as a dependency in your package.json.`
+    );
   });
 });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -38,7 +38,7 @@ export function getLoadShareModulePath(pkg: string): string {
 }
 export function writeLoadShareModule(pkg: string, shareItem: ShareItem, command: string) {
   loadShareCacheMap[pkg].writeSync(`
-    
+
     ;() => import(${JSON.stringify(getPreBuildLibImportId(pkg))}).catch(() => {});
     // dev uses dynamic import to separate chunks
     ${command !== 'build' ? `;() => import(${JSON.stringify(pkg)}).catch(() => {});` : ''}


### PR DESCRIPTION
Close #132

- Add `assertModuleFound` utility to provide clearer error messages when shared modules are not found
- Replace direct `VirtualModule.findModule` calls with `assertModuleFound` in proxy shared module plugin
- Include unit test for new error handling behavior