### PR TITLE
chore: standardize pnpm version

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Enable Corepack and Setup PNPM
         run: |
           corepack enable
-          corepack prepare pnpm@9.1.3 --activate
+          corepack prepare pnpm@9.14.2 --activate
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,7 +20,7 @@ jobs:
       - name: PNPM Install
         uses: pnpm/action-setup@v4
         with:
-          version: 9.1.3
+          version: 9.14.2
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: PNPM Install
         uses: pnpm/action-setup@v4
         with:
-          version: 9.1.3
+          version: 9.14.2
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/module-federation/vite/issues"
   },
   "homepage": "https://github.com/module-federation/vite#readme",
-  "packageManager": "pnpm@9.1.3",
+  "packageManager": "pnpm@9.14.2",
   "peerDependencies": {
     "vite": "<=6"
   },


### PR DESCRIPTION
## Summary\n- align pnpm version to 9.14.2 in packageManager and CI workflows\n\n## Testing\n- not run (config-only change)