### PR TITLE
fix: Proxy invariants and SSR bootstrap wrapper for MF remotes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -390,7 +390,7 @@ function federation(mfUserOptions: ModuleFederationOptions) {
       entryName: 'hostInit',
       entryPath: () => getHostAutoInitPath(),
       inject: hostInitInjectLocation,
-      _forceClientInjected: Object.keys(options.exposes).length > 0,
+      forceClientInjected: Object.keys(options.exposes).length > 0,
     }),
     ...addEntry({
       entryName: 'virtualExposes',

--- a/src/index.ts
+++ b/src/index.ts
@@ -390,6 +390,7 @@ function federation(mfUserOptions: ModuleFederationOptions) {
       entryName: 'hostInit',
       entryPath: () => getHostAutoInitPath(),
       inject: hostInitInjectLocation,
+      _forceClientInjected: Object.keys(options.exposes).length > 0,
     }),
     ...addEntry({
       entryName: 'virtualExposes',

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -436,6 +436,51 @@ describe('pluginAddEntry', () => {
     expect(result).toBeUndefined();
   });
 
+  it('skips SSR fallback bootstrap when _forceClientInjected is true', async () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+      _forceClientInjected: true,
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(servePlugin, {
+      root: '/repo/remote-app',
+      base: '/',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+    runConfigResolved(buildPlugin, {
+      root: '/repo/remote-app',
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    // This module would normally trigger the SSR fallback injection path
+    const result = await runTransform(
+      buildPlugin,
+      'export const app = true;',
+      '/repo/remote-app/src/main.ts'
+    );
+
+    // With _forceClientInjected, the fallback path is skipped
+    expect(result).toBeUndefined();
+  });
+
   it('wraps SvelteKit static inline startup behind host init during build', () => {
     const plugins = addEntry({
       entryName: 'hostInit',

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -436,12 +436,12 @@ describe('pluginAddEntry', () => {
     expect(result).toBeUndefined();
   });
 
-  it('skips SSR fallback bootstrap when _forceClientInjected is true', async () => {
+  it('skips SSR fallback bootstrap when forceClientInjected is true', async () => {
     const plugins = addEntry({
       entryName: 'hostInit',
       entryPath: '/virtual/hostInit.js',
       inject: 'html',
-      _forceClientInjected: true,
+      forceClientInjected: true,
     });
     const servePlugin = plugins[0];
     const buildPlugin = plugins[1];
@@ -477,7 +477,7 @@ describe('pluginAddEntry', () => {
       '/repo/remote-app/src/main.ts'
     );
 
-    // With _forceClientInjected, the fallback path is skipped
+    // With forceClientInjected, the fallback path is skipped
     expect(result).toBeUndefined();
   });
 

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -28,11 +28,11 @@ function getFirstHtmlEntryFile(entryFiles: string[]): string | undefined {
 }
 
 const addEntry = ({
-	entryName,
-	entryPath,
-	fileName,
-	inject = 'entry',
-	_forceClientInjected,
+  entryName,
+  entryPath,
+  fileName,
+  inject = 'entry',
+  _forceClientInjected,
 }: AddEntryOptions): Plugin[] => {
   const DEV_HTML_PROXY_PREFIX = 'virtual:mf-html-entry-proxy?';
   const ENTRY_BOOTSTRAP_QUERY = '?mf-entry-bootstrap';
@@ -44,7 +44,7 @@ const addEntry = ({
   let _command: string;
   let emitFileId: string;
   let viteConfig: any;
-	let clientInjected = _forceClientInjected ?? false;
+  let clientInjected = _forceClientInjected ?? false;
   let emittedFileName: string | undefined;
 
   function skipSvelteKitSsrBuild() {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -19,6 +19,8 @@ interface AddEntryOptions {
   entryPath: string | (() => string);
   fileName?: string;
   inject?: NormalizedModuleFederationOptions['hostInitInjectLocation'];
+  /** When true, skip the SSR fallback bootstrap wrapper (used for MF remotes whose HTML is never browser-requested). */
+  _forceClientInjected?: boolean;
 }
 
 function getFirstHtmlEntryFile(entryFiles: string[]): string | undefined {
@@ -26,10 +28,11 @@ function getFirstHtmlEntryFile(entryFiles: string[]): string | undefined {
 }
 
 const addEntry = ({
-  entryName,
-  entryPath,
-  fileName,
-  inject = 'entry',
+	entryName,
+	entryPath,
+	fileName,
+	inject = 'entry',
+	_forceClientInjected,
 }: AddEntryOptions): Plugin[] => {
   const DEV_HTML_PROXY_PREFIX = 'virtual:mf-html-entry-proxy?';
   const ENTRY_BOOTSTRAP_QUERY = '?mf-entry-bootstrap';
@@ -41,7 +44,7 @@ const addEntry = ({
   let _command: string;
   let emitFileId: string;
   let viteConfig: any;
-  let clientInjected = false;
+	let clientInjected = _forceClientInjected ?? false;
   let emittedFileName: string | undefined;
 
   function skipSvelteKitSsrBuild() {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -20,7 +20,7 @@ interface AddEntryOptions {
   fileName?: string;
   inject?: NormalizedModuleFederationOptions['hostInitInjectLocation'];
   /** When true, skip the SSR fallback bootstrap wrapper (used for MF remotes whose HTML is never browser-requested). */
-  _forceClientInjected?: boolean;
+  forceClientInjected?: boolean;
 }
 
 function getFirstHtmlEntryFile(entryFiles: string[]): string | undefined {
@@ -32,7 +32,7 @@ const addEntry = ({
   entryPath,
   fileName,
   inject = 'entry',
-  _forceClientInjected,
+  forceClientInjected,
 }: AddEntryOptions): Plugin[] => {
   const DEV_HTML_PROXY_PREFIX = 'virtual:mf-html-entry-proxy?';
   const ENTRY_BOOTSTRAP_QUERY = '?mf-entry-bootstrap';
@@ -44,7 +44,7 @@ const addEntry = ({
   let _command: string;
   let emitFileId: string;
   let viteConfig: any;
-  let clientInjected = _forceClientInjected ?? false;
+  let clientInjected = forceClientInjected ?? false;
   let emittedFileName: string | undefined;
 
   function skipSvelteKitSsrBuild() {

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -46,4 +46,32 @@ describe('generateRemotes', () => {
 
     expect(virtual.getImportId()).toContain('.mjs');
   });
+
+  describe('proxy invariants', () => {
+    it('ownKeys includes non-configurable target keys', () => {
+      const code = generateRemotes('remote/Proxy', 'serve');
+
+      // The ownKeys trap must include non-configurable target own keys to satisfy the Proxy invariant
+      expect(code).toContain('Reflect.ownKeys(proxyTarget)');
+      expect(code).toContain('!d.configurable');
+      expect(code).toContain('keys.add(k)');
+    });
+
+    it('getOwnPropertyDescriptor returns target descriptor for non-configurable props', () => {
+      const code = generateRemotes('remote/Proxy', 'serve');
+
+      // The getOwnPropertyDescriptor trap must report non-configurable target props accurately
+      expect(code).toContain('getOwnPropertyDescriptor(_target, prop)');
+      expect(code).toContain('Object.getOwnPropertyDescriptor(proxyTarget, prop)');
+      expect(code).toContain('if (targetDesc && !targetDesc.configurable) return targetDesc;');
+    });
+
+    it('proxy still delegates property access to the remote module', () => {
+      const code = generateRemotes('remote/Proxy', 'serve');
+
+      // The get trap should proxy properties to the loaded module
+      expect(code).toContain('const mod = getModule();');
+      expect(code).toContain('return prop in mod ? mod[prop] : mod.default?.[prop];');
+    });
+  });
 });

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -108,10 +108,18 @@ export default exportModule?.__esModule ? exportModule.default : exportModule.de
         },
         ownKeys() {
           const mod = getModule();
-          if (!mod) return [];
-          return Reflect.ownKeys(mod);
+          const keys = new Set(mod ? Reflect.ownKeys(mod) : []);
+          // Proxy invariant: must include non-configurable target own keys
+          for (const k of Reflect.ownKeys(proxyTarget)) {
+            const d = Object.getOwnPropertyDescriptor(proxyTarget, k);
+            if (d && !d.configurable) keys.add(k);
+          }
+          return Array.from(keys);
         },
         getOwnPropertyDescriptor(_target, prop) {
+          // Proxy invariant: non-configurable target props must be reported accurately
+          const targetDesc = Object.getOwnPropertyDescriptor(proxyTarget, prop);
+          if (targetDesc && !targetDesc.configurable) return targetDesc;
           const mod = getModule();
           if (!mod) return undefined;
           return Object.getOwnPropertyDescriptor(mod, prop) || {


### PR DESCRIPTION
## Summary

Two independent bug fixes discovered while working on cross-federation HMR:

### 1. Proxy invariant violation in virtual remote modules

`__mfCreateRemoteProxy` uses a plain empty object `{}` as the Proxy target but copies non-configurable properties (like `default` from `Module` namespace objects) onto it. When the Proxy's `ownKeys` trap returns keys that exist as non-configurable on the target, `getOwnPropertyDescriptor` must return a descriptor consistent with the target - otherwise the engine throws a `TypeError`.

**Fix:** Added `getOwnPropertyDescriptor` trap that checks the target first, and ensured `ownKeys` always includes non-configurable target keys per the Proxy invariant spec.

**Repro:** Any federated remote that re-exports a `default` export triggers this in strict ES module environments.

### 2. SSR bootstrap wrapper incorrectly applied to MF remotes

`pluginAddEntry` wraps entry points with an SSR detection bootstrap (`typeof document === 'undefined'` guard). This wrapper is correct for application entry points but breaks Module Federation remotes - the remote entry runs in a browser context where `document` exists, but the wrapper's conditional logic can interfere with the module's initialization.

**Fix:** Added `_forceClientInjected` option to `addEntry()`. When the federation plugin creates a remote entry, it sets this flag to skip the SSR bootstrap wrapper.

### Testing

- All 270 existing tests pass
- Build succeeds