### PR TITLE
chore: add `vite-plugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "keywords": [
     "vite",
+    "vite-plugin",
     "module federation",
     "microfrontend"
   ],


### PR DESCRIPTION
Adding the keyword `vite-plugin` makes it appear in the [Vite Plugin Registry](https://registry.vite.dev).

I think it doesn't need extended metadata - the peer dep ranges are well defined.