### PR TITLE
fix: preserve import-false shared sub-dependencies in dev

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -724,6 +724,66 @@ describe('pluginProxySharedModule_preBuild', () => {
     readFileSyncMock.mockReset().mockReturnValue('{}');
   });
 
+  it('preserves import false shared sub-dependencies in dev mode without warning', () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    existsSyncMock.mockImplementation(
+      (p: string) => p === '/repo/apps/remote/node_modules/shared-lib/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p === '/repo/apps/remote/node_modules/shared-lib/package.json') {
+        return JSON.stringify({
+          name: 'shared-lib',
+          dependencies: { pinia: '^3.0.0' },
+        });
+      }
+      return '{}';
+    });
+
+    const shared: NormalizedShared = {
+      'shared-lib': {
+        name: 'shared-lib',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '^1.0.0', strictVersion: false },
+      },
+      pinia: {
+        name: 'pinia',
+        from: '',
+        version: '3.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^3.0.0',
+          strictVersion: false,
+          import: false,
+        },
+      },
+    };
+
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta() } as unknown as ConfigPluginContext,
+      config,
+      {
+        command: 'serve',
+        mode: 'development',
+      } as ConfigEnv
+    );
+
+    expect(shared).toHaveProperty('shared-lib');
+    expect(shared).toHaveProperty('pinia');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
   it('uses auto-detected workspace sources in serve prebuild resolution without null deref', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -126,6 +126,10 @@ function excludeSharedSubDependencies(shared: NormalizedShared): void {
     for (const dep of deps) {
       const depKey = sharedKeyByBase.get(dep);
       if (depKey && depKey !== parentKey) {
+        if (shared[depKey]?.shareConfig.import === false) {
+          continue;
+        }
+
         mfWarn(
           `"${dep}" is a dependency of shared package "${parentKey}" and is also shared separately. ` +
             `This may cause initialization order issues in dev mode. ` +


### PR DESCRIPTION
Close #660

Preserves `import false` shared sub-dependencies in dev mode without warning.
This respects host-provided shared modules while keeping existing auto-exclusion behavior for other duplicate sub-dependencies.