### PR TITLE
fix: preserve proxy import alias after Rollup deconflict  

### DIFF
--- a/integration/proxy-alias-deconflict.test.ts
+++ b/integration/proxy-alias-deconflict.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { resolveProxyAlias } from '../src/utils/bundleHelpers';
+
+describe('resolveProxyAlias', () => {
+  it('keeps b.local when it is referenced in the code body', () => {
+    const fullImport = `import{r as commonjsGlobal$1}from"./proxy-abc.js"`;
+    const code = `${fullImport};console.log(commonjsGlobal$1);`;
+
+    const result = resolveProxyAlias(
+      { imported: 'r', local: 'commonjsGlobal$1' },
+      'commonjsGlobal',
+      code,
+      fullImport
+    );
+
+    expect(result.local).toBe('commonjsGlobal$1');
+  });
+
+  it('restores proxyLocal when b.local is NOT referenced in the code body', () => {
+    const fullImport = `import{r as require$0}from"./proxy-abc.js"`;
+    const code = `${fullImport};console.log(require$$0);`;
+
+    const result = resolveProxyAlias(
+      { imported: 'r', local: 'require$0' },
+      'require$$0',
+      code,
+      fullImport
+    );
+
+    expect(result.local).toBe('require$$0');
+  });
+
+  it('escapes special regex characters in b.local (e.g. $$)', () => {
+    const fullImport = `import{r as require$$0}from"./proxy-abc.js"`;
+    const code = `${fullImport};console.log(require$$0);`;
+
+    const result = resolveProxyAlias(
+      { imported: 'r', local: 'require$$0' },
+      'require$$0',
+      code,
+      fullImport
+    );
+
+    expect(result.local).toBe('require$$0');
+  });
+
+  it('returns proxyLocal when b.local only appears in the import statement', () => {
+    const fullImport = `import{r as mangledName}from"./proxy-abc.js"`;
+    const code = `${fullImport};console.log(originalName);`;
+
+    const result = resolveProxyAlias(
+      { imported: 'r', local: 'mangledName' },
+      'originalName',
+      code,
+      fullImport
+    );
+
+    expect(result.local).toBe('originalName');
+  });
+
+  it('preserves imported field unchanged', () => {
+    const fullImport = `import{myExport as renamed}from"./proxy.js"`;
+    const code = `${fullImport};console.log(original);`;
+
+    const result = resolveProxyAlias(
+      { imported: 'myExport', local: 'renamed' },
+      'original',
+      code,
+      fullImport
+    );
+
+    expect(result.imported).toBe('myExport');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import pluginProxyRemotes from './plugins/pluginProxyRemotes';
 import { proxySharedModule } from './plugins/pluginProxySharedModule_preBuild';
 import pluginVarRemoteEntry from './plugins/pluginVarRemoteEntry';
 import aliasToArrayPlugin from './utils/aliasToArrayPlugin';
+import { resolveProxyAlias } from './utils/bundleHelpers';
 import {
   ModuleFederationOptions,
   NormalizedModuleFederationOptions,
@@ -362,7 +363,6 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
             // loadShare-dependent value.
             const inlineable: Array<{ local: string; funcBody: string }> = [];
             const nonInlineable: Array<{ imported: string; local: string }> = [];
-            const codeWithoutImport = code.replace(fullImport, '');
 
             for (const b of bindings) {
               const proxyLocal = exportMap[b.imported];
@@ -395,14 +395,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
                 );
                 inlineable.push({ local: b.local, funcBody: renamedFunc });
               } else {
-                // If b.local isn't referenced in the code body, Rollup's deconflict
-                // mangled only the alias — restore proxyLocal so they stay in sync.
-                const escapedLocal = b.local.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                const localUsedInCode = new RegExp(`\\b${escapedLocal}\\b`).test(codeWithoutImport);
-                nonInlineable.push({
-                  imported: b.imported,
-                  local: localUsedInCode ? b.local : proxyLocal,
-                });
+                nonInlineable.push(resolveProxyAlias(b, proxyLocal, code, fullImport));
               }
             }
 

--- a/src/utils/bundleHelpers.ts
+++ b/src/utils/bundleHelpers.ts
@@ -1,5 +1,25 @@
 import { OutputBundle } from 'rollup';
 
+/**
+ * Resolve the local alias for a non-inlineable proxy binding.
+ * If Rollup's deconflict renamed the alias but didn't update references
+ * in the code body, fall back to proxyLocal so they stay in sync.
+ */
+export function resolveProxyAlias(
+  binding: { imported: string; local: string },
+  proxyLocal: string,
+  code: string,
+  fullImport: string
+): { imported: string; local: string } {
+  const codeWithoutImport = code.replace(fullImport, '');
+  const escapedLocal = binding.local.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const localUsedInCode = new RegExp(`\\b${escapedLocal}\\b`).test(codeWithoutImport);
+  return {
+    imported: binding.imported,
+    local: localUsedInCode ? binding.local : proxyLocal,
+  };
+}
+
 export function findRemoteEntryFile(filename: string, bundle: OutputBundle) {
   for (const [_, fileData] of Object.entries(bundle)) {
     if (


### PR DESCRIPTION
After updating to the latest version I ran into this runtime error:

```
index-BrR8pw7K.js:493 Uncaught ReferenceError: require$$0 is not defined
```

Tracked it down to how non-inlineable bindings get reconstructed in the commonjs-proxy import. Rollup's deconfliction sometimes renames the import alias (e.g. `require$$0 → require$0`) but doesn't update references in the chunk's code body — those still use the original name, so the binding is undefined at runtime.

The fix checks whether `b.local `(the deconflicted alias) actually appears in the code body (excluding the import line). If it doesn't, the code body still references `proxyLocal` from the proxy's export map, so we use that as the alias instead. If `b.local` is used in the code body, we keep it - Rollup's rename was correct in that case (e.g. `commonjsGlobal → commonjsGlobal$1` to avoid a local variable clash).