### PR TITLE
fix: support shared package subpaths for Lit in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ export default defineConfig({
 
 In this remote app configuration, we define a remoteEntry.js file that will expose the App component.
 The shared property ensures that both host and remote applications use the same vue library.
+Package shares also apply to their package subpaths, so sharing `lit` covers imports like
+`lit/directives/class-map.js`.
 
 ## The Host Application configuration
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ export default defineConfig({
 
 In this remote app configuration, we define a remoteEntry.js file that will expose the App component.
 The shared property ensures that both host and remote applications use the same vue library.
-Package shares also apply to their package subpaths, so sharing `lit` covers imports like
-`lit/directives/class-map.js`.
 
 ## The Host Application configuration
 

--- a/examples/vite-webpack-rspack/remote/vite.config.js
+++ b/examples/vite-webpack-rspack/remote/vite.config.js
@@ -22,6 +22,11 @@ export default defineConfig({
   server: {
     port: 4001,
   },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+  },
   build: {
     modulePreload: false,
     target: "esnext",

--- a/integration/esm-virtual-modules.test.ts
+++ b/integration/esm-virtual-modules.test.ts
@@ -45,8 +45,7 @@ describe('ESM virtual modules', () => {
       viteConfig: { resolve: { preserveSymlinks: true } },
     });
     const allCode = getAllChunkCode(output);
-    // The CJS dep is replaced by a loadShare shim — verify the build succeeded
-    // and the shared module was properly resolved via the runtime
-    expect(allCode).toContain('loadShare("cjs-dep"');
+    // Shared package subpaths should also proxy through the runtime shim.
+    expect(allCode).toContain('loadShare("cjs-dep/client"');
   });
 });

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -32,8 +32,8 @@ vi.mock('../../utils/VirtualModule', () => ({
   }),
 }));
 
-import { proxySharedModule } from '../pluginProxySharedModule_preBuild';
 import { NormalizedShared } from '../../utils/normalizeModuleFederationOptions';
+import { proxySharedModule } from '../pluginProxySharedModule_preBuild';
 
 const preBuildShareItemMap = new Map<string, NormalizedShared[string]>();
 const addUsedSharesCalls: string[] = [];
@@ -295,6 +295,72 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(resolution).toEqual({ id: '/resolved//mock/path.js' });
     expect(preBuildShareItemMap.get('transitive/runtime.js')).toBe(shared.transitive);
     expect(addUsedSharesCalls).toContain('transitive/runtime.js');
