### PR TITLE
fix: resolve shared packages

### DIFF
--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -23,6 +23,7 @@ export type RemoteEntryType =
   | string;
 
 import * as fs from 'fs';
+import { createRequire } from 'node:module';
 import * as path from 'pathe';
 
 interface ExposesItem {
@@ -126,7 +127,8 @@ function removePathFromNpmPackage(packageString: string): string {
  */
 function searchPackageVersion(sharedName: string): string | undefined {
   try {
-    const sharedPath = require.resolve(sharedName);
+    const projectRequire = createRequire(process.cwd());
+    const sharedPath = projectRequire.resolve(sharedName);
     let potentialPackageJsonDir = path.dirname(sharedPath);
     const rootDir = path.parse(potentialPackageJsonDir).root;
     while (
@@ -135,7 +137,7 @@ function searchPackageVersion(sharedName: string): string | undefined {
     ) {
       const potentialPackageJsonPath = path.join(potentialPackageJsonDir, 'package.json');
       if (fs.existsSync(potentialPackageJsonPath)) {
-        const potentialPackageJson = require(potentialPackageJsonPath);
+        const potentialPackageJson = JSON.parse(fs.readFileSync(potentialPackageJsonPath, 'utf-8'));
         if (
           typeof potentialPackageJson == 'object' &&
           potentialPackageJson !== null &&


### PR DESCRIPTION
## Summary
If we include this package via symlink (pnpm link), package versions are resolved incorrectly. This fix corrects the issue with local patches and improves usability.


## Problem
- pnpm workspace
- nx monorepo

Federation config:
```js
{
 // ...
  shared: {
    'vue': { singleton: true }
  },
}
```

```bash
# link to local version
pnpm link --global @module-federation/vite

# run project
nx run host:dev
```

And we get a problem:
```
Error: Cannot find module 'vue/package.json'                                 
Require stack:                                                               
- /Users/admin/Developer/module-federation-vite/lib/index.mjs            
    at Module._resolveFilename (node:internal/modules/cjs/loader:1420:15)    
    at defaultResolveImpl (node:internal/modules/cjs/loader:1058:19)         
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1063:22)     
    at Module._load (node:internal/modules/cjs/loader:1226:37)               
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)            
    at wrapModuleLoad (node:internal/modules/cjs/loader:244:24)              
    at Module.require (node:internal/modules/cjs/loader:1503:12)             
    at require (node:internal/modules/helpers:152:16)                        
    at normalizeShareItem (file:///Users/admin/Developer/module-federation-vite/lib/index.mjs:588:14)                                                
    at file:///Users/admin/Developer/module-federation-vite/lib/index.mjs:634:17 {                                                                   
      code: 'MODULE_NOT_FOUND',                                                  
      requireStack: ['/Users/admin/Developer/module-federation-vite/lib/index.mjs' ]          
    } 
```