### PR TITLE
chore: revert "1.11.1" version updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/vite",
-  "version": "1.11.1",
+  "version": "1.11.0",
   "description": "Vite plugin for Module Federation",
   "type": "module",
   "main": "./lib/index.cjs",


### PR DESCRIPTION
### Description

This reverts commit 18b8267cc8740aeb644bc6ebfa8c544768808b43. Which was done without using changesets. This version was also not released.