### PR TITLE
ci: publish on GitHub release tags

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -50,7 +50,14 @@ jobs:
       - name: Verify tag matches package.json version
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          VERSION_FROM_TAG="${TAG#v}"
+          if [ "${TAG#v}" != "$TAG" ]; then
+            echo "Invalid tag format; refusing to publish."
+            echo "Expected: 1.2.3 (no leading 'v')"
+            echo "Got: $TAG"
+            exit 1
+          fi
+
+          VERSION_FROM_TAG="$TAG"
           PKG_VERSION="$(node -p "require('./package.json').version")"
 
           if [ "$PKG_VERSION" != "$VERSION_FROM_TAG" ]; then
@@ -68,7 +75,7 @@ jobs:
         shell: bash
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          VERSION="${TAG#v}"
+          VERSION="$TAG"
           DIST_TAG="latest"
 
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,14 +9,14 @@ This repo uses Changesets for versioning, and publishes to npm from GitHub Relea
 2. Create + merge the release PR
    - GitHub Actions: `Release Pull Request`
 3. Create a GitHub Release for the merge commit
-   - Tag format: `v<package.json version>` (example: `v1.11.0`)
+   - Tag format: `<package.json version>` (example: `1.11.0`)
    - Stable: mark as a normal release
-   - Pre-release: mark as a prerelease; use a pre-id in the version (examples: `v1.12.0-next.1`, `v1.12.0-beta.1`, `v1.12.0-alpha.1`)
+   - Pre-release: mark as a prerelease; use a pre-id in the version (examples: `1.12.0-next.1`, `1.12.0-beta.1`, `1.12.0-alpha.1`)
 4. GitHub Actions publishes to npm
    - Workflow: `Publish (GitHub Release)`
    - Dist-tag: `latest` for stable releases; for prereleases it derives from the version (`next|beta|alpha`, default `next`)
 
 ## Notes
 
-- Publish job hard-fails if `tag_name` does not match `package.json` version (after stripping leading `v`).
+- Publish job hard-fails if `tag_name` does not match `package.json` version (and tags must not start with `v`).
 - Requires `NPM_TOKEN` secret.


### PR DESCRIPTION
Adds tag-based publishing like ../zephyr-packages, but driven by Changesets (no version patching in CI).

- New workflow: Publish (GitHub Release) (.github/workflows/publish-on-release.yml)
  - triggers on GitHub Release events (released/prereleased)
  - checks out the release tag
  - verifies tag == package.json version (tag format: 1.2.3, no leading v)
  - publishes with dist-tag: latest (stable) or next/beta/alpha (prerelease, derived from version)
- Docs: docs/RELEASING.md
