### PR TITLE
fix: stripEmptyPreloadCalls skipping non-empty preload helpers

### DIFF
--- a/src/utils/__tests__/controlChunkSanitizer.test.ts
+++ b/src/utils/__tests__/controlChunkSanitizer.test.ts
@@ -26,6 +26,39 @@ describe('controlChunkSanitizer', () => {
     ).toBe('import "./other.js";export const usedShared = {};');
   });
 
+  it('preserves preload helpers with non-empty dependency arrays', () => {
+    const code =
+      'import{_ as o}from"./preload-helper-BDBacUwf.js";' +
+      'const n={' +
+      '"@byte/api":async()=>await import("./index-DaqjAZdf.js"),' +
+      '"@byte/ui":async()=>await o(()=>import("./index-Bc0YS1wt.js"),__vite__mapDeps([0]),import.meta.url),' +
+      '"@byte/user-session":async()=>await o(()=>import("./index-BV4s8wZv.js"),[],import.meta.url),' +
+      '"react":async()=>await import("./index-DlZQ-_sN.js")' +
+      '}';
+
+    const result = stripEmptyPreloadCalls(code);
+
+    expect(result).toContain(
+      '"@byte/ui":async()=>await o(()=>import("./index-Bc0YS1wt.js"),__vite__mapDeps([0]),import.meta.url)'
+    );
+
+    expect(result).toContain('"@byte/user-session":async()=>await import("./index-BV4s8wZv.js")');
+
+    expect(result).not.toMatch(/await import\([^)]+\),__vite__mapDeps/);
+  });
+
+  it('does not break when only non-empty preload helpers exist', () => {
+    const code =
+      'import{_ as o}from"./preload-helper.js";' +
+      'const n={' +
+      '"@byte/ui":async()=>await o(()=>import("./ui.js"),__vite__mapDeps([0]),import.meta.url)' +
+      '}';
+
+    const result = stripEmptyPreloadCalls(code);
+
+    expect(result).toContain('o(()=>import("./ui.js"),__vite__mapDeps([0]),import.meta.url)');
+  });
+
   it('detects federation control chunks', () => {
     expect(isFederationControlChunk('remoteEntry.js', 'remoteEntry.js')).toBe(true);
     expect(isFederationControlChunk('assets/hostInit-abc.js', 'remoteEntry.js')).toBe(true);

--- a/src/utils/controlChunkSanitizer.ts
+++ b/src/utils/controlChunkSanitizer.ts
@@ -22,15 +22,20 @@ export function stripEmptyPreloadCalls(code: string): string {
       while (cursor < nextCode.length) {
         const char = nextCode[cursor];
         if (char === '(') depth++;
-        else if (char === ')') depth--;
-        else if (depth === 0 && nextCode.startsWith(',[],import.meta.url)', cursor)) {
+        else if (char === ')') {
+          depth--;
+          if (depth < 0) break;
+        } else if (depth === 0 && nextCode.startsWith(',[],import.meta.url)', cursor)) {
           replacementEnd = cursor;
           break;
         }
         cursor++;
       }
 
-      if (replacementEnd === -1) break;
+      if (replacementEnd === -1) {
+        start = nextCode.indexOf(marker, start + marker.length);
+        continue;
+      }
 
       const expression = nextCode.slice(exprStart, replacementEnd);
       nextCode =


### PR DESCRIPTION
## Summary

Resolves #517

- Fixes a bug where `stripEmptyPreloadCalls` would halt processing entirely when it encountered a Vite preload helper with a **non-empty** dependency array (e.g. `__vite__mapDeps([0])`). This caused subsequent empty-dep preload calls in the same chunk to be left un-stripped, producing broken runtime imports.

- Two issues in the parenthesis-depth parser were corrected:
  1. **Unbalanced depth tracking** — a closing `)` belonging to the outer wrapper would decrement `depth` past zero and continue scanning, eventually failing to match anything. The parser now `break`s when depth goes negative.
  2. **Early termination** — when no `,[],import.meta.url)` suffix was found (i.e. the call has real dependencies and should be preserved), the loop `break`ed instead of advancing to the next marker, silently skipping all remaining calls.

## Test plan

- [x] Added test: mixed chunk containing both non-empty (`__vite__mapDeps([0])`) and empty (`[]`) preload helpers — verifies the non-empty call is preserved and the empty call is unwrapped to a plain `import()`.
- [x] Added test: chunk with only non-empty preload helpers — verifies nothing is incorrectly stripped.
- [x] Verify existing `controlChunkSanitizer` tests still pass (`vitest run`).
- [x] Smoke-test a host app that consumes remotes with CSS dependencies (the real-world trigger for non-empty `__vite__mapDeps`).