### PR TITLE
fix: prevent broadcast loop from MF-generated output files

### DIFF
--- a/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
+++ b/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
@@ -329,4 +329,44 @@ describe('pluginDevRemoteHmr', () => {
     expect(server.ws.send).toHaveBeenCalledWith({ type: 'full-reload' });
     expect(server.ws.send).toHaveBeenCalledTimes(1);
   });
+
+  it('should ignore .mf output directory files', () => {
+    const plugin = pluginDevRemoteHmr(
+      normalizeModuleFederationOptions({
+        name: 'remote-app',
+        filename: 'remoteEntry.js',
+        exposes: { './Button': './src/Button.tsx' },
+        virtualModuleDir: '__mf__virtual',
+      })
+    );
+
+    const { server, emit } = createServer();
+    runConfigureServer(plugin, server);
+
+    emit('change', '/project/.mf/diagnostics/latest.json');
+    emit('change', 'C:\\project\\.mf\\diagnostics\\latest.json');
+
+    expect(server.ws.send).not.toHaveBeenCalled();
+  });
+
+  it('should ignore mf-manifest.json and mf-stats.json', () => {
+    const plugin = pluginDevRemoteHmr(
+      normalizeModuleFederationOptions({
+        name: 'remote-app',
+        filename: 'remoteEntry.js',
+        exposes: { './Button': './src/Button.tsx' },
+        virtualModuleDir: '__mf__virtual',
+      })
+    );
+
+    const { server, emit } = createServer();
+    runConfigureServer(plugin, server);
+
+    emit('change', '/project/mf-manifest.json');
+    emit('change', 'C:\\project\\mf-manifest.json');
+    emit('change', '/project/mf-stats.json');
+    emit('change', 'C:\\project\\mf-stats.json');
+
+    expect(server.ws.send).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/pluginDevRemoteHmr.ts
+++ b/src/plugins/pluginDevRemoteHmr.ts
@@ -41,7 +41,13 @@ function shouldIgnoreFile(file: string, options: NormalizedModuleFederationOptio
     file.includes('/.vite/') ||
     file.includes('\\.vite\\') ||
     file.includes('/.__mf__temp/') ||
-    file.includes('\\.__mf__temp\\')
+    file.includes('\\.__mf__temp\\') ||
+    file.includes('/.mf/') ||
+    file.includes('\\.mf\\') ||
+    file.includes('/mf-manifest.json') ||
+    file.includes('\\mf-manifest.json') ||
+    file.includes('/mf-stats.json') ||
+    file.includes('\\mf-stats.json')
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes an infinite broadcast loop in `pluginDevRemoteHmr` caused by MF-generated output files triggering the file watcher.

### Problem

The remote-side file watcher broadcasts `mf:remote-update` on every file change. However, Module Federation itself writes files during dev:

- `.mf/diagnostics/latest.json` - runtime diagnostics
- `mf-manifest.json` / `mf-stats.json` - manifest plugin output

These writes trigger the watcher, which broadcasts, which can trigger further writes, creating a tight infinite loop that saturates the WebSocket and causes constant full-reloads on the host.

### Fix

Added `.mf/`, `mf-manifest.json`, and `mf-stats.json` to the `shouldIgnoreFile` exclusion list, matching the existing pattern for `node_modules`, `.vite`, and `.__mf__temp`.

Both Unix (`/`) and Windows (`\`) path separators are covered, consistent with the existing exclusions.

### Testing

- Added 2 new test cases covering all new exclusion patterns (both path separator variants)
- All 272 tests pass
- Build succeeds