### PR TITLE
fix: enable environments

### DIFF
--- a/integration/fixtures/multi-env/client-entry.js
+++ b/integration/fixtures/multi-env/client-entry.js
@@ -1,0 +1,11 @@
+// Named imports from a package that is declared as a shared dep in the
+// federation environment.  In a multi-environment build the federation
+// aliases / resolveId must NOT leak here — defu should resolve normally.
+import { createDefu } from 'defu';
+
+export const merge = createDefu((obj, key, value) => {
+  if (typeof obj[key] === 'number' && typeof value === 'number') {
+    obj[key] += value;
+    return true;
+  }
+});

--- a/integration/fixtures/multi-env/exposed-module.js
+++ b/integration/fixtures/multi-env/exposed-module.js
@@ -1,0 +1,8 @@
+import { createDefu } from 'defu';
+
+export const merge = createDefu((obj, key, value) => {
+  if (typeof obj[key] === 'number' && typeof value === 'number') {
+    obj[key] += value;
+    return true;
+  }
+});

--- a/integration/fixtures/multi-env/federation-entry.js
+++ b/integration/fixtures/multi-env/federation-entry.js
@@ -1,0 +1,1 @@
+console.log('federation entry');

--- a/integration/multi-environment.test.ts
+++ b/integration/multi-environment.test.ts
@@ -1,0 +1,116 @@
+import { resolve } from 'path';
+import { createBuilder, type Plugin, type Rollup } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { federation } from '../src/index';
+import { isRollupChunk } from './helpers/assertions';
+import { FIXTURES } from './helpers/build';
+
+function getAllChunkCode(output: Rollup.RollupOutput): string {
+  return output.output
+    .filter(isRollupChunk)
+    .map((c) => c.code)
+    .join('\n');
+}
+
+const MULTI_ENV_MF_OPTIONS = {
+  name: 'multiEnvRemote',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './exposed': resolve(FIXTURES, 'multi-env', 'exposed-module.js'),
+  },
+  shared: { defu: {} },
+  dts: false,
+};
+
+/**
+ * Scope every plugin to the 'federation' environment only —
+ * mirrors what @sanity/federation does with applyToEnvironment.
+ */
+function scopeToFederation(plugins: Plugin[]): Plugin[] {
+  return plugins.map((p) => ({
+    ...p,
+    applyToEnvironment: (env: { name: string }) => env.name === 'federation',
+  }));
+}
+
+async function buildMultiEnv(plugins: Plugin[]) {
+  const builder = await createBuilder({
+    root: resolve(FIXTURES, 'multi-env'),
+    logLevel: 'silent',
+    environments: {
+      federation: {
+        consumer: 'client',
+        build: {
+          write: false,
+          minify: false,
+          rollupOptions: {
+            input: { entry: resolve(FIXTURES, 'multi-env', 'federation-entry.js') },
+          },
+        },
+      },
+      client: {
+        consumer: 'client',
+        build: {
+          write: false,
+          minify: false,
+          rollupOptions: {
+            input: { entry: resolve(FIXTURES, 'multi-env', 'client-entry.js') },
+            preserveEntrySignatures: 'exports-only',
+          },
+        },
+      },
+    },
+    builder: {},
+    plugins,
+  });
+
+  // Build federation first (writes virtual module files as a side effect),
+  // then client.
+  const fedResult = (await builder.build(builder.environments.federation)) as Rollup.RollupOutput;
+  const clientResult = (await builder.build(builder.environments.client)) as Rollup.RollupOutput;
+
+  return { fedResult, clientResult };
+}
+
+/**
+ * Tests that mf-vite works correctly inside a multi-environment Vite build.
+ *
+ * When a wrapper (e.g. @sanity/federation) scopes mf-vite plugins to a
+ * single environment via `applyToEnvironment`, per-environment hooks like
+ * `resolveId` and `load` only fire in that environment.  Global hooks
+ * (`config`) still run everywhere, so shared-dep aliases registered there
+ * would leak to all environments.
+ *
+ * The fix moves build-mode resolution from global aliases to per-environment
+ * `resolveId` hooks.  These tests verify that the federation environment
+ * still resolves shared deps through loadShare, while the client environment
+ * resolves them normally with no interference.
+ */
+describe('multi-environment build', () => {
+  it('shared dep resolution is scoped to the federation environment', async () => {
+    const { fedResult, clientResult } = await buildMultiEnv(
+      scopeToFederation(federation(MULTI_ENV_MF_OPTIONS))
+    );
+
+    // --- Federation environment ---
+    // Shared deps should be routed through the MF runtime
+    const fedCode = getAllChunkCode(fedResult);
+    expect(fedCode).toContain('loadShare');
+
+    // --- Client environment ---
+    // Shared deps should resolve normally — no loadShare shim
+    const clientCode = getAllChunkCode(clientResult);
+    expect(clientCode).not.toContain('loadShare');
+    // The actual defu code should be bundled directly
+    expect(clientCode).toContain('createDefu');
+  });
+
+  it('named exports resolve correctly in the federation environment', async () => {
+    const { fedResult } = await buildMultiEnv(scopeToFederation(federation(MULTI_ENV_MF_OPTIONS)));
+
+    // The exposed module uses `import { createDefu } from 'defu'` — a named
+    // import.  syntheticNamedExports must be set correctly for this to resolve.
+    const fedCode = getAllChunkCode(fedResult);
+    expect(fedCode).toContain('createDefu');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "pretty-quick": "^4.0.0",
     "rollup": "^4.47.1",
     "tsdown": "^0.20.3",
-    "vite": "^5.4.3",
+    "vite": "^7.1.7",
     "vitest": "^2.1.1",
     "cjs-dep": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.20.3
         version: 0.20.3(typescript@5.5.3)
       vite:
-        specifier: ^5.4.3
-        version: 5.4.3(@types/node@22.7.4)(sass-embedded@1.77.8)(terser@5.31.6)
+        specifier: ^7.1.7
+        version: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.6.1)
       vitest:
         specifier: ^2.1.1
         version: 2.1.1(@types/node@22.7.4)(sass-embedded@1.77.8)(terser@5.31.6)
@@ -22786,6 +22786,22 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.15.18
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass-embedded: 1.77.8
+      terser: 5.31.6
+      yaml: 2.6.1
+
+  vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.6.1):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.47.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.7.4
       fsevents: 2.3.3
       jiti: 2.6.1
       sass-embedded: 1.77.8

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
       entryPath: VIRTUAL_EXPOSES,
     }),
     pluginProxyRemoteEntry(),
