### PR TITLE
fix(ci): align trusted publisher environment casing

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: publish
+    environment: Publish
     steps:
       - name: Checkout source
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- change publish workflow environment name from 'publish' to 'Publish'
- match npm Trusted Publisher config exactly

## Why
npm Trusted Publisher OIDC subject matching is strict; environment mismatch blocks publish.