### PR TITLE
fix: use already-initialized runtime instance to avoid mixing ESM and CJS imports

### DIFF
--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -25,12 +25,9 @@ export function getUsedRemotesMap() {
 }
 export function generateRemotes(id: string, command: string) {
   return `
-    // Use dynamic import() - works in both browser (dev) and Rollup (build)
-    const initModulePromise = import("${virtualRuntimeInitStatus.getImportId()}")
-    const res = initModulePromise
-      .then(({initPromise}) => initPromise)
-      .then(runtime => runtime.loadRemote(${JSON.stringify(id)}))
-    const exportModule = ${command !== 'build' ? '/*mf top-level-await placeholder replacement mf*/' : 'await '}initModulePromise.then(({initPromise}) => initPromise).then(_ => res)
+    const {initPromise} = require("${virtualRuntimeInitStatus.getImportId()}")
+    const res = initPromise.then(runtime => runtime.loadRemote(${JSON.stringify(id)}))
+    const exportModule = ${command !== 'build' ? '/*mf top-level-await placeholder replacement mf*/' : 'await '}initPromise.then(_ => res)
     module.exports = exportModule
   `;
 }

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -1,16 +1,22 @@
 import VirtualModule from '../utils/VirtualModule';
 export const virtualRuntimeInitStatus = new VirtualModule('runtimeInit');
 export function writeRuntimeInitStatus() {
+  // Use globalThis singleton to ensure only one initPromise exists
+  const globalKey = `__mf_init__${virtualRuntimeInitStatus.getImportId()}__`;
   virtualRuntimeInitStatus.writeSync(`
-    let initResolve, initReject
-    const initPromise = new Promise((re, rj) => {
-      initResolve = re
-      initReject = rj
-    })
-    module.exports = {
-      initPromise,
-      initResolve,
-      initReject
+    const globalKey = ${JSON.stringify(globalKey)}
+    if (!globalThis[globalKey]) {
+      let initResolve, initReject
+      const initPromise = new Promise((re, rj) => {
+        initResolve = re
+        initReject = rj
+      })
+      globalThis[globalKey] = {
+        initPromise,
+        initResolve,
+        initReject
+      }
     }
+    module.exports = globalThis[globalKey]
     `);
 }

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -41,16 +41,14 @@ export function writeLoadShareModule(pkg: string, shareItem: ShareItem, command:
     ;() => import(${JSON.stringify(getPreBuildLibImportId(pkg))}).catch(() => {});
     // dev uses dynamic import to separate chunks
     ${command !== 'build' ? `;() => import(${JSON.stringify(pkg)}).catch(() => {});` : ''}
-    // Use dynamic import() - works in both browser (dev) and Rollup (build)
-    const res = import("${virtualRuntimeInitStatus.getImportId()}")
-      .then(({initPromise}) => initPromise)
-      .then(runtime => runtime.loadShare(${JSON.stringify(pkg)}, {
-        customShareInfo: {shareConfig:{
-          singleton: ${shareItem.shareConfig.singleton},
-          strictVersion: ${shareItem.shareConfig.strictVersion},
-          requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)}
-        }}
-      }))
+    const {initPromise} = require("${virtualRuntimeInitStatus.getImportId()}")
+    const res = initPromise.then(runtime => runtime.loadShare(${JSON.stringify(pkg)}, {
+      customShareInfo: {shareConfig:{
+        singleton: ${shareItem.shareConfig.singleton},
+        strictVersion: ${shareItem.shareConfig.strictVersion},
+        requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)}
+      }}
+    }))
     const exportModule = ${command !== 'build' ? '/*mf top-level-await placeholder replacement mf*/' : 'await '}res.then(factory => factory())
     module.exports = exportModule
   `);


### PR DESCRIPTION
Issue: https://github.com/module-federation/vite/issues/362

Multiple instances of `@module-federation/runtime` are used because:
- virtualRemoteEntry.ts imports via ESM import
- virtualShared_preBuild.ts imports via CommonJS require

The fix is to get loadShare/loadRemote methods directly from the runtime instance that was passed through initPromise.

An alternative solution could be turning `@module-federation/runtime` into a singleton but there are multiple edge cases to take care of like: it could be pre-bundled in one of the remotes, multiple versions could be imported, etc. 