### PR TITLE
fix: restrict remote named exports plugin to rolldown only

### DIFF
--- a/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
+++ b/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseAst } from 'rollup/parseAst';
 
+const { getIsRolldownMock } = vi.hoisted(() => ({
+  getIsRolldownMock: vi.fn(() => true),
+}));
+
 vi.mock('../../utils/packageUtils', () => ({
-  getIsRolldown: () => true,
+  getIsRolldown: getIsRolldownMock,
 }));
 
 import { pluginRemoteNamedExports } from '../pluginRemoteNamedExports';
@@ -34,11 +38,23 @@ async function transform(code: string, id = '/src/app.js', parseError = false, o
 describe('pluginRemoteNamedExports', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getIsRolldownMock.mockReturnValue(true);
   });
 
   // ── bail-out conditions ──────────────────────────────────────
 
   describe('bail-out', () => {
+    it('skips in non-rolldown dev', async () => {
+      getIsRolldownMock.mockReturnValue(false);
+      const plugin = pluginRemoteNamedExports(OPTIONS);
+      const result = await (plugin as any).transform.call(
+        createContext(),
+        'import { foo } from "remoteApp/utils";',
+        '/src/app.js'
+      );
+      expect(result).toBeUndefined();
+    });
+
     it('skips when no remotes configured', async () => {
       const result = await transform(
         'import { foo } from "remoteApp/utils"',

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -21,8 +21,9 @@
 import { init as initEsLexer, parse as parseEsImports } from 'es-module-lexer';
 import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
-import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { loadWalk } from '../utils/loadWalk';
+import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import { getIsRolldown } from '../utils/packageUtils';
 import { LOAD_REMOTE_TAG, LOAD_SHARE_TAG } from '../virtualModules';
 
 const JS_EXTENSIONS_RE = /\.(?:[mc]?[jt]sx?|vue|svelte)(?:\?|$)/;
@@ -551,6 +552,7 @@ export function pluginRemoteNamedExports(options: NormalizedModuleFederationOpti
     name: 'module-federation-remote-named-exports',
     enforce: 'post',
     async transform(code: string, id: string) {
+      if (!getIsRolldown(this)) return;
       if (remoteNames.length === 0) return;
       // Skip federation internal modules
       if (id.includes(LOAD_REMOTE_TAG) || id.includes(LOAD_SHARE_TAG)) return;


### PR DESCRIPTION
Close #619