### PR TITLE
fix: Add peerDependencies for vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   },
   "homepage": "https://github.com/module-federation/vite#readme",
   "packageManager": "pnpm@9.1.3",
+  "peerDependencies": {
+    "vite": "<=6"
+  },
   "dependencies": {
     "@module-federation/runtime": "^0.21.6",
     "@module-federation/sdk": "^0.21.6",


### PR DESCRIPTION
The plugin currently does not support Vite 7.