### PR TITLE
fix: add-entry with renderBuiltUrl [372]

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vite plugin for Module Federation",
   "type": "module",
   "source": "src/index.ts",
-  "main": "./lib/index.ts",
+  "main": "./lib/index.cjs",
   "types": "lib/index.d.ts",
   "files": [
     "lib/**/*"


### PR DESCRIPTION
Linked is a small fix to added support to `renderBuiltUrl` inside add-entry's plugin.
Fixes #372