### PR TITLE
fix(css): correctly extract CSS from the vite pipeline

### DIFF
--- a/.changeset/sharp-eagles-jog.md
+++ b/.changeset/sharp-eagles-jog.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/vite': patch
+---
+
+fix: css loaded in environments was not linked to exposed modules

--- a/src/utils/__tests__/cssModuleHelpers.test.ts
+++ b/src/utils/__tests__/cssModuleHelpers.test.ts
@@ -126,6 +126,76 @@ describe('cssModuleHelpers', () => {
         },
       });
     });
+
+    it('tracks CSS assets from viteMetadata.importedCss', () => {
+      const bundle = {
+        'App-abc123.js': {
+          type: 'chunk',
+          fileName: 'App-abc123.js',
+          modules: {
+            '/src/App.tsx': {},
+            '/src/App.css.ts': {},
+            '/src/App.css.ts.vanilla.css': {},
+          },
+          dynamicImports: [],
+          viteMetadata: {
+            importedCss: new Set<string>(['app.css']),
+            importedAssets: new Set<string>(),
+          },
+        },
+        'app.css': {
+          type: 'asset',
+          fileName: 'app.css',
+        },
+      } as Record<string, OutputBundleItem>;
+
+      const filesMap = {};
+      const moduleMatcher = (path: string) => (path === '/src/App.tsx' ? path : undefined);
+
+      processModuleAssets(bundle, filesMap, moduleMatcher);
+
+      expect(filesMap).toEqual({
+        '/src/App.tsx': {
+          js: { sync: ['App-abc123.js'], async: [] },
+          css: { sync: ['app.css'], async: [] },
+        },
+      });
+    });
+
+    it('tracks CSS assets when chunk contains CSS modules but viteMetadata.importedCss is empty', () => {
+      const bundle = {
+        'App-abc123.js': {
+          type: 'chunk',
+          fileName: 'App-abc123.js',
+          modules: {
+            '/src/App.tsx': {},
+            '/src/App.css.ts': {},
+            '/src/App.css.ts.vanilla.css': {},
+          },
+          dynamicImports: [],
+          viteMetadata: {
+            importedCss: new Set<string>(),
+            importedAssets: new Set<string>(),
+          },
+        },
+        'app.css': {
+          type: 'asset',
+          fileName: 'app.css',
+        },
+      } as Record<string, OutputBundleItem>;
+
+      const filesMap = {};
+      const moduleMatcher = (path: string) => (path === '/src/App.tsx' ? path : undefined);
+
+      processModuleAssets(bundle, filesMap, moduleMatcher);
+
+      expect(filesMap).toEqual({
+        '/src/App.tsx': {
+          js: { sync: ['App-abc123.js'], async: [] },
+          css: { sync: ['app.css'], async: [] },
+        },
+      });
+    });
   });
 
   describe('addCssAssetsToAllExports', () => {


### PR DESCRIPTION
### Description
In Vite environment builds, chunk.viteMetadata.importedCss is not populated even when the chunk contains CSS modules (e.g. from vanilla-extract). This means CSS assets are emitted to disk but never appear in `mf-manifest.json` under `exposes[].assets.css`

### Solution
The fix adds a fallback: when importedCss is empty, check if the chunk's modules contain any CSS files. If they do, associate the bundle's CSS assets with that chunk.

### Notes
Environments was technically added in V6, but better finalised in V7, so this probably helps towards #320 