### PR TITLE
fix: handle excluded shared keys and scoped remote names in dev bootstrap

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../utils/packageUtils', () => ({
 
 import addEntry from '../pluginAddEntry';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
+import { addUsedRemote } from '../../virtualModules/virtualRemotes';
 
 type AddEntryPlugin = ReturnType<typeof addEntry>[number];
 
@@ -190,6 +191,57 @@ describe('pluginAddEntry', () => {
     expect(result?.code).toContain('const { initHost } = await import("/virtual/hostInit.js");');
     expect(result?.code).toContain('const runtime = await initHost();');
     expect(result?.code).toContain('})().then(() => import("/src/main.tsx?mf-entry-bootstrap"));');
+  });
+
+  it('preloads scoped remote subpaths but skips the bare scoped remote key', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-scoped-'));
+    const htmlFile = path.join(tempDir, 'index.html');
+    fs.writeFileSync(
+      htmlFile,
+      [
+        '<!doctype html>',
+        '<html>',
+        '  <body>',
+        '    <script type="module" src="/src/main.ts"></script>',
+        '  </body>',
+        '</html>',
+      ].join('\n')
+    );
+    addUsedRemote('@scope/remote', '@scope/remote');
+    addUsedRemote('@scope/remote', '@scope/remote/Button');
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(buildPlugin, 'export const app = true;', '/src/main.ts')) as
+      | { code: string }
+      | undefined;
+
+    expect(result?.code).toContain('runtime.loadRemote("@scope/remote/Button")');
+    expect(result?.code).not.toContain('runtime.loadRemote("@scope/remote")');
   });
 
   it('rewrites dev html entry scripts to external proxy modules instead of inline scripts', async () => {

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -118,6 +118,14 @@ async function runGenerateBundleWithManifest(
     usedShares?: Set<string>;
     usedRemotes?: Map<string, Set<string>>;
     exposePaths?: Record<string, { import: string }>;
+    shareItems?: Record<
+      string,
+      | {
+          version: string;
+          shareConfig: { requiredVersion: string; singleton?: boolean };
+        }
+      | undefined
+    >;
   } = {},
   command: 'serve' | 'build' = 'build'
 ): Promise<Record<string, string>> {
@@ -141,9 +149,14 @@ async function runGenerateBundleWithManifest(
   });
   getUsedRemotesMap.mockReturnValue(runtime.usedRemotes || new Map());
   getUsedShares.mockReturnValue(runtime.usedShares || new Set());
-  getNormalizeShareItem.mockReturnValue({
-    version: '1.0.0',
-    shareConfig: { requiredVersion: '*' },
+  getNormalizeShareItem.mockImplementation((shareKey: string) => {
+    if (runtime.shareItems && Object.hasOwn(runtime.shareItems, shareKey)) {
+      return runtime.shareItems[shareKey];
+    }
+    return {
+      version: '1.0.0',
+      shareConfig: { requiredVersion: '*' },
+    };
   });
 
   const [, buildPlugin] = manifestPlugin();
@@ -273,6 +286,29 @@ describe('pluginMFManifest', () => {
     expect(manifest).not.toHaveProperty('shared');
     expect(manifest).not.toHaveProperty('exposes');
     expect(stats).not.toHaveProperty('assetAnalysis');
+  });
+
+  it('skips used shared keys missing from normalized shared config', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, {
+      usedShares: new Set(['react', '@scope/utils']),
+      shareItems: {
+        react: {
+          version: '18.0.0',
+          shareConfig: { requiredVersion: '^18.0.0', singleton: true },
+        },
+        '@scope/utils': undefined,
+      },
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+    expect(manifest.shared).toHaveLength(1);
+    expect(manifest.shared[0]).toMatchObject({
+      name: 'react',
+      version: '18.0.0',
+      singleton: true,
+      requiredVersion: '^18.0.0',
+    });
   });
 
   it('preserves publicPath "auto" in manifest metaData', async () => {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -129,9 +129,14 @@ const addEntry = ({
   }
 
   function getBootstrapSource(initSrc: string, entrySrc: string) {
-    const remotePreloads = Object.values(getUsedRemotesMap())
-      .flatMap((remotes) => Array.from(remotes))
-      .filter((remote) => remote.includes('/'))
+    // Keep only sub-path entries (e.g. "remote/App"); skip bare remote keys
+    // ("remote" or scoped "@scope/remote") since they refer to the container
+    // itself, not an exposed module. The previous `includes('/')` check
+    // incorrectly matched scoped names like "@scope/remote".
+    const remotePreloads = Object.entries(getUsedRemotesMap())
+      .flatMap(([remoteKey, remotes]) =>
+        Array.from(remotes).filter((remote) => remote !== remoteKey)
+      )
       .sort()
       .map((remote) => `runtime.loadRemote(${JSON.stringify(remote)})`)
       .join(',');

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -280,27 +280,32 @@ const Manifest = (): Plugin[] => {
     );
 
     // Process shared dependencies
-    const shared = Array.from(getUsedShares()).map((shareKey) => {
+    const shared = Array.from(getUsedShares()).flatMap((shareKey) => {
       const shareItem = getNormalizeShareItem(shareKey);
+      // shareItem can be undefined when a key was added to usedShares before
+      // excludeSharedSubDependencies removed it from options.shared in dev mode.
+      if (!shareItem) return [];
       const assets = preloadMap[shareKey] || createEmptyAssetMap();
 
-      return {
-        id: `${name}:${shareKey}`,
-        name: shareKey,
-        version: shareItem.version,
-        singleton: shareItem.shareConfig.singleton,
-        requiredVersion: shareItem.shareConfig.requiredVersion,
-        assets: {
-          js: {
-            async: assets.js.async,
-            sync: assets.js.sync,
-          },
-          css: {
-            async: assets.css.async,
-            sync: assets.css.sync,
+      return [
+        {
+          id: `${name}:${shareKey}`,
+          name: shareKey,
+          version: shareItem.version,
+          singleton: shareItem.shareConfig.singleton,
+          requiredVersion: shareItem.shareConfig.requiredVersion,
+          assets: {
+            js: {
+              async: assets.js.async,
+              sync: assets.js.sync,
+            },
+            css: {
+              async: assets.css.async,
+              sync: assets.css.sync,
+            },
           },
         },
-      };
+      ];
     });
 
     // Process exposed modules


### PR DESCRIPTION
## Bug 1: `generateMFManifest` crashes on shared keys removed by `excludeSharedSubDependencies`

The new `excludeSharedSubDependencies` (dev mode only) deletes a shared key from `options.shared` if it is a dependency of another shared package. But the key may already be in `usedShares` (added earlier by `createEarlyVirtualModulesPlugin`, `enforce: "pre"`). When `/mf-manifest.json` is requested, `generateMFManifest` iterates `usedShares`, calls `getNormalizeShareItem(key)` (returns `undefined`), then crashes on `shareItem.version`. Dev server responds 500 and the host fails with `RUNTIME-003: Failed to get manifest`.

`generateLocalSharedImportMap` in the same file already guards against this — `generateMFManifest` was missing the same check.

**Repro:** share two packages where one is listed as a `dependency` of the other (e.g. `@scope/components` deps include `@scope/utils`, both shared).

**Fix** in `src/plugins/pluginMFManifest.ts`: switch `.map()` to `.flatMap()` and skip entries with no `shareItem`.

## Bug 2: Scoped remote names break the auto-preload bootstrap

`pluginAddEntry.ts` builds the host bootstrap with:

```ts
.filter((remote) => remote.includes('/'))
```

intending to keep only sub-path entries (e.g. `remote/App`) and skip bare container names (`remote`). For scoped remotes like `@scope/remote`, the `/` from the scope makes the bare name pass the filter. The generated bootstrap then calls `runtime.loadRemote("@scope/remote")` with no exposed path, which is translated into module `.` and fails with `Module . does not exist in container`. The host never boots.

**Repro:** any host with a scoped remote (`@scope/remote`) where the remote only declares sub-path exposes (no `'.'`).

**Fix** in `src/plugins/pluginAddEntry.ts`: compare against the remote key instead of using the `/` heuristic.

```ts
const remotePreloads = Object.entries(getUsedRemotesMap())
  .flatMap(([remoteKey, remotes]) =>
    Array.from(remotes).filter((remote) => remote !== remoteKey)
  )
  .sort()
  .map((remote) => `runtime.loadRemote(${JSON.stringify(remote)})`)
  .join(',');
```