### PR TITLE
feat: add vite runtime remote registration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This plugin makes Module Federation work together with [Vite](https://vitejs.dev
 
 ### [More examples here](https://github.com/module-federation/vite/tree/main/examples)<br>
 
+Includes a pure runtime host example in [`examples/vite-runtime-register`](./examples/vite-runtime-register).
+
 ## Try this crazy example with all these bundlers together
 
 <img src="./docs/multi-example.png"/>

--- a/examples/vite-runtime-register/README.md
+++ b/examples/vite-runtime-register/README.md
@@ -1,0 +1,29 @@
+# Vite Runtime Register Example
+
+Pure runtime host + Vite remote.
+
+What it shows:
+
+- host creates a Module Federation runtime instance
+- host registers React shared deps at runtime
+- host registers a remote with `registerRemotes()`
+- host loads exposed modules with `loadRemote()`
+
+Run dev:
+
+```bash
+pnpm --filter examples-vite-runtime-register-remote dev
+pnpm --filter examples-vite-runtime-register-host dev
+```
+
+URLs:
+
+- host: `http://localhost:4175`
+- remote: `http://localhost:4176`
+
+Run preview:
+
+```bash
+pnpm --filter examples-vite-runtime-register-remote preview
+pnpm --filter examples-vite-runtime-register-host preview
+```

--- a/examples/vite-runtime-register/vite-host/index.html
+++ b/examples/vite-runtime-register/vite-host/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite Runtime Host</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/examples/vite-runtime-register/vite-host/package.json
+++ b/examples/vite-runtime-register/vite-host/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "examples-vite-runtime-register-host",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite build && vite preview"
+  },
+  "dependencies": {
+    "@module-federation/runtime": "2.2.3",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^5.1.2",
+    "vite": "npm:rolldown-vite@^7.3.1"
+  }
+}

