### PR TITLE
fix(core): resolve version even when import is false

### DIFF
--- a/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
+++ b/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
@@ -231,7 +231,10 @@ describe('pluginDevRemoteHmr', () => {
   });
 
   describe('react-refresh proxy middleware', () => {
-    function makeRemotePlugin(opts: { exposes?: Record<string, unknown>; remoteHmr?: boolean }) {
+    function makeRemotePlugin(opts: {
+      exposes?: Record<string, string | { import: string }>;
+      remoteHmr?: boolean;
+    }) {
       return pluginDevRemoteHmr(
         normalizeModuleFederationOptions({
           name: 'test-app',

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -288,7 +288,34 @@ describe('normalizeModuleFederationOption', () => {
       });
     });
 
-    it('skips package.json resolution for import: false and does not error', () => {
+    it('resolves version for import: false when package is installed', () => {
+      mfErrorSpy.mockClear();
+
+      // Version resolution is required even when import: false.
+      // The `import: false` flag indicates "this app does not PROVIDE the module"
+      // (it must be supplied by the host), but the runtime still needs to know
+      // the version for share scope registration and singleton validation.
+      // Without a resolved version, the MF runtime defaults to version "0",
+      // which breaks satisfy() checks and causes false-positive singleton warnings.
+      const result = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          react: {
+            import: false,
+            singleton: true,
+          },
+        },
+      }).shared;
+
+      // Should resolve version from react's package.json
+      expect(result['react'].version).toBeDefined();
+      expect(result['react'].version).not.toBe('0');
+      expect(result['react'].shareConfig.requiredVersion).toMatch(/^\^/);
+      expect(result['react'].shareConfig.import).toBe(false);
+      expect(result['react'].shareConfig.singleton).toBe(true);
+    });
+
+    it('does not error when version resolution fails for import: false', () => {
       mfErrorSpy.mockClear();
 
       const result = normalizeModuleFederationOptions({
@@ -301,9 +328,11 @@ describe('normalizeModuleFederationOption', () => {
         },
       }).shared;
 
-      // Should not trigger any mfError calls for unresolvable packages
+      // Should not trigger any mfError calls for unresolvable packages when import: false
       expect(mfErrorSpy).not.toHaveBeenCalled();
 
+      // Version should be undefined but should not cause runtime issues
+      // because the host should provide this module
       expect(result['not-installed-pkg']).toEqual({
         from: '',
         name: 'not-installed-pkg',

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -147,7 +147,9 @@ export interface ShareItem {
  * @returns {string | undefined}
  */
 function searchPackageVersion(sharedName: string): string | undefined {
-  const installed = getInstalledPackageJson(sharedName, { packageName: sharedName });
+  const installed = getInstalledPackageJson(sharedName, {
+    packageName: sharedName,
+  });
   const version = installed?.packageJson.version;
   return typeof version === 'string' ? version : undefined;
 }
@@ -161,7 +163,9 @@ function inferVersionFromRequiredVersion(requiredVersion?: string): string | und
 function getLitExportSubpathShares(sharedName: string): string[] {
   if (sharedName !== 'lit') return [];
 
-  const installedPackageJson = getInstalledPackageJson(sharedName, { packageName: sharedName });
+  const installedPackageJson = getInstalledPackageJson(sharedName, {
+    packageName: sharedName,
+  });
   const exportsField = installedPackageJson?.packageJson.exports;
   if (!exportsField || typeof exportsField === 'string') return [];
 
@@ -188,27 +192,39 @@ function normalizeShareItem(
 
   const isImportFalse = typeof shareItem === 'object' && shareItem.import === false;
 
-  // Skip package.json resolution when import: false — this app doesn't
-  // provide the package, so it may not be installed at all.
-  if (!isImportFalse) {
+  // Version resolution is required even when import: false.
+  //
+  // The `import: false` flag indicates "this app does not PROVIDE the module"
+  // (it must be supplied by the host), but the runtime still needs to know
+  // the version for share scope registration and singleton validation.
+  //
+  // Without a resolved version, the MF runtime defaults to version "0",
+  // which breaks satisfy() checks and causes false-positive warnings like:
+  //   "Version 0 from ... does not satisfy the requirement of ... which needs *)"
+  //
+  // Errors are only thrown when version resolution fails for non-import:false
+  // modules, as those are expected to be resolvable.
+  try {
     try {
+      version = require(path.join(getPackageName(key), 'package.json')).version;
+    } catch (e1) {
       try {
-        version = require(path.join(getPackageName(key), 'package.json')).version;
-      } catch (e1) {
-        try {
-          const localPath = path.join(
-            process.cwd(),
-            'node_modules',
-            getPackageName(key),
-            'package.json'
-          );
-          version = require(localPath).version;
-        } catch (e2) {
-          version = searchPackageVersion(key);
-          if (!version) mfError(e1);
+        const localPath = path.join(
+          process.cwd(),
+          'node_modules',
+          getPackageName(key),
+          'package.json'
+        );
+        version = require(localPath).version;
+      } catch (e2) {
+        version = searchPackageVersion(key);
+        if (!version && !isImportFalse) {
+          mfError(e1);
         }
       }
-    } catch (e) {
+    }
+  } catch (e) {
+    if (!isImportFalse) {
       mfError(`Unexpected error resolving version for ${key}:`, e);
     }
   }


### PR DESCRIPTION
- Attempt version resolution even when import: false
- Only suppress mfError on missing version when import: false
- Add test for version resolution with import: false
- Add test for graceful failure when version not found