### PR TITLE
fix(ci): enforce trusted-publisher release semantics

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -89,14 +89,30 @@ jobs:
             exit 1
           fi
 
-          # Trusted publishers cannot promote dist-tags without publishing.
-          # Enforce prerelease semver for prerelease events to avoid same-version republish failures.
-          if [ "${{ github.event.action }}" = "prereleased" ] && [[ "$PKG_VERSION" != *-* ]]; then
-            echo "Invalid prerelease version for prerelease event."
-            echo "Use a prerelease semver, e.g. 1.12.0-next.1 / 1.12.0-beta.1 / 1.12.0-alpha.1"
-            echo "Do not prerelease a plain stable version like: $PKG_VERSION"
-            exit 1
+      - name: Patch prerelease version with next tag
+        if: github.event_name == 'release' && github.event.action == 'prereleased'
+        shell: bash
+        run: |
+          PACKAGE_NAME="@module-federation/vite"
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          BASE_VERSION="${CURRENT_VERSION%%-*}"
+          CURRENT_NEXT="$(npm view "$PACKAGE_NAME" "dist-tags.next" --json 2>/dev/null || true)"
+          CURRENT_NEXT="${CURRENT_NEXT#\"}"
+          CURRENT_NEXT="${CURRENT_NEXT%\"}"
+          if [ "$CURRENT_NEXT" = "null" ]; then
+            CURRENT_NEXT=""
           fi
+
+          PREFIX_REGEX="^${BASE_VERSION//./\\.}-next\.([0-9]+)$"
+          if [[ "$CURRENT_NEXT" =~ $PREFIX_REGEX ]]; then
+            NEXT_NUMBER=$((BASH_REMATCH[1] + 1))
+          else
+            NEXT_NUMBER=1
+          fi
+
+          NEXT_VERSION="${BASE_VERSION}-next.${NEXT_NUMBER}"
+          npm pkg set version="$NEXT_VERSION"
+          echo "Set prerelease version: $NEXT_VERSION"
 
       - name: Build
         run: pnpm run build
@@ -111,14 +127,8 @@ jobs:
               DIST_TAG="next"
             fi
           else
-            TAG="${{ github.event.release.tag_name }}"
-            VERSION="$TAG"
-            if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-              if [[ "$VERSION" =~ -(alpha|beta|next|rc)($|\.) ]]; then
-                DIST_TAG="${BASH_REMATCH[1]}"
-              else
-                DIST_TAG="next"
-              fi
+            if [ "${{ github.event.action }}" = "prereleased" ]; then
+              DIST_TAG="next"
             fi
           fi
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,12 +11,15 @@ This repo uses Changesets for versioning, and publishes to npm via GitHub Action
 3. Create a GitHub Release for the merge commit
    - Tag format: `<package.json version>` (example: `1.11.0`)
    - Stable: mark as a normal release
-   - Pre-release: mark as a prerelease; use a pre-id in the version (examples: `1.12.0-next.1`, `1.12.0-beta.1`, `1.12.0-alpha.1`)
+   - Pre-release: mark as a prerelease on the same stable tag (example: `1.12.0`)
 4. GitHub Actions publishes to npm
    - Workflow: `Publish (GitHub Release)` (`.github/workflows/publish-on-release.yml`)
    - Dist-tag:
-     - Release trigger: `latest` for stable releases; for prereleases it derives from the version (`next|beta|alpha`, default `next`)
+     - Release trigger: `latest` for stable releases; `next` for prereleases
      - Manual trigger (`workflow_dispatch`): `latest` or `next` from workflow input
+   - Pre-release versioning:
+     - On `prereleased` events, workflow patches `package.json` to `<base>-next.<N>` before publish.
+     - `<N>` increments from current npm `next` dist-tag when prefix matches, otherwise starts at `1`.
    - Existing version handling:
      - If the exact version is already on npm and already under the target dist-tag, publish is skipped (idempotent rerun).
      - If the version already exists but target dist-tag points elsewhere, workflow fails (no republish, no dist-tag promotion).
@@ -37,5 +40,4 @@ Use the `Publish (GitHub Release)` workflow with `Run workflow`:
   - repo: `module-federation/vite`
   - workflow: `.github/workflows/publish-on-release.yml`
   - environment: `publish`
-- Prerelease GitHub releases must use prerelease semver (example: `1.12.0-next.1`, not `1.12.0`).
-- Stable promotion is by publishing a new stable semver, not by retagging an already published version.
+- Promotion flow: prerelease publishes `-next.N`; stable release publishes base stable version to `latest`.


### PR DESCRIPTION
## Summary
- enforce prerelease semver on `prereleased` events (must include pre-id)
- block republish attempts when version already exists under a different dist-tag
- keep trusted-publisher-only flow (no dist-tag promotion path)
- document release constraints and expected semver flow

## Why
Fixes npm publish failures like:
`You cannot publish over the previously published versions`
when trying prerelease -> latest with same semver.