### PR TITLE
fix: resolve `publicPath: auto` correctly

### DIFF
--- a/src/utils/__tests__/publicPath.test.ts
+++ b/src/utils/__tests__/publicPath.test.ts
@@ -13,6 +13,34 @@ describe('resolvePublicPath', () => {
     expect(resolvePublicPath(options, '/vite/')).toBe('https://cdn.example.com/');
   });
 
+  it('should treat publicPath "auto" as unset and fall back to viteBase', () => {
+    const options = {
+      ...mockOptions,
+      publicPath: 'auto',
+    };
+    expect(resolvePublicPath(options, '/vite/')).toBe('/vite/');
+    expect(resolvePublicPath(options, '/vite')).toBe('/vite/');
+  });
+
+  it('should treat publicPath "auto" as unset and fall back to "auto" when no viteBase', () => {
+    const options = {
+      ...mockOptions,
+      publicPath: 'auto',
+    };
+    expect(resolvePublicPath(options, '')).toBe('auto');
+  });
+
+  it('should not produce malformed URLs when publicPath is "auto" and filename is concatenated', () => {
+    const options = {
+      ...mockOptions,
+      publicPath: 'auto',
+    };
+    const filename = 'remoteEntry.js';
+    const resolved = resolvePublicPath(options, '/');
+    // Must not produce "autoremoteEntry.js"
+    expect(resolved + filename).toBe('/remoteEntry.js');
+  });
+
   it('should return "auto" when originalBase is empty string', () => {
     expect(resolvePublicPath(mockOptions, '/vite/', '')).toBe('auto');
   });

--- a/src/utils/publicPath.ts
+++ b/src/utils/publicPath.ts
@@ -12,8 +12,9 @@ export function resolvePublicPath(
   viteBase: string,
   originalBase?: string
 ): string {
-  // Use explicitly set publicPath if provided
-  if (options.publicPath) {
+  // Use explicitly set publicPath if provided, but treat "auto" as unset
+  // (webpack convention: "auto" means infer at runtime, not a literal path segment)
+  if (options.publicPath && options.publicPath !== 'auto') {
     return options.publicPath;
   }
 


### PR DESCRIPTION
Close #561 

`publicPath` can be set to `auto`, in which case the resolution fails: https://github.com/module-federation/vite/issues/561
