### PR TITLE
fix: expose ModuleFederationOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -605,4 +605,4 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
   ];
 }
 
-export { federation };
+export { federation, type ModuleFederationOptions };


### PR DESCRIPTION
Hi!

Very small improvement to make consumption friendlier in TS projects where the federation option object is constructed outside of the function call

You can see on <https://npmx.dev/package-code/@module-federation/vite/v/1.12.0/lib%2Findex.d.mts> all the other types that are accessible indirectly (through `ModuleFederationOptions`) for end users

Cheers!
