### PR TITLE
chore: apply bundler orientated settings to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "module": "commonjs",
-    "target": "es6",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### Description

Reworks the tsconfig to apply bundler specific defaults since the package is built with a bundler as opposed to TSC. This avoids issues like `import.meta` not being available in `commonjs` where we make both a CJS & ESM version of the package.

*can be closed if we dont want to do this, this is related to #404*