### PR TITLE
fix: solve plugins cannot resolve error

### DIFF
--- a/src/plugins/pluginModuleParseEnd.ts
+++ b/src/plugins/pluginModuleParseEnd.ts
@@ -7,8 +7,16 @@ import { VIRTUAL_EXPOSES } from '../virtualModules';
 
 let _resolve: any,
   _reject: any,
+  _parseTimeout: any,
   promise = new Promise((resolve, reject) => {
-    _resolve = resolve;
+    _parseTimeout = setTimeout(() => {
+      console.warn('Parse timeout (5s) - forcing resolve');
+      resolve(1);
+    }, 5000);
+    _resolve = (v: any) => {
+      clearTimeout(_parseTimeout);
+      resolve(v);
+    };
     _reject = reject;
   });
 let parsePromise = promise;


### PR DESCRIPTION
This update introduces a 5-second timeout, if the promise doesn't resolve within this timeframe, it will now force a resolution to prevent potential hangs during the build or serve process.

Close #245 