### PR TITLE
fix(manifest): correctly preserve publicPath setting

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -190,4 +190,52 @@ describe('pluginMFManifest', () => {
     expect(manifest).not.toHaveProperty('exposes');
     expect(stats).not.toHaveProperty('assetAnalysis');
   });
+
+  it('preserves publicPath "auto" in manifest metaData', async () => {
+    getNormalizeModuleFederationOptions.mockReturnValue({
+      name: 'basicRemote',
+      filename: 'remoteEntry.js',
+      getPublicPath: undefined,
+      varFilename: undefined,
+      manifest: true,
+      exposes: {},
+      remotes: {},
+      shared: {},
+      publicPath: 'auto',
+      bundleAllCSS: false,
+      shareStrategy: 'version-first',
+      implementation: 'module-federation-runtime',
+      runtimePlugins: [],
+      virtualModuleDir: '__mf__virtual',
+      hostInitInjectLocation: 'html',
+      moduleParseTimeout: 10,
+      ignoreOrigin: false,
+    } as any);
+    getUsedRemotesMap.mockReturnValue(new Map());
+    getUsedShares.mockReturnValue(new Set());
+
+    const [, buildPlugin] = manifestPlugin();
+    const emitted: Record<string, string> = {};
+
+    buildPlugin.config?.({}, { command: 'build', mode: 'test' });
+    buildPlugin.configResolved?.({
+      root: '/',
+      base: '/',
+      build: {},
+      server: { origin: 'http://localhost' },
+    } as any);
+
+    const ctx = {
+      emitFile: vi.fn((asset: { fileName: string; source: string }) => {
+        emitted[asset.fileName] = asset.source;
+        return `id:${asset.fileName}`;
+      }),
+      resolve: vi.fn(async () => ({ id: '/node_modules/react/index.js' })),
+    };
+
+    await buildPlugin.generateBundle?.call(ctx as any, {}, makeBundle() as any);
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    expect(manifest.metaData.publicPath).toBe('auto');
+  });
 });

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -169,7 +169,14 @@ const Manifest = (): Plugin[] => {
         if (_command === 'serve') {
           base = (config.server.origin || '') + config.base;
         }
-        publicPath = resolvePublicPath(mfOptions, base, _originalConfigBase);
+        // resolvePublicPath treats "auto" as unset to avoid broken concatenation
+        // in dev code generation (e.g. "auto" + "remoteEntry.js" → "autoremoteEntry.js").
+        // For the manifest, "auto" is a valid sentinel the MF runtime understands,
+        // so we preserve it here before falling back to the resolver.
+        publicPath =
+          mfOptions.publicPath === 'auto'
+            ? 'auto'
+            : resolvePublicPath(mfOptions, base, _originalConfigBase);
       },
       /**
        * Generates the module federation manifest file


### PR DESCRIPTION
### Description

#562 correctly solved the issue of looking at the wrong server for `manifest` files etc. however, manifests were then incorrectly set. Instead we can still preserve the magic string `auto` since the runtime still understands this string & can use it accordingly to then get the remote from the server _after_ fetching it's manifest.
