### PR TITLE
fix: create virtual module directories before writing files

### DIFF
--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -153,10 +153,14 @@ export default class VirtualModule {
     if (!this.inited) {
       this.inited = true;
     }
-    writeFileSync(this.getPath(), code);
+    const path = this.getPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, code);
   }
 
   write(code: string) {
-    writeFile(this.getPath(), code, function () {});
+    const path = this.getPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFile(path, code, function () {});
   }
 }

--- a/src/utils/__tests__/VirtualModule.test.ts
+++ b/src/utils/__tests__/VirtualModule.test.ts
@@ -1,4 +1,8 @@
-import { getSuffix, assertModuleFound } from '../VirtualModule';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import { join } from 'pathe';
+import { tmpdir } from 'os';
+import VirtualModule, { getSuffix, assertModuleFound } from '../VirtualModule';
+import { normalizeModuleFederationOptions } from '../normalizeModuleFederationOptions';
 
 describe('getSuffix', () => {
   it('returns .js for simple package without extension', () => {
@@ -48,5 +52,26 @@ describe('assertModuleFound', () => {
     }).toThrow(
       `Module Federation shared module '${str}' not found. Please ensure it's installed as a dependency in your package.json.`
     );
+  });
+});
+
+describe('VirtualModule writeSync', () => {
+  it('creates missing virtual module directories before writing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'mf-vm-'));
+    try {
+      mkdirSync(join(root, 'node_modules'), { recursive: true });
+      normalizeModuleFederationOptions({
+        name: 'analytics',
+      });
+      VirtualModule.setRoot(root);
+
+      const vm = new VirtualModule('mui/styles', '__loadShare__', '.js');
+      vm.writeSync('export default 1;');
+
+      expect(existsSync(vm.getPath())).toBe(true);
+      expect(readFileSync(vm.getPath(), 'utf8')).toBe('export default 1;');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- ensure `VirtualModule.writeSync` creates parent directories before writing generated files
- apply the same guard to async `write` to keep behavior consistent
- add a regression test that writes a `loadShare` virtual module with no pre-existing `__mf__virtual` directory

## Testing
- Not runnable in this environment because repository dependencies are not installed (missing `vitest` without full bootstrap).
- Included a focused unit test (`src/utils/__tests__/VirtualModule.test.ts`) that validates directory creation before file writes; this should run in CI.

## Related
- Fixes #419