### PR TITLE
fix(examples): enable HMR for vite-vite example host and remotes

### DIFF
--- a/examples/vite-vite/vite-host/src/App.jsx
+++ b/examples/vite-vite/vite-host/src/App.jsx
@@ -13,7 +13,7 @@ import { ref } from 'vue';
 console.log('Share Vue', ref);
 console.log('Share React', R, RD);
 
-export default function () {
+export default function HostApp() {
   return (
     <div style={{ background: 'lightgray' }}>
       <p>

--- a/examples/vite-vite/vite-remote/src/App1.jsx
+++ b/examples/vite-vite/vite-remote/src/App1.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import vueImg from "./assets/vue.svg";
+import vueImg from './assets/vue.svg';
 
-export default function () {
+export default function App1() {
   return (
     <div style={{ background: 'yellow', padding: 30 }}>
       <img src={vueImg} />

--- a/examples/vite-vite/vite-remote/vite.config.js
+++ b/examples/vite-vite/vite-remote/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
   },
   base: 'http://localhost:5176/testbase',
   plugins: [
-    react({ jsxImportSource: '@emotion/react' }),
+    react({ jsxImportSource: '@emotion/react', reactRefreshHost: 'http://localhost:5175' }),
     federation({
       name: '@namespace/viteViteRemote',
       exposes: {


### PR DESCRIPTION
Add `reactRefreshHost` to the remote's React plugin config to route HMR updates through the host's WebSocket. Name anonymous default exports so React Fast Refresh can track component boundaries.