--- a/examples/vite-runtime-register/vite-host/src/App.jsx
+++ b/examples/vite-runtime-register/vite-host/src/App.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import {
+  loadRuntimeComponent,
+  loadRuntimeMessage,
+  registerRuntimeRemote,
+  remoteEntryUrl,
+} from './runtime';
+import './index.css';
+
+export default function App() {
+  const [registered, setRegistered] = useState(false);
+  const [message, setMessage] = useState('Remote not loaded yet.');
+  const [RemoteCard, setRemoteCard] = useState(null);
+  const [error, setError] = useState('');
+
+  const onRegister = () => {
+    try {
+      registerRuntimeRemote();
+      setRegistered(true);
+      setError('');
+      setMessage(`Registered runtimeRemote -> ${remoteEntryUrl}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onLoadMessage = async () => {
+    try {
+      const nextMessage = await loadRuntimeMessage();
+      setError('');
+      setMessage(nextMessage);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onLoadComponent = async () => {
+    try {
+      const nextComponent = await loadRuntimeComponent();
+      setError('');
+      setRemoteCard(() => nextComponent);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <main className="shell">
+      <section className="panel hero">
+        <p className="eyebrow">Pure Runtime Host</p>
+        <h1>Register a Vite remote at runtime</h1>
+        <p className="lede">
+          No static federation config in the host. The app creates a runtime
+          instance, registers React as shared, then adds the remote on demand.
+        </p>
+      </section>
+
+      <section className="panel flow">
+        <div className="step">
+          <span>1</span>
+          <div>
+            <h2>Register remote</h2>
+            <p>{remoteEntryUrl}</p>
+          </div>
+          <button onClick={onRegister}>registerRemotes()</button>
+        </div>
+
+        <div className="step">
+          <span>2</span>
+          <div>
+            <h2>Load exposed data</h2>
+            <p>Calls `loadRemote('runtimeRemote/message')`.</p>
+          </div>
+          <button disabled={!registered} onClick={onLoadMessage}>
+            loadRemote() data
+          </button>
+        </div>
+
+        <div className="step">
+          <span>3</span>
+          <div>
+            <h2>Load exposed component</h2>
+            <p>Calls `loadRemote('runtimeRemote/MessageCard')`.</p>
+          </div>
+          <button disabled={!registered} onClick={onLoadComponent}>
+            loadRemote() component
+          </button>
+        </div>
+      </section>
+
+      <section className="panel output">
+        <h2>Status</h2>
+        <pre>{message}</pre>
+        {error ? <pre className="error">{error}</pre> : null}
+      </section>
+
+      <section className="panel output">
+        <h2>Remote render</h2>
+        {RemoteCard ? <RemoteCard /> : <p>Load the remote component to render it here.</p>}
+      </section>
+    </main>
+  );
+}

--- a/examples/vite-runtime-register/vite-host/src/index.css
+++ b/examples/vite-runtime-register/vite-host/src/index.css
@@ -1,0 +1,146 @@
+:root {
+  color: #f5efe0;
+  background:
+    radial-gradient(circle at top, rgba(255, 176, 89, 0.2), transparent 32%),
+    linear-gradient(180deg, #18110f 0%, #0f0b0a 100%);
+  font-family:
+    'IBM Plex Sans',
+    'Avenir Next',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  background: #ffb059;
+  color: #281a11;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.8rem 1.1rem;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+pre {
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.shell {
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 48px 20px 64px;
+}
+
+.panel {
+  backdrop-filter: blur(18px);
+  background: rgba(30, 22, 19, 0.8);
+  border: 1px solid rgba(255, 176, 89, 0.16);
+  border-radius: 28px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.25);
+  margin-bottom: 18px;
+  padding: 24px;
+}
+
+.hero h1,
+.flow h2,
+.output h2 {
+  font-family:
+    'IBM Plex Mono',
+    'SFMono-Regular',
+    monospace;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 6vw, 3.8rem);
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  margin: 0.35rem 0 0.75rem;
+  max-width: 11ch;
+}
+
+.eyebrow {
+  color: #ffb059;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.lede {
+  color: #d2c7bf;
+  font-size: 1.05rem;
+  margin: 0;
+  max-width: 58ch;
+}
+
+.flow {
+  display: grid;
+  gap: 16px;
+}
+
+.step {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 20px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: auto 1fr auto;
+  padding: 18px;
+}
+
+.step span {
+  align-items: center;
+  border: 1px solid rgba(255, 176, 89, 0.32);
+  border-radius: 999px;
+  color: #ffb059;
+  display: inline-flex;
+  font-family:
+    'IBM Plex Mono',
+    'SFMono-Regular',
+    monospace;
+  height: 40px;
+  justify-content: center;
+  width: 40px;
+}
+
+.step h2,
+.output h2 {
+  margin: 0 0 0.35rem;
+}
+
+.step p {
+  color: #d2c7bf;
+  margin: 0;
+}
+
+.output {
+  display: grid;
+  gap: 12px;
+}
+
+.error {
+  color: #ff8f8f;
+}
+
+@media (max-width: 720px) {
+  .step {
+    grid-template-columns: 1fr;
+  }
+}

--- a/examples/vite-runtime-register/vite-host/src/main.jsx
+++ b/examples/vite-runtime-register/vite-host/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('app')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/vite-runtime-register/vite-host/src/runtime.js
+++ b/examples/vite-runtime-register/vite-host/src/runtime.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { createInstance } from '@module-federation/runtime';
+
+const remoteEntryUrl =
+  import.meta.env.VITE_REMOTE_ENTRY_URL ??
+  'http://localhost:4176/mf-manifest.json';
+
+const mf = createInstance({
+  name: 'viteRuntimeRegisterHost',
+  remotes: [],
+});
+
+mf.registerShared({
+  react: {
+    version: React.version,
+    scope: 'default',
+    lib: () => React,
+    shareConfig: {
+      singleton: true,
+      requiredVersion: `^${React.version}`,
+    },
+  },
+  'react-dom': {
+    version: ReactDOM.version || React.version,
+    scope: 'default',
+    lib: () => ReactDOM,
+    shareConfig: {
+      singleton: true,
+      requiredVersion: `^${ReactDOM.version || React.version}`,
+    },
+  },
+});
+
+export function registerRuntimeRemote() {
+  mf.registerRemotes([
+    {
+      name: 'runtimeRemote',
+      entry: remoteEntryUrl,
+      type: 'module',
+    },
+  ]);
+}
+
+export async function loadRuntimeComponent() {
+  const mod = await mf.loadRemote('runtimeRemote/MessageCard');
+  return mod?.default ?? mod?.MessageCard ?? null;
+}
+
+export async function loadRuntimeMessage() {
+  const mod = await mf.loadRemote('runtimeRemote/message');
+  const getMessage = mod?.default ?? mod?.getMessage;
+
+  return typeof getMessage === 'function' ? getMessage() : 'No message found.';
+}
+
+export { remoteEntryUrl };

--- a/examples/vite-runtime-register/vite-host/vite.config.js
+++ b/examples/vite-runtime-register/vite-host/vite.config.js
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: false,
+    port: 4175,
+  },
+  preview: {
+    port: 4175,
+  },
+});

--- a/examples/vite-runtime-register/vite-remote/index.html
+++ b/examples/vite-runtime-register/vite-remote/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite Runtime Remote</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/examples/vite-runtime-register/vite-remote/package.json
+++ b/examples/vite-runtime-register/vite-remote/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "examples-vite-runtime-register-remote",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite build && vite preview"
+  },
+  "dependencies": {
+    "@module-federation/vite": "workspace:*",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^5.1.2",
+    "vite": "npm:rolldown-vite@^7.3.1"
+  }
+}

--- a/examples/vite-runtime-register/vite-remote/src/App.jsx
+++ b/examples/vite-runtime-register/vite-remote/src/App.jsx
@@ -1,0 +1,13 @@
+import MessageCard from './MessageCard';
+import { getMessage } from './message';
+
+export default function App() {
+  return (
+    <main className="standalone">
+      <p className="tag">Standalone remote</p>
+      <h1>runtimeRemote</h1>
+      <p>{getMessage()}</p>
+      <MessageCard />
+    </main>
+  );
+}

--- a/examples/vite-runtime-register/vite-remote/src/MessageCard.jsx
+++ b/examples/vite-runtime-register/vite-remote/src/MessageCard.jsx
@@ -1,0 +1,14 @@
+import './index.css';
+
+export default function MessageCard() {
+  return (
+    <article className="card">
+      <p className="tag">runtimeRemote/MessageCard</p>
+      <h3>Remote component mounted</h3>
+      <p>
+        Built with <code>@module-federation/vite</code>, discovered through the
+        runtime manifest, rendered inside the host app.
+      </p>
+    </article>
+  );
+}

--- a/examples/vite-runtime-register/vite-remote/src/index.css
+++ b/examples/vite-runtime-register/vite-remote/src/index.css
@@ -1,0 +1,70 @@
+:root {
+  color: #f7f4ef;
+  background:
+    radial-gradient(circle at bottom right, rgba(84, 160, 255, 0.28), transparent 28%),
+    linear-gradient(180deg, #0d1a2d 0%, #08111e 100%);
+  font-family:
+    'IBM Plex Sans',
+    'Avenir Next',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+code {
+  font-family:
+    'IBM Plex Mono',
+    'SFMono-Regular',
+    monospace;
+}
+
+.standalone,
+.card {
+  backdrop-filter: blur(18px);
+  background: rgba(14, 28, 49, 0.72);
+  border: 1px solid rgba(141, 195, 255, 0.24);
+  border-radius: 28px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.22);
+}
+
+.standalone {
+  margin: 48px auto;
+  max-width: 720px;
+  padding: 28px;
+}
+
+.card {
+  margin-top: 18px;
+  padding: 22px;
+}
+
+.tag {
+  color: #8dc3ff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+}
+
+h1,
+h3 {
+  font-family:
+    'IBM Plex Mono',
+    'SFMono-Regular',
+    monospace;
+  margin: 0 0 0.75rem;
+}
+
+p {
+  color: #d6dce6;
+  margin: 0;
+}

--- a/examples/vite-runtime-register/vite-remote/src/main.jsx
+++ b/examples/vite-runtime-register/vite-remote/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('app')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/vite-runtime-register/vite-remote/src/message.js
+++ b/examples/vite-runtime-register/vite-remote/src/message.js
@@ -1,0 +1,5 @@
+export function getMessage() {
+  return 'Remote data loaded through the runtime after registerRemotes().';
+}
+
+export default getMessage;

--- a/examples/vite-runtime-register/vite-remote/vite.config.js
+++ b/examples/vite-runtime-register/vite-remote/vite.config.js
@@ -1,0 +1,38 @@
+import { federation } from '@module-federation/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: 'http://localhost:4176/',
+  plugins: [
+    react(),
+    federation({
+      name: 'runtimeRemote',
+      manifest: true,
+      exposes: {
+        './MessageCard': './src/MessageCard.jsx',
+        './message': './src/message.js',
+      },
+      shared: {
+        react: {
+          singleton: true,
+        },
+        'react-dom': {
+          singleton: true,
+        },
+      },
+      dts: false,
+    }),
+  ],
+  server: {
+    open: false,
+    origin: 'http://localhost:4176',
+    port: 4176,
+  },
+  preview: {
+    port: 4176,
+  },
+  build: {
+    target: 'chrome89',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,44 @@ importers:
         specifier: ^1.4.1
         version: 1.4.4(@swc/helpers@0.5.3)(rollup@4.59.0)(vite@5.4.3(@types/node@25.3.3)(lightningcss@1.32.0)(sass-embedded@1.77.8)(terser@5.31.6))
 
+  examples/vite-runtime-register/vite-host:
+    dependencies:
+      '@module-federation/runtime':
+        specifier: 2.2.3
+        version: 2.2.3
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.2(rolldown-vite@7.3.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.2))
+      vite:
+        specifier: npm:rolldown-vite@^7.3.1
+        version: rolldown-vite@7.3.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.2)
+
+  examples/vite-runtime-register/vite-remote:
+    dependencies:
+      '@module-federation/vite':
+        specifier: workspace:*
+        version: link:../../..
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.2(rolldown-vite@7.3.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.2))
+      vite:
+        specifier: npm:rolldown-vite@^7.3.1
+        version: rolldown-vite@7.3.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.2)
+
   examples/vite-vite/vite-host:
     dependencies:
       '@emotion/react':


### PR DESCRIPTION
## Summary
- add a new `examples/vite-runtime-register` pair with a pure runtime host and a Vite remote
- show `createInstance()`, runtime shared registration, `registerRemotes()`, and `loadRemote()` end-to-end
- document the example in the root README and add lockfile entries for the new workspace packages

## Verification
- `pnpm --filter examples-vite-runtime-register-remote build`
- `pnpm --filter examples-vite-runtime-register-host build`
- browser smoke test against both previews: register remote, load remote data, load remote component
