### PR TITLE
fix: removed a warning that falsely warns that `getPublicPath` is ignored

### DIFF
--- a/src/utils/logUtils.ts
+++ b/src/utils/logUtils.ts
@@ -1,2 +1,0 @@
-export const warn = (message: string) =>
-  message.split('\n').forEach((msg) => console.warn('\x1b[33m%s\x1b[0m', msg));

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -24,7 +24,6 @@ export type RemoteEntryType =
 
 import * as fs from 'fs';
 import * as path from 'pathe';
-import { warn } from './logUtils';
 
 interface ExposesItem {
   import: string;
@@ -403,12 +402,6 @@ export function getNormalizeShareItem(key: string) {
 export function normalizeModuleFederationOptions(
   options: ModuleFederationOptions
 ): NormalizedModuleFederationOptions {
-  if (options.getPublicPath) {
-    warn(
-      `We are ignoring the getPublicPath options because they are natively supported by Vite\nwith the "experimental.renderBuiltUrl" configuration https://vitejs.dev/guide/build#advanced-base-options`
-    );
-  }
-
   if (options.virtualModuleDir && options.virtualModuleDir.includes('/')) {
     throw new Error(
       `Invalid virtualModuleDir: "${options.virtualModuleDir}". ` +


### PR DESCRIPTION
It looks like the warning was introduced in [this commit](https://github.com/module-federation/vite/pull/108/files).  
`getPublicPath` was restored a day later in [this commit](https://github.com/module-federation/vite/commit/2670d79c79ebaa5c6d163b52826aef0e93827acd#diff-abc6cd67fc307307789c9cacee7765bf773360586663d0bc333eeb55766f8830R344-R345), but the warning is still in the code.

Nowadays [`publicPath` and `getPublicPath` are still in the code](https://github.com/module-federation/vite/blob/b65d5762301dbb50f0e09172d2b70c0c1b9d0eeb/src/utils/normalizeModuleFederationOptions.ts#L435-L436), so these options don't appear to actually be ignored.