### PR TITLE
fix: use static imports in dev HTML proxy to preserve script execution order

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -146,7 +146,7 @@ describe('pluginAddEntry', () => {
     expect(result).not.toContain('<script type="module">');
   });
 
-  it('keeps base on host init when rewriting external dev html entry scripts', () => {
+  it('rewrites entry scripts and resolves proxy imports with non-root base (#590)', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-html-base-'));
     fs.writeFileSync(path.join(tempDir, 'index.html'), '<html></html>');
 
@@ -174,16 +174,28 @@ describe('pluginAddEntry', () => {
       build: { rollupOptions: {} },
     } as any);
 
+    // User's HTML with a non-root base — entry src may or may not include base
     const hook = servePlugin.transformIndexHtml;
     const handler = typeof hook === 'object' ? hook.handler : hook;
     const result = handler?.(
       '<html><head><script type="module" src="/foo/@vite/client"></script></head><body><script type="module" src="/foo/src/main.tsx"></script></body></html>'
-    );
+    ) as string;
 
+    // Vite client must not be rewritten
     expect(result).toContain('src="/foo/@vite/client"');
+    // Entry script must be rewritten to use the proxy module
     expect(result).toContain('src="/@id/virtual:mf-html-entry-proxy?');
-    expect(result).toContain('init=%2Ffoo%2F%40id%2Fvirtual%3Amf-host-init');
-    expect(result).toContain('entry=%2Ffoo%2Fsrc%2Fmain.tsx');
-    expect(result).not.toContain('src="/foo/@id/virtual:mf-html-entry-proxy?');
+
+    // Extract the proxy module ID from the rewritten HTML and load it
+    const proxyIdMatch = result.match(/src="\/@id\/(virtual:mf-html-entry-proxy\?[^"]+)"/);
+    expect(proxyIdMatch).not.toBeNull();
+    const proxyId = decodeURIComponent(proxyIdMatch![1]).replace(/&amp;/g, '&');
+    const code = servePlugin.load?.(proxyId) as string;
+
+    // The proxy module must import both init and entry as resolvable paths
+    // (no base prefix — Vite's server-side resolver handles base itself)
+    expect(code).toContain('import "/@id/virtual:mf-host-init"');
+    expect(code).toContain('import "/src/main.tsx"');
+    expect(code).not.toContain('/foo/');
   });
 });

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -93,16 +93,19 @@ const addEntry = ({
         handler(c) {
           if (!injectHtml()) return;
           clientInjected = true;
-          // Strip base from paths — devHtmlHook runs after pre hooks and
-          // prepends the base to all script src attributes automatically.
+          // Normalize all paths to root-relative (without base) before storing
+          // in query params. devHtmlHook runs after pre hooks and prepends base
+          // to script src attributes automatically, and Vite's server-side import
+          // resolver also handles base — so query params must be base-free.
+          // Note: originalSrc may or may not include the base depending on the
+          // user's HTML (#590), so we normalize both directions uniformly.
           const base = viteConfig.base.replace(/\/$/, '');
-          const stripBase = (p: string) => (base && p.startsWith(base) ? p.slice(base.length) : p);
-          const applyBase = (p: string) =>
-            p.startsWith('/') && base && !p.startsWith(base + '/') ? `${base}${p}` : p;
+          const stripBase = (p: string) =>
+            base && p.startsWith(base + '/') ? p.slice(base.length) : p;
           const html = rewriteEntryScripts(c, (originalSrc) => {
             const query = new URLSearchParams({
-              init: sanitizeDevEntryPath(devEntryPath),
-              entry: sanitizeDevEntryPath(applyBase(originalSrc)),
+              init: sanitizeDevEntryPath(stripBase(devEntryPath)),
+              entry: sanitizeDevEntryPath(stripBase(originalSrc)),
             }).toString();
             return `/@id/${DEV_HTML_PROXY_PREFIX}${query}`;
           });
@@ -120,11 +123,14 @@ const addEntry = ({
         const initSrc = params.get('init');
         const entrySrc = params.get('entry');
         if (!initSrc || !entrySrc) return;
-        return `
-const baseUrl = document.baseURI || window.location.href;
-await import(new URL(${JSON.stringify(initSrc)}, baseUrl).href);
-await import(new URL(${JSON.stringify(entrySrc)}, baseUrl).href);
-`;
+        // Use static imports (not dynamic `await import()`) so that init and
+        // entry become part of the browser's static module dependency graph.
+        // This guarantees:
+        //   1. init executes fully (including TLA) before entry starts (#396)
+        //   2. the browser waits for the entire import tree before firing the
+        //      `load` event, preserving standard script execution order (#571)
+        //   3. no inline script content in the HTML, keeping CSP intact (#528)
+        return `import ${JSON.stringify(initSrc)};\nimport ${JSON.stringify(entrySrc)};\n`;
       },
       transform(code, id) {
         if (id.includes('node_modules') || inject !== 'html' || htmlFilePath) {


### PR DESCRIPTION
Close #598 

## Summary

- Fixes #598 — external module scripts execute after `load` event in dev mode
- Replaces dynamic `await import()` with static `import` in the virtual proxy module
- Normalizes query param paths to be base-free, removing the `applyBase`/`strip` roundtrip

## Test plan

- [x] Existing tests pass (208)
- [x] Verified with [reproduction repo](https://github.com/arshabh-agarwal/mf-vite-571-repro) — both `pnpm dev` and `pnpm dev:basepath`
- [x] Updated test for non-root base (#590) to exercise full flow (HTML rewrite → proxy load)