### PR TITLE
fix: resolve warnings when building with sourcemaps enabled

### DIFF
--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'pathe';
 import { Plugin } from 'vite';
+import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 
 interface AddEntryOptions {
   entryName: string;
@@ -153,7 +154,7 @@ const addEntry = ({
           const injection = `
           import ${JSON.stringify(entryPath)};
           `;
-          return injection + code;
+          return mapCodeToCodeWithSourcemap(injection + code);
         }
       },
     },

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,6 +1,8 @@
 import { Plugin, UserConfig } from 'vite';
+import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 import { NormalizedShared } from '../utils/normalizeModuleFederationOptions';
 import { PromiseStore } from '../utils/PromiseStore';
+import VirtualModule, { assertModuleFound } from '../utils/VirtualModule';
 import {
   addUsedShares,
   generateLocalSharedImportMap,
@@ -12,7 +14,6 @@ import {
   writePreBuildLibPath,
 } from '../virtualModules';
 import { parsePromise } from './pluginModuleParseEnd';
-import VirtualModule, { assertModuleFound } from '../utils/VirtualModule';
 
 export function proxySharedModule(options: {
   shared?: NormalizedShared;
@@ -30,9 +31,11 @@ export function proxySharedModule(options: {
           return parsePromise.then((_) => generateLocalSharedImportMap());
         }
       },
-      transform(code, id) {
+      transform(_, id) {
         if (id.includes(getLocalSharedImportMapPath())) {
-          return parsePromise.then((_) => generateLocalSharedImportMap());
+          return mapCodeToCodeWithSourcemap(
+            parsePromise.then((_) => generateLocalSharedImportMap())
+          );
         }
       },
     },

--- a/src/utils/mapCodeToCodeWithSourcemap.ts
+++ b/src/utils/mapCodeToCodeWithSourcemap.ts
@@ -1,0 +1,16 @@
+import MagicString from 'magic-string';
+
+export async function mapCodeToCodeWithSourcemap(code?: string | Promise<string>) {
+  const resolvedCode = await code;
+
+  if (resolvedCode === undefined) {
+    return;
+  }
+
+  const s = new MagicString(resolvedCode);
+
+  return {
+    code: s.toString(),
+    map: s.generateMap({ hires: true }),
+  };
+}


### PR DESCRIPTION
When vite is configured to generate sourcemaps we are getting warnings about missing sourcemaps from the plugins that use the transform hook. To address this issue we should return both the code and the map in the transform hook.

<img width="2561" height="361" alt="image" src="https://github.com/user-attachments/assets/bd158c60-e526-45de-b6a4-eff82f91cb69" />
