### PR TITLE
feat: support MF_BUILD_VERSION env var for dynamic buildVersion in manifest

### DIFF
--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -20,6 +20,20 @@ import {
 } from '../utils/cssModuleHelpers';
 import { resolvePublicPath } from '../utils/publicPath';
 
+/**
+ * Resolves the build version for the module federation manifest.
+ *
+ * Priority:
+ * 1. `MF_BUILD_VERSION` environment variable (set by CI or manually)
+ * 2. Falls back to `'1.0.0'` to preserve backward compatibility
+ *
+ * This mirrors the behavior of the webpack/rspack plugins via
+ * `getBuildVersion()` from `@module-federation/managers`.
+ */
+function getBuildVersion(): string {
+  return process.env['MF_BUILD_VERSION'] ?? '1.0.0';
+}
+
 // Helper to build share key map with proper context typing
 interface BuildFileToShareKeyMapContext {
   resolve: PluginContext['resolve'];
@@ -115,7 +129,7 @@ const Manifest = (): Plugin[] => {
                 metaData: {
                   name: name,
                   type: 'app',
-                  buildInfo: { buildVersion: '1.0.0', buildName: name },
+                  buildInfo: { buildVersion: getBuildVersion(), buildName: name },
                   remoteEntry: {
                     name: filename,
                     path: '',
@@ -354,7 +368,7 @@ const Manifest = (): Plugin[] => {
         name,
         type: 'app',
         buildInfo: {
-          buildVersion: '1.0.0',
+          buildVersion: getBuildVersion(),
           buildName: name,
         },
         remoteEntry,


### PR DESCRIPTION
## Problem

The `buildVersion` field in the `mf-manifest.json` is hardcoded to `'1.0.0'` in two places inside `pluginMFManifest.ts`:

- Dev server middleware response
- `generateMFManifest()` used at build time

This means setting `MF_BUILD_VERSION` has no effect when using the Vite plugin, even though it works correctly in the webpack/rspack plugins (via `getBuildVersion()` from `@module-federation/managers`).

## Solution

Introduce a `getBuildVersion()` helper that mirrors the resolution priority used by `@module-federation/managers`:

1. `process.env['MF_BUILD_VERSION']` — explicit override (CI pipelines, manual builds)
2. `'1.0.0'` — backward-compatible fallback when the env var is not set

Replace both hardcoded `buildVersion: '1.0.0'` occurrences with `getBuildVersion()`.

## Why not depend on `@module-federation/managers`?

`@module-federation/managers` is not a current dependency of this package. Adding it for a two-line util would be unnecessary. The helper is self-contained and matches the documented behavior.

## Usage

```bash
# CI or Jenkins
MF_BUILD_VERSION=1.2.3 vite build
# → mf-manifest.json buildVersion: "1.2.3"

# Local dev (no env var set)
vite build
# → mf-manifest.json buildVersion: "1.0.0"  (unchanged behavior)
```

## Testing

Verified locally against `@module-federation/vite@1.13.5` by:
1. Building without `MF_BUILD_VERSION` → `buildVersion` remains `"1.0.0"` ✓
2. Building with `MF_BUILD_VERSION=2.5.1` → `buildVersion` is `"2.5.1"` ✓

Fixes: webpack/rspack parity for `MF_BUILD_VERSION` in Vite builds.