### PR TITLE
fix: fix automatic sharing for export subpaths

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -89,6 +89,24 @@ function getEarlyInitPlugin(): Plugin {
   return plugin;
 }
 
+function getEarlyInitPluginWithLitShare(): Plugin {
+  const plugin = federation({
+    name: 'host',
+    filename: 'remoteEntry.js',
+    shared: {
+      lit: {
+        singleton: true,
+      },
+      'lit/directives/class-map.js': {
+        singleton: true,
+      },
+    },
+  }).find((entry) => entry.name === 'vite:module-federation-early-init');
+
+  if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+  return plugin;
+}
+
 function getModuleFederationVitePlugin(): Plugin {
   const plugin = federation({
     name: 'host',
@@ -251,6 +269,34 @@ describe('vite:module-federation-early-init', () => {
 
     expect(config.optimizeDeps.include).toContain(getPreBuildLibImportId('vue'));
     expect(config.optimizeDeps.include).toContain(getLoadShareImportId('vue', false, 'serve'));
+  });
+
+  it('excludes lit shared ids from optimizeDeps in serve', () => {
+    const plugin = getEarlyInitPluginWithLitShare();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+        exclude: [],
+      },
+    };
+
+    const configHook = typeof plugin.config === 'function' ? plugin.config : plugin.config?.handler;
+    configHook?.call({ meta: {} } as any, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps.exclude).toContain('lit');
+    expect(config.optimizeDeps.exclude).toContain('lit/directives/class-map.js');
+    expect(config.optimizeDeps.include).toContain(getPreBuildLibImportId('lit'));
+    expect(config.optimizeDeps.include).toContain(
+      getPreBuildLibImportId('lit/directives/class-map.js')
+    );
+    expect(config.optimizeDeps.include).not.toContain(getLoadShareImportId('lit', false, 'serve'));
+    expect(config.optimizeDeps.include).not.toContain(
+      getLoadShareImportId('lit/directives/class-map.js', false, 'serve')
+    );
   });
 
   it('excludes bare remote ids from optimizeDeps in Rolldown serve', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ function insertAfterLastTopLevelImport(code: string, snippet: string): string | 
  */
 function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOptions): Plugin {
   const { shared, remotes, virtualModuleDir } = options;
+  const isLitShare = (pkg: string) => pkg === 'lit' || pkg.startsWith('lit/');
 
   return {
     name: 'vite:module-federation-early-init',
@@ -199,16 +200,23 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
           }
           addUsedShares(key);
           if (_command === 'serve' && shareItem.shareConfig?.import !== false) {
-            if (!isRolldown) {
+            const optimizeDeps = (config.optimizeDeps ??= {});
+            optimizeDeps.include ??= [];
+            optimizeDeps.exclude ??= [];
+            const shouldBypassOptimizeDep = isLitShare(key);
+            if (shouldBypassOptimizeDep) {
+              optimizeDeps.exclude.push(key);
+            }
+            if (!isRolldown && !shouldBypassOptimizeDep) {
               // In non-Rolldown Vite (< 8), loadShare modules are CJS and
               // don't use real TLA, so the dep optimizer handles them fine.
-              config.optimizeDeps.include!.push(getLoadShareImportId(key, isRolldown, _command));
+              optimizeDeps.include.push(getLoadShareImportId(key, isRolldown, _command));
             }
             // When isRolldown (Vite 8+), loadShare modules are ESM with
             // top-level await. Including them in optimizeDeps causes the dep
             // optimizer to convert ESM→CJS, stripping `await` and turning
             // shared modules into unresolved Promises (breaks Pinia plugins, etc).
-            config.optimizeDeps.include!.push(getPreBuildLibImportId(key));
+            optimizeDeps.include.push(getPreBuildLibImportId(key));
           }
         }
         writeLocalSharedImportMap();

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -26,7 +26,7 @@ import * as fs from 'fs';
 import { createRequire } from 'node:module';
 import * as path from 'pathe';
 import { createModuleFederationError, mfError } from './logger';
-import { removePathFromNpmPackage } from './packageUtils';
+import { getInstalledPackageJson, removePathFromNpmPackage } from './packageUtils';
 
 interface ExposesItem {
   import: string;
@@ -166,6 +166,18 @@ function inferVersionFromRequiredVersion(requiredVersion?: string): string | und
   return match?.[0];
 }
 
+function getLitExportSubpathShares(sharedName: string): string[] {
+  if (sharedName !== 'lit') return [];
+
+  const installedPackageJson = getInstalledPackageJson(sharedName, { packageName: sharedName });
+  const exportsField = installedPackageJson?.packageJson.exports;
+  if (!exportsField || typeof exportsField === 'string') return [];
+
+  return Object.keys(exportsField as Record<string, unknown>)
+    .filter((key) => key.startsWith('./') && key !== '.' && !key.includes('*'))
+    .map((key) => `${sharedName}/${key.slice(2)}`);
+}
+
 function normalizeShareItem(
   key: string,
   shareItem:
@@ -256,17 +268,26 @@ function normalizeShared(
 ): NormalizedShared {
   if (!shared) return {};
   const result: NormalizedShared = {};
+  const sourceEntries: Array<[string, string | Record<string, any>]> = [];
   if (Array.isArray(shared)) {
     shared.forEach((key) => {
       result[key] = normalizeShareItem(key, key);
+      sourceEntries.push([key, key]);
     });
-    return result;
-  }
-  if (typeof shared === 'object') {
+  } else if (typeof shared === 'object') {
     Object.keys(shared).forEach((key) => {
-      result[key] = normalizeShareItem(key, shared[key] as any);
+      const value = shared[key] as any;
+      result[key] = normalizeShareItem(key, value);
+      sourceEntries.push([key, value]);
     });
   }
+
+  sourceEntries.forEach(([key, value]) => {
+    for (const subpathShare of getLitExportSubpathShares(key)) {
+      if (result[subpathShare]) continue;
+      result[subpathShare] = normalizeShareItem(subpathShare, value as any);
+    }
+  });
 
   return result;
 }

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import { createRequire } from 'module';
 import path from 'pathe';
 import { createModuleFederationError } from './logger';
 
@@ -23,6 +24,12 @@ export function setPackageDetectionCwd(cwd: string) {
 export function getPackageDetectionCwd() {
   return packageDetectionCwd || process.cwd();
 }
+
+export type InstalledPackageJson = {
+  path: string;
+  dir: string;
+  packageJson: Record<string, unknown>;
+};
 /**
  * Escaping rules:
  * Convert using the format __${mapping}__, where _ and $ are not allowed in npm package names but can be used in variable names.
@@ -73,6 +80,74 @@ export function removePathFromNpmPackage(packageString: string): string {
   const regex = /^(?:@[^/]+\/)?[^/]+/;
   const match = packageString.match(regex);
   return match ? match[0] : packageString;
+}
+
+export function getInstalledPackageJson(
+  pkg: string,
+  opts?: { cwd?: string; packageName?: string }
+): InstalledPackageJson | undefined {
+  const cwd = opts?.cwd || getPackageDetectionCwd();
+  const packageName = opts?.packageName || removePathFromNpmPackage(pkg);
+
+  try {
+    const projectRequire = createRequire(new URL(`file://${path.join(cwd, 'package.json')}`));
+    let resolvedPath: string | undefined;
+
+    try {
+      resolvedPath = projectRequire.resolve(pkg);
+    } catch {
+      resolvedPath = projectRequire.resolve(packageName);
+    }
+
+    let currentDir = path.dirname(resolvedPath);
+    const rootDir = path.parse(currentDir).root;
+
+    while (true) {
+      const packageJsonPath = path.join(currentDir, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
+        try {
+          const packageJson = JSON.parse(packageJsonContent) as Record<string, unknown>;
+          if (packageJson.name === packageName) {
+            return {
+              path: packageJsonPath,
+              dir: currentDir,
+              packageJson,
+            };
+          }
+        } catch (error) {
+          if (!(error instanceof SyntaxError)) throw error;
+        }
+      }
+      if (currentDir === rootDir) break;
+      currentDir = path.dirname(currentDir);
+    }
+  } catch {
+    let currentDir = cwd;
+    const rootDir = path.parse(currentDir).root;
+
+    while (true) {
+      const packageJsonPath = path.join(currentDir, 'node_modules', packageName, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        try {
+          return {
+            path: packageJsonPath,
+            dir: path.dirname(packageJsonPath),
+            packageJson: JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as Record<
+              string,
+              unknown
+            >,
+          };
+        } catch {
+          return undefined;
+        }
+      }
+      if (currentDir === rootDir) break;
+      currentDir = path.dirname(currentDir);
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -35,6 +35,12 @@ vi.mock('../../utils/VirtualModule', () => {
 vi.mock('fs', () => ({
   existsSync: vi.fn(
     (filePath: string) =>
+      filePath.endsWith('node_modules/lit/package.json') ||
+      filePath.endsWith('/lit/package.json') ||
+      filePath.endsWith('node_modules/lit/index.js') ||
+      filePath.endsWith('/lit/index.js') ||
+      filePath.endsWith('node_modules/lit/directives/class-map.js') ||
+      filePath.endsWith('/lit/directives/class-map.js') ||
       filePath.endsWith('node_modules/mock-package-esm-only/package.json') ||
       filePath.endsWith('/mock-package-esm-only/package.json') ||
       filePath.endsWith('node_modules/mock-package-typeonly/package.json') ||
@@ -47,6 +53,27 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-generator-export/package.json')
   ),
   readFileSync: vi.fn((filePath: string) => {
+    if (
+      filePath.endsWith('node_modules/lit/package.json') ||
+      filePath.endsWith('/lit/package.json')
+    ) {
+      return JSON.stringify({
+        name: 'lit',
+        exports: {
+          '.': './index.js',
+          './directives/class-map.js': './directives/class-map.js',
+        },
+      });
+    }
+    if (filePath.endsWith('node_modules/lit/index.js') || filePath.endsWith('/lit/index.js')) {
+      return 'export const useCounter = () => 1; export function useLogger() {}';
+    }
+    if (
+      filePath.endsWith('node_modules/lit/directives/class-map.js') ||
+      filePath.endsWith('/lit/directives/class-map.js')
+    ) {
+      return 'export const useCounter = () => 1; export function useLogger() {}';
+    }
     if (
       filePath.endsWith('node_modules/mock-package-esm-only/package.json') ||
       filePath.endsWith('/mock-package-esm-only/package.json')
@@ -190,6 +217,11 @@ vi.mock('module', async (importOriginal) => {
           (error as Error & { code?: string }).code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
           throw error;
         }
+        if (pkg === 'lit' || pkg.startsWith('lit/')) {
+          const error = new Error('ERR_REQUIRE_ESM');
+          (error as Error & { code?: string }).code = 'ERR_REQUIRE_ESM';
+          throw error;
+        }
         if (pkg === 'mock-package-typeonly' || pkg.startsWith('mock-package-typeonly/')) {
           const error = new Error('ERR_REQUIRE_ESM');
           (error as Error & { code?: string }).code = 'ERR_REQUIRE_ESM';
@@ -225,6 +257,12 @@ vi.mock('module', async (importOriginal) => {
         }
         if (pkg === 'mock-package-esm-only/stores' || pkg === 'mock-package-esm-only') {
           return '/repo/apps/remote/node_modules/mock-package-esm-only/dist/stores.js';
+        }
+        if (pkg === 'lit') {
+          return '/repo/apps/remote/node_modules/lit/index.js';
+        }
+        if (pkg === 'lit/directives/class-map.js') {
+          return '/repo/apps/remote/node_modules/lit/directives/class-map.js';
         }
         if (pkg === 'mock-package-typeonly' || pkg.startsWith('mock-package-typeonly/')) {
           return '/repo/apps/remote/node_modules/mock-package-typeonly/src/index.jsx';
@@ -721,5 +759,57 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).not.toContain('import "/repo/packages/pkg-b/dist/index.js";');
     expect(generatedCode).not.toContain('import("transitive-pkg")');
+  });
+
+  it('generates ESM loadShare wrappers for lit subpath shares in serve mode', () => {
+    const pkg = 'lit/directives/class-map.js';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const { initPromise } = globalThis[globalKey];');
+    expect(generatedCode).toContain('export default exportModule.default ?? exportModule;');
+    expect(generatedCode).toContain('export { __mf_0 as useCounter, __mf_1 as useLogger };');
+    expect(generatedCode).not.toContain('__prebuild__');
+    expect(generatedCode).not.toContain('import("lit/directives/class-map.js")');
+    expect(generatedCode).not.toContain('const {initPromise} = require(');
+  });
+
+  it('generates ESM loadShare wrappers for lit root share in serve mode', () => {
+    const pkg = 'lit';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const { initPromise } = globalThis[globalKey];');
+    expect(generatedCode).toContain('export default exportModule.default ?? exportModule;');
+    expect(generatedCode).toContain('export { __mf_0 as useCounter, __mf_1 as useLogger };');
+    expect(generatedCode).not.toContain('__prebuild__');
+    expect(generatedCode).not.toContain('import("lit")');
+    expect(generatedCode).not.toContain('const {initPromise} = require(');
   });
 });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -16,6 +16,7 @@ import { mfWarn } from '../utils/logger';
 import { ShareItem } from '../utils/normalizeModuleFederationOptions';
 import {
   getPackageDetectionCwd,
+  getInstalledPackageJson,
   hasPackageDependency,
   removePathFromNpmPackage,
 } from '../utils/packageUtils';
@@ -68,65 +69,6 @@ function resolvePackageEntryFromProjectRoot(pkg: string): string | undefined {
   }
 }
 
-function getInstalledPackageJsonPath(pkg: string): string | undefined {
-  try {
-    const packageName = removePathFromNpmPackage(pkg);
-    const projectRequire = createRequire(
-      new URL(`file://${path.join(getPackageDetectionCwd(), 'package.json')}`)
-    );
-    let resolvedPath: string | undefined;
-
-    try {
-      resolvedPath = projectRequire.resolve(pkg);
-    } catch {
-      resolvedPath = projectRequire.resolve(packageName);
-    }
-
-    let currentDir = path.dirname(resolvedPath);
-    const rootDir = path.parse(currentDir).root;
-
-    while (currentDir !== rootDir) {
-      const packageJsonPath = path.join(currentDir, 'package.json');
-      if (existsSync(packageJsonPath)) {
-        const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
-        try {
-          const packageJson = JSON.parse(packageJsonContent) as { name?: string };
-          if (packageJson.name === packageName) return packageJsonPath;
-        } catch (error) {
-          // Skip malformed package.json and continue searching up the tree
-          if (!(error instanceof SyntaxError)) throw error;
-        }
-      }
-      currentDir = path.dirname(currentDir);
-    }
-
-    const rootPackageJsonPath = path.join(rootDir, 'package.json');
-    if (existsSync(rootPackageJsonPath)) {
-      const rootPackageJsonContent = readFileSync(rootPackageJsonPath, 'utf-8');
-      try {
-        const packageJson = JSON.parse(rootPackageJsonContent) as { name?: string };
-        if (packageJson.name === packageName) return rootPackageJsonPath;
-      } catch (error) {
-        // Skip malformed root package.json
-        if (!(error instanceof SyntaxError)) throw error;
-      }
-    }
-  } catch {
-    const packageName = removePathFromNpmPackage(pkg);
-    let currentDir = getPackageDetectionCwd();
-    const rootDir = path.parse(currentDir).root;
-
-    while (currentDir !== rootDir) {
-      const packageJsonPath = path.join(currentDir, 'node_modules', packageName, 'package.json');
-      if (existsSync(packageJsonPath)) return packageJsonPath;
-      currentDir = path.dirname(currentDir);
-    }
-
-    const rootPackageJsonPath = path.join(rootDir, 'node_modules', packageName, 'package.json');
-    return existsSync(rootPackageJsonPath) ? rootPackageJsonPath : undefined;
-  }
-}
-
 function resolveImportTarget(exportsField: unknown): string | undefined {
   if (typeof exportsField === 'string') return exportsField;
   if (!exportsField || typeof exportsField !== 'object') return undefined;
@@ -149,11 +91,11 @@ function resolveImportTarget(exportsField: unknown): string | undefined {
 function getPackageEsmEntryPath(pkg: string): string | undefined {
   try {
     const resolvedEntryPath = resolvePackageEntryFromProjectRoot(pkg);
-    const packageJsonPath = getInstalledPackageJsonPath(pkg);
-    if (!packageJsonPath) return resolvedEntryPath;
+    const installedPackageJson = getInstalledPackageJson(pkg);
+    if (!installedPackageJson) return resolvedEntryPath;
 
     const packageName = removePathFromNpmPackage(pkg);
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    const packageJson = installedPackageJson.packageJson as {
       exports?: Record<string, unknown> | string;
       module?: string;
     };
@@ -176,7 +118,7 @@ function getPackageEsmEntryPath(pkg: string): string | undefined {
     const target = resolveImportTarget(exportsField) || packageJson.module;
     if (!target) return resolvedEntryPath;
 
-    return path.resolve(path.dirname(packageJsonPath), target);
+    return path.resolve(installedPackageJson.dir, target);
   } catch {
     return resolvePackageEntryFromProjectRoot(pkg);
   }
@@ -382,9 +324,12 @@ export function getSharedImportSource(pkg: string, shareItem?: ShareItem): strin
 export const LOAD_SHARE_TAG = '__loadShare__';
 
 const loadShareCacheMap: Record<string, VirtualModule> = {};
+function shouldUseEsmLoadShare(pkg: string, command?: string, isRolldown?: boolean): boolean {
+  return command === 'build' || !!isRolldown || pkg === 'lit' || pkg.startsWith('lit/');
+}
 export function getLoadShareImportId(pkg: string, isRolldown: boolean, command?: string): string {
   if (!loadShareCacheMap[pkg]) {
-    const useESM = isRolldown || command === 'build';
+    const useESM = shouldUseEsmLoadShare(pkg, command, isRolldown);
     const ext = useESM ? '.mjs' : '.js';
     loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, ext);
   }
@@ -402,12 +347,12 @@ export function writeLoadShareModule(
   isRolldown: boolean
 ) {
   if (!loadShareCacheMap[pkg]) {
-    const useESM = isRolldown || command === 'build';
+    const useESM = shouldUseEsmLoadShare(pkg, command, isRolldown);
     const ext = useESM ? '.mjs' : '.js';
     loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, ext);
   }
 
-  const useESM = command === 'build' || isRolldown;
+  const useESM = shouldUseEsmLoadShare(pkg, command, isRolldown);
   const importLine =
     command === 'build'
       ? getRuntimeInitPromiseBootstrapCode()
@@ -473,6 +418,7 @@ export function writeLoadShareModule(
   const localProviderPath = getLocalProviderImportPath(pkg);
   const isWorkspacePackage =
     isWorkspaceFilePath(localProviderPath) || isWorkspaceFilePath(concreteSharedImportSource);
+  const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
   const providerImportId = localProviderPath || concreteSharedImportSource || sharedImportSource;
   const namedExports = getPackageNamedExports(pkg);
   let exportLine: string;
@@ -489,12 +435,12 @@ export function writeLoadShareModule(
   }
 
   const prebuildImportLine =
-    isWorkspacePackage && command !== 'build'
+    (isWorkspacePackage && command !== 'build') || skipServePrebuildWarmup
       ? ''
       : `import ${escapeGeneratedStringLiteral(sharedImportSource)};`;
   const devDynamicImportLine = isWorkspacePackage
     ? ''
-    : command !== 'build'
+    : command !== 'build' && !skipServePrebuildWarmup
       ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});`
       : '';
 


### PR DESCRIPTION
Close #615 

Sharing lit is now sufficient to share the sub-exports as well, as the plugin automatically handles the heavy lifting of sharing them.

This is fixing mixed lit mode too:
- host dev and remote preview
- host preview and remote dev
