### PR TITLE
chore(peerDeps): relax vite peerDep to include anything 7 and under

### DIFF
--- a/.changeset/sour-areas-cover.md
+++ b/.changeset/sour-areas-cover.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/vite': patch
+---
+
+Update vite peerDeps to include any version 7 and under

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/module-federation/vite#readme",
   "packageManager": "pnpm@10.28.2",
   "peerDependencies": {
-    "vite": "<=7.1.7"
+    "vite": "<8"
   },
   "dependencies": {
     "@module-federation/dts-plugin": "^0.21.6",


### PR DESCRIPTION
Right now the Vite peerDep is set to 7.1.7 and under. There are releases higher than that now, so this will relax that to support any version of 7 and under.