### PR TITLE
fix: fix import from shared modules

### DIFF
--- a/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
+++ b/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseAst } from 'rollup/parseAst';
 
+const mockGetIsRolldown = vi.fn(() => true);
 vi.mock('../../utils/packageUtils', () => ({
-  getIsRolldown: () => true,
+  getIsRolldown: (...args: any[]) => mockGetIsRolldown(...args),
 }));
 
 import { pluginRemoteNamedExports } from '../pluginRemoteNamedExports';
@@ -24,8 +25,18 @@ function createContext(parseError = false) {
   };
 }
 
-async function transform(code: string, id = '/src/app.js', parseError = false, options = OPTIONS) {
+async function transform(
+  code: string,
+  id = '/src/app.js',
+  parseError = false,
+  options = OPTIONS,
+  command: 'serve' | 'build' = 'serve'
+) {
   const plugin = pluginRemoteNamedExports(options);
+  // Invoke the config hook to set the command (applyShared depends on it)
+  if ((plugin as any).config) {
+    (plugin as any).config({}, { command });
+  }
   const ctx = createContext(parseError);
   const result = await (plugin as any).transform.call(ctx, code, id);
   return result?.code as string | undefined;
@@ -343,6 +354,154 @@ describe('pluginRemoteNamedExports', () => {
     it('skips .json files', async () => {
       const result = await transform('{"remoteApp": true}', '/src/config.json');
       expect(result).toBeUndefined();
+    });
+  });
+
+  // ── shared module imports (Rolldown lacks syntheticNamedExports) ──
+
+  describe('shared module imports', () => {
+    // Shared rewriting only applies in build mode
+    async function transformBuild(
+      code: string,
+      id = '/src/app.js',
+      parseError = false,
+      options = SHARED_OPTIONS as any
+    ) {
+      return transform(code, id, parseError, options, 'build');
+    }
+
+    const SHARED_OPTIONS = {
+      remotes: {
+        remoteApp: { external: ['remoteApp'], shareScope: 'default' },
+      },
+      shared: {
+        react: { singleton: true },
+        '@acme/ui': { singleton: true },
+        '@mui/material': { singleton: true },
+        '@mui/x-date-pickers-pro/AdapterLuxon': { singleton: true },
+      },
+    } as any;
+
+    it('rewrites named import from shared package', async () => {
+      const result = await transformBuild('import { useState } from "react";');
+      expect(result).toContain('import { __moduleExports as');
+      expect(result).toContain('const { useState }');
+      expect(result).not.toContain('import { useState }');
+    });
+
+    it('rewrites named import from scoped shared package', async () => {
+      const result = await transformBuild('import { Button } from "@acme/ui";');
+      expect(result).toContain('__moduleExports');
+      expect(result).toContain('const { Button }');
+    });
+
+    it('does not rewrite deep imports of shared packages', async () => {
+      const result = await transformBuild('import IconButton from "@mui/material/IconButton";');
+      // Default-only import → skip. But more importantly, deep imports
+      // should not be matched as shared (only exact package names).
+      expect(result).toBeUndefined();
+    });
+
+    it('rewrites shared package with subpath when explicitly listed', async () => {
+      const result = await transformBuild(
+        'import { AdapterLuxon } from "@mui/x-date-pickers-pro/AdapterLuxon";'
+      );
+      expect(result).toContain('__moduleExports');
+      expect(result).toContain('const { AdapterLuxon }');
+    });
+
+    it('rewrites multiple named imports from shared package', async () => {
+      const result = await transformBuild('import { useState, useEffect, useRef } from "react";');
+      expect(result).toContain('__moduleExports');
+      expect(result).toContain('const { useState, useEffect, useRef }');
+    });
+
+    it('skips default-only import from shared package', async () => {
+      const result = await transformBuild('import React from "react";');
+      expect(result).toBeUndefined();
+    });
+
+    it('rewrites default + named import from shared package', async () => {
+      const result = await transformBuild('import React, { useState } from "react";');
+      expect(result).toContain('default as React');
+      expect(result).toContain('__moduleExports');
+      expect(result).toContain('const { useState }');
+    });
+
+    it('rewrites namespace import from shared package', async () => {
+      const result = await transformBuild('import * as React from "react";');
+      expect(result).toContain('import { __moduleExports as React }');
+      expect(result).not.toContain('import *');
+    });
+
+    it('wraps dynamic import of shared package', async () => {
+      const result = await transformBuild('const React = import("react");');
+      expect(result).toContain('.then(function(__mf_m__)');
+      expect(result).toContain('__moduleExports');
+    });
+
+    it('rewrites re-export from shared package', async () => {
+      const result = await transformBuild('export { useState } from "react";');
+      expect(result).toContain('import { __moduleExports as');
+      expect(result).toContain('__mf_re_');
+      expect(result).toContain('as useState');
+    });
+
+    it('handles mixed remote and shared imports in one file', async () => {
+      const code = [
+        'import { foo } from "remoteApp/utils";',
+        'import { useState } from "react";',
+      ].join('\n');
+      const result = await transformBuild(code);
+      expect(result).toContain('const { foo }');
+      expect(result).toContain('const { useState }');
+    });
+
+    it('still works when only shared packages are configured (no remotes)', async () => {
+      const sharedOnlyOptions = {
+        remotes: {},
+        shared: {
+          react: { singleton: true },
+        },
+      } as any;
+      const result = await transformBuild(
+        'import { useState } from "react";',
+        '/src/app.js',
+        false,
+        sharedOnlyOptions
+      );
+      expect(result).toContain('__moduleExports');
+      expect(result).toContain('const { useState }');
+    });
+
+    it('rewrites shared import via es-module-lexer fallback', async () => {
+      const result = await transformBuild(
+        'import { useState } from "react";',
+        '/src/app.tsx',
+        true
+      );
+      expect(result).toContain('__moduleExports');
+      expect(result).toContain('const { useState }');
+    });
+
+    it('skips __loadShare__ modules for shared packages', async () => {
+      const result = await transformBuild(
+        'import { useState } from "react";',
+        '/virtual/__loadShare__react.js'
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('does not rewrite __loadShare__ imports in dev mode (non-Rolldown)', async () => {
+      mockGetIsRolldown.mockReturnValueOnce(false);
+      const code = [
+        'import { useState } from "__mf__virtual/host__loadShare__react__loadShare__.js";',
+        'import { foo } from "remoteApp/utils";',
+      ].join('\n');
+      const result = await transform(code, '/src/app.js', false, SHARED_OPTIONS);
+      // Only the remote import should be rewritten, not the shared __loadShare__ import
+      expect(result).toContain('const { foo }');
+      expect(result).not.toContain('const { useState }');
     });
   });
 

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -1,15 +1,16 @@
 /**
- * Transforms consumer-side imports of remote modules so that named exports
- * are accessible even when the bundler does not support syntheticNamedExports
- * (Rolldown / Vite 8+).
+ * Transforms consumer-side imports of federated modules (both remote and
+ * shared) so that named exports are accessible even when the bundler does
+ * not support syntheticNamedExports (Rolldown / Vite 8+).
  *
- * The remote proxy module exports:
+ * The remote/shared proxy module exports:
  *   export const __moduleExports = exportModule;   // full namespace
  *   export default exportModule.default ?? exportModule;  // unwrapped default
  *
  * This plugin rewrites consumer code:
- *   import { foo } from "remote/xxx"
- *     → import { __moduleExports as __mf_ns_0 } from "remote/xxx"; const { foo } = __mf_ns_0;
+ *   import { foo } from "remote/xxx"       // remote module
+ *   import { useState } from "react"       // shared module
+ *     → import { __moduleExports as __mf_ns_0 } from "..."; const { foo } = __mf_ns_0;
  *
  *   import("remote/xxx")
  *     → import("remote/xxx").then(…)  // spreads __moduleExports into namespace
@@ -23,6 +24,7 @@ import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { loadWalk } from '../utils/loadWalk';
+import { getIsRolldown } from '../utils/packageUtils';
 import { LOAD_REMOTE_TAG, LOAD_SHARE_TAG } from '../virtualModules';
 
 const JS_EXTENSIONS_RE = /\.(?:[mc]?[jt]sx?|vue|svelte)(?:\?|$)/;
@@ -539,40 +541,55 @@ function collectFromRegex(
 
 export function pluginRemoteNamedExports(options: NormalizedModuleFederationOptions): Plugin {
   const remoteNames = Object.keys(options.remotes);
-
-  function isRemoteImport(source: string): boolean {
-    return (
-      remoteNames.some((name) => source === name || source.startsWith(name + '/')) ||
-      source.includes(LOAD_REMOTE_TAG)
-    );
-  }
+  const sharedNames = Object.keys(options.shared ?? {});
+  let command = 'serve';
 
   return {
     name: 'module-federation-remote-named-exports',
     enforce: 'post',
+    config(_config, env) {
+      command = env.command;
+    },
     async transform(code: string, id: string) {
-      if (remoteNames.length === 0) return;
+      // Shared-module rewriting only applies in build mode, where the
+      // module-federation-esm-shims plugin adds __moduleExports to shared
+      // modules.  In dev mode (both Rolldown and non-Rolldown), the virtual
+      // shared modules already provide explicit named exports, and Vite's dep
+      // optimizer would rename __moduleExports making it unreachable by name.
+      const applyShared = command === 'build';
+      const federatedNames = applyShared ? [...remoteNames, ...sharedNames] : remoteNames;
+
+      if (federatedNames.length === 0) return;
       // Skip federation internal modules
       if (id.includes(LOAD_REMOTE_TAG) || id.includes(LOAD_SHARE_TAG)) return;
       // Only process JS-like files to avoid parsing CSS/JSON/etc.
       if (!JS_EXTENSIONS_RE.test(id)) return;
-      // Quick bail-out: does the source mention any remote name?
-      if (!remoteNames.some((name) => code.includes(name))) return;
+      // Quick bail-out: does the source mention any federated module name?
+      if (!federatedNames.some((name) => code.includes(name))) return;
+
+      function isFederatedImport(source: string): boolean {
+        return (
+          remoteNames.some((name) => source === name || source.startsWith(name + '/')) ||
+          (applyShared && sharedNames.includes(source)) ||
+          source.includes(LOAD_REMOTE_TAG) ||
+          (applyShared && source.includes(LOAD_SHARE_TAG))
+        );
+      }
 
       let imports: ImportInfo[] | undefined;
 
       try {
         const ast = this.parse(code);
-        imports = await collectFromAST(ast, code, isRemoteImport);
+        imports = await collectFromAST(ast, code, isFederatedImport);
       } catch {
         // this.parse() delegates to acorn which does not support TypeScript
         // syntax (import type, interfaces, generics, etc.).  Fall back to
         // es-module-lexer so TS/TSX consumer files are still transformed.
-        imports = await collectFromEsLexer(code, isRemoteImport);
+        imports = await collectFromEsLexer(code, isFederatedImport);
       }
 
       if ((!imports || imports.length === 0) && REGEX_FALLBACK_EXTENSIONS_RE.test(id)) {
-        imports = collectFromRegex(code, isRemoteImport);
+        imports = collectFromRegex(code, isFederatedImport);
       }
       if (!imports) return;
       return applyRewrites(code, imports, id);


### PR DESCRIPTION
# Rewrite named imports from shared modules for Rolldown compatibility

Fixes #575

## Summary

- Extend `pluginRemoteNamedExports` to rewrite named imports from shared dependencies, not just remote modules
- Shared modules use the same `__moduleExports` virtual module shape as remotes and need the same import transformation under Rolldown
- Add 11 new test cases covering shared module import rewriting

## Problem

Vite 8 uses Rolldown, which does not support Rollup's `syntheticNamedExports` module metadata. The plugin generates `__loadShare__` virtual modules for shared dependencies that only export `default` and `__moduleExports`. Under Rollup, `syntheticNamedExports: "__moduleExports"` allowed named imports to resolve dynamically. Under Rolldown, this fails with `MISSING_EXPORT` errors for every named import from a shared dependency:

```
[MISSING_EXPORT] Error: "useState" is not exported by
  "node_modules/__mf__virtual/host__loadShare__react__loadShare__.mjs"
```

The existing `pluginRemoteNamedExports` already handles this for remote modules but not for shared modules, which have the exact same problem.

Reproduction: https://github.com/falldowngoboone/mf-shared-module-imports-bug

## Solution

Extended `pluginRemoteNamedExports` to handle both remote and shared module imports:

1. Added `sharedNames` derived from `options.shared` alongside the existing `remoteNames`
2. Combined both into `federatedNames` for early bail-out checks
3. Renamed `isRemoteImport` to `isFederatedImport`, which now matches:
   - Remote package names (with subpath support, e.g. `remoteApp/utils`)
   - Shared package names by **exact match only** (e.g. `react` matches, `@mui/material/IconButton` does not -- deep imports resolve to the actual npm package, not a `__loadShare__` virtual module)
   - `__loadRemote__` and `__loadShare__` tagged imports
4. The same rewriting transformation is applied to both remote and shared imports:

```js
// Input
import { useState } from "react";

// Output
import { __moduleExports as __mf_ns_0 } from "react";
const { useState } = __mf_ns_0;
```

## Test plan

All 206 existing tests continue to pass. Added 11 new test cases in the `shared module imports` suite:

- Rewrites named import from a shared package (`react`)
- Rewrites named import from a scoped shared package (`@acme/ui`)
- Does not rewrite deep imports of shared packages (`@mui/material/IconButton`)
- Rewrites shared package with explicit subpath entry (`@mui/x-date-pickers-pro/AdapterLuxon`)
- Rewrites multiple named imports from a shared package
- Skips default-only import from a shared package
- Rewrites default + named import from a shared package
- Wraps dynamic import of a shared package
- Rewrites re-export from a shared package
- Handles mixed remote and shared imports in one file
- Still works when only shared packages are configured (no remotes)
