### PR TITLE
fix: skip proxying shared imports from node_modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -862,7 +862,6 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
         config.optimizeDeps ||= {};
         config.optimizeDeps.include ||= [];
         config.optimizeDeps.include.push('@module-federation/runtime');
-        config.optimizeDeps.include.push(virtualDir);
 
         // Prevent Vite from externalizing virtual modules during SSR.
         // Files in node_modules/__mf__virtual/ contain `import("virtual:...")`
@@ -895,6 +894,7 @@ function federation(mfUserOptions: ModuleFederationOptions): Plugin[] {
           config.build = defu(config.build || {}, { target: 'esnext' });
         } else {
           // Vite 5-7: virtual modules use CJS for dev, need interop
+          config.optimizeDeps.include.push(virtualDir);
           config.optimizeDeps.needsInterop ||= [];
           config.optimizeDeps.needsInterop.push(virtualDir);
           config.optimizeDeps.needsInterop.push(getLocalSharedImportMapPath());

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { hasPackageDependencyMock, existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
-  hasPackageDependencyMock: vi.fn(),
-  existsSyncMock: vi.fn(() => false),
-  readFileSyncMock: vi.fn(() => '{}'),
-}));
+const { hasPackageDependencyMock, existsSyncMock, readFileSyncMock, getIsRolldownMock } =
+  vi.hoisted(() => ({
+    hasPackageDependencyMock: vi.fn(),
+    existsSyncMock: vi.fn(() => false),
+    readFileSyncMock: vi.fn(() => '{}'),
+    getIsRolldownMock: vi.fn(() => false),
+  }));
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -19,7 +21,7 @@ vi.mock('../../utils/packageUtils', () => ({
   hasPackageDependency: hasPackageDependencyMock,
   setPackageDetectionCwd: vi.fn(),
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
-  getIsRolldown: () => false,
+  getIsRolldown: getIsRolldownMock,
   removePathFromNpmPackage: (pkg: string) => {
     const match = pkg.match(/^(?:@[^/]+\/)?[^/]+/);
     return match ? match[0] : pkg;
@@ -121,6 +123,7 @@ function makeShared(): NormalizedShared {
 describe('pluginProxySharedModule_preBuild', () => {
   beforeEach(() => {
     hasPackageDependencyMock.mockReset();
+    getIsRolldownMock.mockReset().mockReturnValue(false);
     preBuildShareItemMap.clear();
   });
 
@@ -219,6 +222,123 @@ describe('pluginProxySharedModule_preBuild', () => {
       expect(resolution).toBeUndefined();
     });
   }
+
+  it('does not proxy shared imports from node_modules during dev optimizeDeps', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getIsRolldownMock.mockReturnValue(true);
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = plugins[1];
+    const config = {
+      resolve: {
+        alias: [] as Array<{
+          find: RegExp;
+          customResolver?: (source: string, importer: string) => unknown;
+        }>,
+      },
+    };
+
+    proxyPlugin.config?.call(
+      {
+        meta: {},
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      config as any,
+      {
+        command: 'serve',
+        mode: 'development',
+      }
+    );
+
+    const alias = config.resolve.alias.find((entry) => entry.find.test('react'));
+    const resolution = await alias?.customResolver?.call(
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      'react',
+      '/repo/node_modules/.pnpm/react-dom@19/node_modules/react-dom/cjs/react-dom.development.js'
+    );
+
+    expect(resolution).toBeUndefined();
+  });
+
+  it('proxies shared imports from node_modules before Rolldown', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getIsRolldownMock.mockReturnValue(false);
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = plugins[1];
+    const config = {
+      resolve: {
+        alias: [] as Array<{
+          find: RegExp;
+          customResolver?: (source: string, importer: string) => unknown;
+        }>,
+      },
+    };
+
+    proxyPlugin.config?.call(
+      {
+        meta: {},
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      config as any,
+      {
+        command: 'serve',
+        mode: 'development',
+      }
+    );
+
+    const alias = config.resolve.alias.find((entry) => entry.find.test('react'));
+    const resolution = await alias?.customResolver?.call(
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      'react',
+      '/repo/node_modules/.pnpm/react-dom@18/node_modules/react-dom/cjs/react-dom.development.js'
+    );
+
+    expect(resolution).toEqual({ id: '/resolved//mock/path.js' });
+  });
+
+  it('proxies shared imports from non-React node_modules during Rolldown dev', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getIsRolldownMock.mockReturnValue(true);
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = plugins[1];
+    const config = {
+      resolve: {
+        alias: [] as Array<{
+          find: RegExp;
+          customResolver?: (source: string, importer: string) => unknown;
+        }>,
+      },
+    };
+
+    proxyPlugin.config?.call(
+      {
+        meta: {},
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      config as any,
+      {
+        command: 'serve',
+        mode: 'development',
+      }
+    );
+
+    const alias = config.resolve.alias.find((entry) => entry.find.test('react'));
+    const resolution = await alias?.customResolver?.call(
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      },
+      'react',
+      '/repo/node_modules/.vite/deps/emotion-element.browser.development.esm.js'
+    );
+
+    expect(resolution).toEqual({ id: '/resolved//mock/path.js' });
+  });
 
   it('skips prebuild for import: false shared deps in configResolved', () => {
     hasPackageDependencyMock.mockReturnValue(false);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -143,6 +143,19 @@ export function proxySharedModule(options: {
                 replacement: '$1',
                 customResolver(source: string, importer: string) {
                   if (/\.css$/.test(source)) return;
+                  const normalizedImporter = importer?.replace(/\\/g, '/');
+                  const isReactCjsImporter =
+                    normalizedImporter &&
+                    /\/node_modules\/(?:\.pnpm\/[^/]+\/node_modules\/)?react(?:-dom)?\/cjs\//.test(
+                      normalizedImporter
+                    );
+                  if (
+                    isRolldown &&
+                    isReactCjsImporter &&
+                    (source === 'react' || source === 'react-dom')
+                  ) {
+                    return;
+                  }
                   // Hard-stop proxying bare React in dev. Vite's RSC pipeline
                   // expects the native server React entry, and wrapping `react`
                   // through loadShare breaks react-server-dom-webpack.


### PR DESCRIPTION
Close #633