+  });
+
+  it('does not proxy imports made from inside a local shared provider package', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const shared: NormalizedShared = {
+      lit: {
+        name: 'lit',
+        from: '',
+        version: '3.3.2',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '*',
+          strictVersion: false,
+        },
+      },
+      'lit-html': {
+        name: 'lit-html',
+        from: '',
+        version: '3.3.2',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^3.3.2',
+          strictVersion: false,
+        },
+      },
+    };
+
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = plugins[1];
+    const config = {
+      resolve: {
+        alias: [] as Array<{
+          find: RegExp;
+          customResolver?: (source: string, importer: string) => unknown;
+        }>,
+      },
+    };
+
+    proxyPlugin.config?.call(
+      {
+        meta: {},
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      config as any,
+      {
+        command: 'build',
+        mode: 'production',
+      }
+    );
+
+    const alias = config.resolve.alias.find((entry) => entry.find.test('lit-html'));
+    expect(alias?.customResolver).toBeTypeOf('function');
+
+    const resolution = await alias?.customResolver?.call(
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      'lit-html',
+      '/repo/apps/remote/node_modules/lit/index.js'
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(addUsedSharesCalls).not.toContain('lit-html');
   });
 
   it('resolves prebuild aliases to configured share import sources in build mode', async () => {

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../utils/packageUtils', () => ({
   setPackageDetectionCwd: vi.fn(),
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
   getIsRolldown: () => false,
+  removePathFromNpmPackage: (value: string) =>
+    value.startsWith('@') ? value.split('/').slice(0, 2).join('/') : value.split('/')[0],
 }));
 
 vi.mock('../../utils/VirtualModule', () => ({
@@ -34,6 +36,7 @@ import { proxySharedModule } from '../pluginProxySharedModule_preBuild';
 import { NormalizedShared } from '../../utils/normalizeModuleFederationOptions';
 
 const preBuildShareItemMap = new Map<string, NormalizedShared[string]>();
+const addUsedSharesCalls: string[] = [];
 
 vi.mock('../../virtualModules', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../virtualModules')>();
@@ -41,6 +44,9 @@ vi.mock('../../virtualModules', async (importOriginal) => {
     ...actual,
     writePreBuildLibPath: (pkg: string, shareItem?: NormalizedShared[string]) => {
       preBuildShareItemMap.set(pkg, shareItem);
+    },
+    addUsedShares: (pkg: string) => {
+      addUsedSharesCalls.push(pkg);
     },
     writeLocalSharedImportMap: vi.fn(),
     getPreBuildShareItem: (pkg: string) => preBuildShareItemMap.get(pkg),
@@ -107,6 +113,7 @@ describe('pluginProxySharedModule_preBuild', () => {
   beforeEach(() => {
     hasPackageDependencyMock.mockReset();
     preBuildShareItemMap.clear();
+    addUsedSharesCalls.length = 0;
   });
 
   for (const testCase of [
@@ -245,6 +252,49 @@ describe('pluginProxySharedModule_preBuild', () => {
     // Normal deps should still have prebuild entries
     expect(preBuildShareItemMap.has('react')).toBe(true);
     expect(preBuildShareItemMap.has('vue')).toBe(true);
+  });
+
+  it('proxies package subpath imports through the base shared config', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const shared = makeShared();
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = plugins[1];
+    const config = {
+      resolve: {
+        alias: [] as Array<{
+          find: RegExp;
+          customResolver?: (source: string, importer: string) => unknown;
+        }>,
+      },
+    };
+
+    proxyPlugin.config?.call(
+      {
+        meta: {},
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      config as any,
+      {
+        command: 'serve',
+        mode: 'development',
+      }
+    );
+
+    const alias = config.resolve.alias.find((entry) => entry.find.test('transitive/runtime.js'));
+    expect(alias?.customResolver).toBeTypeOf('function');
+
+    const resolution = await alias?.customResolver?.call(
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      'transitive/runtime.js',
+      '/src/main.ts'
+    );
+
+    expect(resolution).toEqual({ id: '/resolved//mock/path.js' });
+    expect(preBuildShareItemMap.get('transitive/runtime.js')).toBe(shared.transitive);
+    expect(addUsedSharesCalls).toContain('transitive/runtime.js');
   });
 
   it('resolves prebuild aliases to configured share import sources in build mode', async () => {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,7 +1,12 @@
 import { Plugin, ResolvedConfig, UserConfig } from 'vite';
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 import { NormalizedShared, ShareItem } from '../utils/normalizeModuleFederationOptions';
-import { getIsRolldown, hasPackageDependency, setPackageDetectionCwd } from '../utils/packageUtils';
+import {
+  getIsRolldown,
+  hasPackageDependency,
+  removePathFromNpmPackage,
+  setPackageDetectionCwd,
+} from '../utils/packageUtils';
 import { PromiseStore } from '../utils/PromiseStore';
 import VirtualModule, { assertModuleFound } from '../utils/VirtualModule';
 import {
@@ -67,11 +72,15 @@ export function proxySharedModule(options: {
             .filter((key) => !(useDirectReactImport && key === 'react'))
             .map((key) => {
               const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
+              const matchesPackageSubpaths =
+                key.endsWith('/') || removePathFromNpmPackage(keyBase) === keyBase;
               const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const escapedKeyBase = escapeRegex(keyBase);
-              // Trailing-slash keys act as package-prefix shares:
-              // "react/" should match both "react" and "react/*".
-              const pattern = key.endsWith('/')
+              // Bare package shares (e.g. "lit") and trailing-slash shares
+              // (e.g. "lit/") should also catch package subpaths like
+              // "lit/directives/class-map.js" so they can register a runtime
+              // share entry instead of being bundled locally.
+              const pattern = matchesPackageSubpaths
                 ? `^(${escapedKeyBase}(?:\\/.*)?)$`
                 : `^(${escapedKeyBase})$`;
               return {
@@ -80,27 +89,18 @@ export function proxySharedModule(options: {
                 replacement: '$1',
                 customResolver(source: string, importer: string) {
                   if (/\.css$/.test(source)) return;
-                  // Hard-stop proxying bare React in dev. Vite's RSC pipeline
-                  // expects the native server React entry, and wrapping `react`
-                  // through loadShare breaks react-server-dom-webpack.
+                  // Hard-stop proxying React package entries in dev. Vite's RSC
+                  // pipeline expects the native server React entry family, and
+                  // wrapping them through loadShare breaks react-server-dom-webpack.
                   // We still register React in the federation share scope via
                   // localSharedImportMap, so shared metadata remains available.
-                  if (useDirectReactImport && source === 'react') {
+                  if (useDirectReactImport && (source === 'react' || source.startsWith('react/'))) {
                     return;
                   }
                   // Skip for localSharedImportMap to break circular TLA deadlock:
                   // loadShare TLA → runtime.loadShare() → get() → import(prebuild)
                   // → alias to pkg name → shared alias → loadShare (DEADLOCK)
                   if (importer && importer.includes('localSharedImportMap')) {
-                    return;
-                  }
-                  // Trailing-slash keys (e.g. "react/") match subpath imports like
-                  // "react/jsx-dev-runtime". However, the MF runtime's loadShare does
-                  // exact key lookup — subpath shares aren't registered and loadShare
-                  // returns false, causing "factory is not a function". Let subpath
-                  // imports resolve normally; the base package singleton sharing
-                  // already ensures a single instance.
-                  if (key.endsWith('/') && source !== key.slice(0, -1)) {
                     return;
                   }
                   const loadSharePath = getLoadShareModulePath(source, isRolldown, command);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,3 +1,4 @@
+import path from 'pathe';
 import { Plugin, ResolvedConfig, UserConfig } from 'vite';
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 import { NormalizedShared, ShareItem } from '../utils/normalizeModuleFederationOptions';
@@ -11,11 +12,11 @@ import { PromiseStore } from '../utils/PromiseStore';
 import VirtualModule, { assertModuleFound } from '../utils/VirtualModule';
 import {
   addUsedShares,
-  getConcreteSharedImportSource,
   generateLocalSharedImportMap,
-  getPreBuildShareItem,
+  getConcreteSharedImportSource,
   getLoadShareModulePath,
   getLocalSharedImportMapPath,
+  getPreBuildShareItem,
   PREBUILD_TAG,
   writeLoadShareModule,
   writeLocalSharedImportMap,
@@ -37,6 +38,43 @@ export function proxySharedModule(options: {
   let _command = 'serve';
   let useDirectReactImport = false;
   const savePrebuild = new PromiseStore<string>();
+  const sharedProviderPackageNames = new Set<string>();
+  const sharedProviderDirectories = new Set<string>();
+
+  Object.keys(shared).forEach((key) => {
+    if (shared[key].shareConfig.import === false) return;
+    const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
+    const packageName = removePathFromNpmPackage(keyBase);
+    if (packageName === keyBase) {
+      sharedProviderPackageNames.add(packageName);
+    }
+    const concreteImportSource = getConcreteSharedImportSource(key, shared[key]);
+    if (concreteImportSource && !concreteImportSource.startsWith('virtual:')) {
+      sharedProviderDirectories.add(path.dirname(concreteImportSource));
+    }
+  });
+
+  function isInsideLocalSharedProvider(importer?: string) {
+    if (!importer) return false;
+    if (importer.includes('localSharedImportMap')) return true;
+
+    for (const pkgName of sharedProviderPackageNames) {
+      if (
+        importer.includes(`/node_modules/${pkgName}/`) ||
+        importer.endsWith(`/node_modules/${pkgName}`)
+      ) {
+        return true;
+      }
+    }
+
+    for (const providerDir of sharedProviderDirectories) {
+      if (importer === providerDir || importer.startsWith(`${providerDir}/`)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   return [
     {
@@ -90,8 +128,7 @@ export function proxySharedModule(options: {
                 customResolver(source: string, importer: string) {
                   if (/\.css$/.test(source)) return;
                   // Hard-stop proxying React package entries in dev. Vite's RSC
-                  // pipeline expects the native server React entry family, and
-                  // wrapping them through loadShare breaks react-server-dom-webpack.
+                  // pipeline expects native server React entrypoints.
                   // We still register React in the federation share scope via
                   // localSharedImportMap, so shared metadata remains available.
                   if (useDirectReactImport && (source === 'react' || source.startsWith('react/'))) {
@@ -100,7 +137,7 @@ export function proxySharedModule(options: {
                   // Skip for localSharedImportMap to break circular TLA deadlock:
                   // loadShare TLA → runtime.loadShare() → get() → import(prebuild)
                   // → alias to pkg name → shared alias → loadShare (DEADLOCK)
-                  if (importer && importer.includes('localSharedImportMap')) {
+                  if (isInsideLocalSharedProvider(importer)) {
                     return;
                   }
                   const loadSharePath = getLoadShareModulePath(source, isRolldown, command);

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -192,6 +192,24 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('virtual:prebuild:transitive-no-override');
   });
 
+  it('registers package subpaths as their own shared entries in localSharedImportMap', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('lit/directives/class-map.js');
+
+    const code = mod.generateLocalSharedImportMap();
+
+    expect(code).toContain('"lit/directives/class-map.js": async () => {');
+    expect(code).toContain(
+      'let pkg = await import("virtual:prebuild:lit/directives/class-map.js");'
+    );
+    expect(code).toContain('"lit/directives/class-map.js": {');
+    expect(code).toContain('name: "lit/directives/class-map.js"');
+  });
+
   it('writes host auto init waiting on __tla before init', async () => {
     hasPackageDependencyMock.mockImplementation((pkg: string) => {
       return pkg === 'vinext';

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -363,6 +363,55 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('import "mock-import-id";');
   });
 
+  it('loads a subpath wrapper from its own shared runtime key in serve mode', () => {
+    const pkg = 'lit/directives/class-map.js';
+    const mockShareItem: ShareItem = {
+      name: 'lit',
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('runtime.loadShare("lit/directives/class-map.js"');
+    expect(generatedCode).toContain('const exportModule = await (async () => {');
+    expect(generatedCode).toContain('return import("/resolved/lit/directives/class-map.js")');
+  });
+
+  it('emits ESM exports for shared packages in serve mode so named exports survive dev transforms', () => {
+    const pkg = 'lit';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const { initPromise } = globalThis[globalKey];');
+    expect(generatedCode).toContain('const exportModule = await (async () => {');
+    expect(generatedCode).toContain('export default exportModule.default ?? exportModule');
+    expect(generatedCode).toContain('export * from "mock-import-id"');
+    expect(generatedCode).toContain('return import("/resolved/lit")');
+    expect(generatedCode).not.toContain('module.exports = exportModule');
+  });
+
   it('uses SSR provider fallback for react in Astro build output', () => {
     hasPackageDependencyMock.mockImplementation((pkg: string) => pkg === 'astro');
 
@@ -462,8 +511,8 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('export *');
     // Should still call loadShare via the runtime
     expect(generatedCode).toContain('runtime.loadShare');
-    // CJS serve mode uses module.exports
-    expect(generatedCode).toContain('module.exports = exportModule');
+    expect(generatedCode).toContain('export default exportModule.default ?? exportModule');
+    expect(generatedCode).not.toContain('module.exports = exportModule');
   });
 
   it('does not reference prebuild modules when import: false in build mode', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -384,7 +384,7 @@ export const LOAD_SHARE_TAG = '__loadShare__';
 const loadShareCacheMap: Record<string, VirtualModule> = {};
 export function getLoadShareImportId(pkg: string, isRolldown: boolean, command?: string): string {
   if (!loadShareCacheMap[pkg]) {
-    const useESM = isRolldown || command === 'build';
+    const useESM = command === 'serve' || command === 'build' || isRolldown;
     const ext = useESM ? '.mjs' : '.js';
     loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, ext);
   }
@@ -402,12 +402,12 @@ export function writeLoadShareModule(
   isRolldown: boolean
 ) {
   if (!loadShareCacheMap[pkg]) {
-    const useESM = isRolldown || command === 'build';
+    const useESM = command === 'serve' || command === 'build' || isRolldown;
     const ext = useESM ? '.mjs' : '.js';
     loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, ext);
   }
 
-  const useESM = command === 'build' || isRolldown;
+  const useESM = command === 'serve' || command === 'build' || isRolldown;
   const importLine =
     command === 'build'
       ? getRuntimeInitPromiseBootstrapCode()
@@ -474,6 +474,15 @@ export function writeLoadShareModule(
   const isWorkspacePackage =
     isWorkspaceFilePath(localProviderPath) || isWorkspaceFilePath(concreteSharedImportSource);
   const providerImportId = localProviderPath || concreteSharedImportSource || sharedImportSource;
+  const resolveShareExpression =
+    command === 'serve'
+      ? `${awaitOrPlaceholder}(async () => {
+      const factory = await res;
+      if (typeof factory === "function") return factory();
+      if (factory) return factory;
+      return import(${escapeGeneratedStringLiteral(providerImportId)});
+    })()`
+      : `${awaitOrPlaceholder}res.then((factory) => (typeof factory === "function" ? factory() : factory))`;
   const namedExports = getPackageNamedExports(pkg);
   let exportLine: string;
   if (namedExports.length > 0) {
@@ -521,8 +530,8 @@ export function writeLoadShareModule(
       useSsrProviderFallback
         ? `(typeof window === "undefined"
       ? ((await providerModulePromise)?.default ?? await providerModulePromise)
-      : ${awaitOrPlaceholder}res.then((factory) => (typeof factory === "function" ? factory() : factory)))`
-        : `${awaitOrPlaceholder}res.then((factory) => (typeof factory === "function" ? factory() : factory))`
+      : ${resolveShareExpression})`
+        : `${resolveShareExpression}`
     }
     ${exportLine}
   `,


### PR DESCRIPTION
## What changed

- match bare shared package keys against package subpaths during proxying, so sharing `lit` also covers `lit/*`
- register shared subpaths as their own runtime entries in `localSharedImportMap`
- make serve-mode `__loadShare__` wrappers await the resolved shared module before destructuring named exports
- document subpath share behavior and add regression coverage around the Lit repro

## Why

The Lit repro in module-federation/vite#606 was still failing in dev with `property is not a function` because subpath imports like `lit/decorators.js` and `lit/directives/class-map.js` were bypassing federation or being exported from a pending Promise. That left host and remote with mismatched Lit module instances and broken named exports on cold start.

## Impact

- shared bare packages now cover their package subpaths in dev/build proxying
- Lit host/remote repro renders on exact `pnpm lit:dev` cold start
- named exports from shared ESM packages survive serve-mode wrappers

## Root cause

Two bugs stacked:

1. package subpaths were not consistently proxied/registered under the runtime share map
2. serve-mode shared wrappers destructured `exportModule` before awaiting the async share resolution, so bindings like `LitElement` and `property` could become `undefined`

## Validation

- `pnpm test`
- `pnpm fmt.check`
- exact repro smoke in `module-federation-vite-examples` with `pnpm lit:dev`
