### PR TITLE
fix: use proxyLocal alias to match code body references after Rollup deconflict mangling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -394,7 +394,9 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
                 );
                 inlineable.push({ local: b.local, funcBody: renamedFunc });
               } else {
-                nonInlineable.push(b);
+                // Use proxyLocal, not b.local: Rollup's deconflict may mangle the alias
+                // (e.g. require$$0 → require$0) without updating the code body references.
+                nonInlineable.push({ imported: b.imported, local: proxyLocal });
               }
             }
 


### PR DESCRIPTION
After updating to the latest version I ran into this runtime error:

```
index-BrR8pw7K.js:493 Uncaught ReferenceError: require$$0 is not defined
```

Tracked it down to how non-inlineable bindings get reconstructed in the commonjs-proxy import. Rollup's deconfliction sometimes renames the import alias (e.g. `require$$0` → `require$0`) but the proxy chunk's code body still references the original name — so at runtime the binding is missing.

The fix is to use `proxyLocal` (the name from the proxy's export map) as the alias instead of `b.local` (the deconflicted one), so they stay in sync.