-    pluginProxyRemotes(options),
+    ...pluginProxyRemotes(options),
     ...pluginModuleParseEnd(
       (id: string) => {
         return (
@@ -94,28 +94,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
       load(id) {
         if (id.startsWith('\0')) return;
         if (id.includes(LOAD_SHARE_TAG) || id.includes(LOAD_REMOTE_TAG)) {
-          let code = readFileSync(id, 'utf-8');
-          /**
-           * Shared/remote shims only have `export default exportModule`.
-           *
-           * We add a second named export (__moduleExports) that holds the full
-           * module namespace and point syntheticNamedExports at it.  This lets
-           * Rollup resolve named imports (e.g. `import { useState } from 'react'`)
-           * from the namespace while still applying its normal default-export
-           * interop — which is needed for libraries like @emotion/styled where
-           * `import styled from '@emotion/styled'` must receive the .default
-           * function, not the raw namespace object.
-           *
-           * Using 'default' as the syntheticNamedExports key would skip the
-           * interop and break default imports.
-           *
-           * @see https://rollupjs.org/plugin-development/#synthetic-named-exports
-           */
-          code = code.replace(
-            'export default exportModule',
-            'export const __moduleExports = exportModule;\n' +
-              'export default exportModule.__esModule ? exportModule.default : exportModule'
-          );
+          const code = readFileSync(id, 'utf-8');
           return { code, syntheticNamedExports: '__moduleExports' };
         }
       },

--- a/src/plugins/pluginProxyRemotes.ts
+++ b/src/plugins/pluginProxyRemotes.ts
@@ -4,25 +4,55 @@ import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFeder
 import { addUsedRemote, getRemoteVirtualModule } from '../virtualModules';
 const filter: (id: string) => boolean = createFilter();
 
-export default function (options: NormalizedModuleFederationOptions): Plugin {
+export default function (options: NormalizedModuleFederationOptions): Plugin[] {
   let command: string;
   const { remotes } = options;
-  return {
-    name: 'proxyRemotes',
-    config(config, { command: _command }) {
-      command = _command;
-      Object.keys(remotes).forEach((key) => {
-        const remote = remotes[key];
-        (config.resolve as any).alias.push({
-          find: new RegExp(`^(${remote.name}(\/.*|$))`),
-          replacement: '$1',
-          customResolver(source: string) {
-            const remoteModule = getRemoteVirtualModule(source, _command);
-            addUsedRemote(remote.name, source);
-            return remoteModule.getPath();
-          },
-        });
-      });
+  // Pre-compiled remote patterns, set in config hook of resolveId plugin
+  let remotePatterns: { name: string; regex: RegExp }[] = [];
+  return [
+    {
+      name: 'proxyRemotes',
+      config(config, { command: _command }) {
+        command = _command;
+        // In dev mode, use aliases (resolveId can't interfere with Vite pre-bundling).
+        // In build mode, aliases are skipped — resolveId handles resolution instead,
+        // so that per-environment scoping (applyToEnvironment) works correctly.
+        if (_command !== 'build') {
+          Object.keys(remotes).forEach((key) => {
+            const remote = remotes[key];
+            (config.resolve as any).alias.push({
+              find: new RegExp(`^(${remote.name}(\/.*|$))`),
+              replacement: '$1',
+              customResolver(source: string) {
+                const remoteModule = getRemoteVirtualModule(source, _command);
+                addUsedRemote(remote.name, source);
+                return remoteModule.getPath();
+              },
+            });
+          });
+        }
+      },
     },
-  };
+    {
+      name: 'proxyRemotes:resolve',
+      enforce: 'pre',
+      apply: 'build',
+      config() {
+        // Pre-compile remote patterns at config time
+        remotePatterns = Object.keys(remotes).map((key) => ({
+          name: remotes[key].name,
+          regex: new RegExp(`^${remotes[key].name}(\/.*|$)`),
+        }));
+      },
+      resolveId(source) {
+        for (const { name, regex } of remotePatterns) {
+          if (regex.test(source)) {
+            const remoteModule = getRemoteVirtualModule(source, 'build');
+            addUsedRemote(name, source);
+            return { id: remoteModule.getPath(), syntheticNamedExports: '__moduleExports' };
+          }
+        }
+      },
+    } satisfies Plugin,
+  ];
 }

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -22,6 +22,8 @@ export function proxySharedModule(options: {
 }): Plugin[] {
   let { shared = {}, include, exclude } = options;
   let _config: UserConfig;
+  // Pre-compiled shared key regex patterns, set in config hook of resolveId plugin
+  let sharedPatterns: { key: string; regex: RegExp }[] = [];
   return [
     {
       name: 'generateLocalSharedImportMap',
@@ -46,60 +48,92 @@ export function proxySharedModule(options: {
         _config = config as any;
       },
       config(config: UserConfig, { command }) {
-        (config.resolve as any).alias.push(
-          ...Object.keys(shared).map((key) => {
-            const pattern = key.endsWith('/')
-              ? `(^${key.replace(/\/$/, '')}(\/.+)?$)`
-              : `(^${key}$)`;
-            return {
-              // Intercept all shared requests and proxy them to loadShare
-              find: new RegExp(pattern),
-              replacement: '$1',
-              customResolver(source: string, importer: string) {
-                if (/\.css$/.test(source)) return;
-                const loadSharePath = getLoadShareModulePath(source);
-                writeLoadShareModule(source, shared[key], command);
-                writePreBuildLibPath(source);
-                addUsedShares(source);
-                writeLocalSharedImportMap();
-                return (this as any).resolve(loadSharePath, importer);
-              },
-            };
-          })
-        );
-        const savePrebuild = new PromiseStore<string>();
+        // In dev mode, use aliases (resolveId can't interfere with Vite pre-bundling).
+        // In build mode, aliases are skipped — resolveId handles resolution instead,
+        // so that per-environment scoping (applyToEnvironment) works correctly.
+        if (command !== 'build') {
+          (config.resolve as any).alias.push(
+            ...Object.keys(shared).map((key) => {
+              const pattern = key.endsWith('/')
+                ? `(^${key.replace(/\/$/, '')}(\/.+)?$)`
+                : `(^${key}$)`;
+              return {
+                // Intercept all shared requests and proxy them to loadShare
+                find: new RegExp(pattern),
+                replacement: '$1',
+                customResolver(source: string, importer: string) {
+                  if (/\.css$/.test(source)) return;
+                  const loadSharePath = getLoadShareModulePath(source);
+                  writeLoadShareModule(source, shared[key], command);
+                  writePreBuildLibPath(source);
+                  addUsedShares(source);
+                  writeLocalSharedImportMap();
+                  return (this as any).resolve(loadSharePath, importer);
+                },
+              };
+            })
+          );
 
-        (config.resolve as any).alias.push(
-          ...Object.keys(shared).map((key) => {
-            return command === 'build'
-              ? {
-                  find: new RegExp(`(.*${PREBUILD_TAG}.*)`),
-                  replacement: function ($1: string) {
-                    const module = assertModuleFound(PREBUILD_TAG, $1) as VirtualModule;
-                    const pkgName = module.name;
-                    return pkgName;
-                  },
-                }
-              : {
-                  find: new RegExp(`(.*${PREBUILD_TAG}.*)`),
-                  replacement: '$1',
-                  async customResolver(source: string, importer: string) {
-                    const module = assertModuleFound(PREBUILD_TAG, source) as VirtualModule;
-                    const pkgName = module.name;
-                    const result = await (this as any)
-                      .resolve(pkgName, importer)
-                      .then((item: any) => item.id);
-                    if (!result.includes(_config.cacheDir)) {
-                      // save pre-bunding module id
-                      savePrebuild.set(pkgName, Promise.resolve(result));
-                    }
-                    // Fix localSharedImportMap import id
-                    return await (this as any).resolve(await savePrebuild.get(pkgName), importer);
-                  },
-                };
-          })
-        );
+          const savePrebuild = new PromiseStore<string>();
+
+          (config.resolve as any).alias.push(
+            ...Object.keys(shared).map((key) => {
+              return {
+                find: new RegExp(`(.*${PREBUILD_TAG}.*)`),
+                replacement: '$1',
+                async customResolver(source: string, importer: string) {
+                  const module = assertModuleFound(PREBUILD_TAG, source) as VirtualModule;
+                  const pkgName = module.name;
+                  const result = await (this as any)
+                    .resolve(pkgName, importer)
+                    .then((item: any) => item.id);
+                  if (!result.includes(_config.cacheDir)) {
+                    // save pre-bunding module id
+                    savePrebuild.set(pkgName, Promise.resolve(result));
+                  }
+                  // Fix localSharedImportMap import id
+                  return await (this as any).resolve(await savePrebuild.get(pkgName), importer);
+                },
+              };
+            })
+          );
+        }
       },
     },
+    {
+      name: 'proxyPreBuildShared:resolve',
+      enforce: 'pre',
+      apply: 'build',
+      config() {
+        // Pre-compile shared key regex patterns at config time
+        sharedPatterns = Object.keys(shared).map((key) => ({
+          key,
+          regex: key.endsWith('/')
+            ? new RegExp(`^${key.replace(/\/$/, '')}(\/.+)?$`)
+            : new RegExp(`^${key}$`),
+        }));
+      },
+      resolveId(source, importer) {
+        // 1. Intercept __prebuild__ imports (from inside __loadShare__ files)
+        if (source.includes(PREBUILD_TAG)) {
+          const module = assertModuleFound(PREBUILD_TAG, source) as VirtualModule;
+          const pkgName = module.name;
+          return (this as any).resolve(pkgName, importer, { skipSelf: true });
+        }
+
+        // 2. Intercept shared dep imports (e.g. 'react', 'react-dom/client')
+        if (/\.css$/.test(source)) return;
+        for (const { key, regex } of sharedPatterns) {
+          if (regex.test(source)) {
+            const loadSharePath = getLoadShareModulePath(source);
+            writeLoadShareModule(source, shared[key], 'build');
+            writePreBuildLibPath(source);
+            addUsedShares(source);
+            writeLocalSharedImportMap();
+            return { id: loadSharePath, syntheticNamedExports: '__moduleExports' };
+          }
+        }
+      },
+    } satisfies Plugin,
   ];
 }

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -31,7 +31,10 @@ export function generateRemotes(id: string, command: string) {
   const awaitOrPlaceholder = isBuild
     ? 'await '
     : '/*mf top-level-await placeholder replacement mf*/';
-  const exportLine = isBuild ? 'export default exportModule' : 'module.exports = exportModule';
+  const exportLine = isBuild
+    ? 'export const __moduleExports = exportModule;\n' +
+      'export default exportModule.__esModule ? exportModule.default : exportModule'
+    : 'module.exports = exportModule';
 
   return `
     ${importLine}

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -44,7 +44,10 @@ export function writeLoadShareModule(pkg: string, shareItem: ShareItem, command:
   const awaitOrPlaceholder = isBuild
     ? 'await '
     : '/*mf top-level-await placeholder replacement mf*/';
-  const exportLine = isBuild ? 'export default exportModule' : 'module.exports = exportModule';
+  const exportLine = isBuild
+    ? 'export const __moduleExports = exportModule;\n' +
+      'export default exportModule.__esModule ? exportModule.default : exportModule'
+    : 'module.exports = exportModule';
 
   loadShareCacheMap[pkg].writeSync(`
     ;() => import(${JSON.stringify(getPreBuildLibImportId(pkg))}).catch(() => {});


### PR DESCRIPTION
### Description 

Moves build-mode resolution of shared dependencies and remote modules from global config.resolve.alias entries to per-environment resolveId hooks. Previously, aliases registered in the config hook leaked into all Vite environments. In a multi-environment build, even the client environment would route shared deps like `defu` through `__loadShare__` proxies. The fix keeps aliases for dev mode (where resolveId can't interfere with Vite pre-bundling) but replaces them in build mode with enforce: 'pre' resolveId plugins that return syntheticNamedExports directly, making them compatible with applyToEnvironment scoping.

### Related PRs

* stacked on top of #420 