### PR TITLE
fix: expose package.json in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       },
       "import": "./lib/index.mjs",
       "require": "./lib/index.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
Hi!

#409 introduced a proper export map, breaking all direct imports (e.g. `import moduleFederationVitePkg from "@module-federation/vite/package.json" with { type: "json" };`)

This PR adds a `./package.json` identifier for easy package import