### PR TITLE
chore(deps): drop defu

### DIFF
--- a/integration/esm-virtual-modules.test.ts
+++ b/integration/esm-virtual-modules.test.ts
@@ -4,7 +4,7 @@ import { buildFixture, FIXTURES } from './helpers/build';
 import { getAllChunkCode } from './helpers/matchers';
 
 const SHARED_REMOTE_MF_OPTIONS = {
-  shared: { defu: {} },
+  shared: { pathe: {} },
   exposes: {
     './exposed': resolve(FIXTURES, 'shared-remote', 'exposed-module.js'),
   },
@@ -17,8 +17,7 @@ describe('ESM virtual modules', () => {
       mfOptions: SHARED_REMOTE_MF_OPTIONS,
     });
     const allCode = getAllChunkCode(output);
-    // createDefu is a named export from defu — it should be present in the output
-    expect(allCode).toContain('createDefu');
+    expect(allCode).toContain('join');
   });
 
   it('emits ESM import/export in build output for shared modules', async () => {

--- a/integration/fixtures/shared-remote/exposed-module.js
+++ b/integration/fixtures/shared-remote/exposed-module.js
@@ -1,8 +1,3 @@
-import { createDefu } from 'defu';
+import { join } from 'pathe';
 
-export const merge = createDefu((obj, key, value) => {
-  if (typeof obj[key] === 'number' && typeof value === 'number') {
-    obj[key] += value;
-    return true;
-  }
-});
+export const nestedPath = join('shared', 'remote');

--- a/integration/helpers/build.ts
+++ b/integration/helpers/build.ts
@@ -1,4 +1,3 @@
-import defu from 'defu';
 import { resolve } from 'path';
 import { build, Rollup, UserConfig as ViteUserConfig } from 'vite';
 import { expect } from 'vitest';
@@ -16,6 +15,30 @@ export interface BuildFixtureOptions {
   viteConfig?: Partial<ViteUserConfig>;
 }
 
+type PlainObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is PlainObject {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function mergeDefaults<T extends PlainObject>(overrides: Partial<T> | undefined, defaults: T): T {
+  const merged: PlainObject = { ...defaults };
+
+  for (const [key, value] of Object.entries(overrides ?? {})) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    const defaultValue = merged[key];
+    merged[key] =
+      isPlainObject(value) && isPlainObject(defaultValue)
+        ? mergeDefaults(value, defaultValue)
+        : value;
+  }
+
+  return merged as T;
+}
+
 export async function buildFixture(opts?: BuildFixtureOptions): Promise<Rollup.RollupOutput> {
   const { fixture = 'basic-remote', mfOptions, viteConfig } = opts ?? {};
 
@@ -27,8 +50,7 @@ export async function buildFixture(opts?: BuildFixtureOptions): Promise<Rollup.R
     dts: false,
   } satisfies Parameters<typeof federation>[0];
 
-  // defu(overrides, defaults) — first arg wins for any key it provides
-  const mergedMfOptions = defu(mfOptions, defaultMfOptions);
+  const mergedMfOptions = mergeDefaults(mfOptions, defaultMfOptions);
 
   const defaultViteConfig: ViteUserConfig = {
     root: resolve(FIXTURES, fixture),
@@ -40,7 +62,7 @@ export async function buildFixture(opts?: BuildFixtureOptions): Promise<Rollup.R
     },
   };
 
-  const mergedViteConfig = defu(viteConfig, defaultViteConfig);
+  const mergedViteConfig = mergeDefaults(viteConfig, defaultViteConfig);
 
   const result = await build({
     ...mergedViteConfig,

--- a/integration/helpers/build.ts
+++ b/integration/helpers/build.ts
@@ -21,10 +21,10 @@ function isPlainObject(value: unknown): value is PlainObject {
   return Object.prototype.toString.call(value) === '[object Object]';
 }
 
-function mergeDefaults<T extends PlainObject>(overrides: Partial<T> | undefined, defaults: T): T {
-  const merged: PlainObject = { ...defaults };
+function mergeDefaults<T extends object>(overrides: Partial<T> | undefined, defaults: T): T {
+  const merged: PlainObject = { ...(defaults as PlainObject) };
 
-  for (const [key, value] of Object.entries(overrides ?? {})) {
+  for (const [key, value] of Object.entries((overrides ?? {}) as PlainObject)) {
     if (value === undefined || value === null) {
       continue;
     }

--- a/integration/remote-entry-isolation.test.ts
+++ b/integration/remote-entry-isolation.test.ts
@@ -11,7 +11,7 @@ const ISOLATION_MF_OPTIONS = {
     './shared': resolve(FIXTURES, 'shared-remote', 'exposed-module.js'),
   },
   shared: {
-    defu: {},
+    pathe: {},
   },
   dts: false,
 } satisfies Partial<ModuleFederationOptions>;

--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -17,17 +17,17 @@ describe('shared dependencies', () => {
   it('routes shared dep through loadShare()', async () => {
     const output = await buildFixture({
       fixture: 'shared-remote',
-      mfOptions: { ...SHARED_BASE_MF_OPTIONS, shared: { defu: {} } },
+      mfOptions: { ...SHARED_BASE_MF_OPTIONS, shared: { pathe: {} } },
     });
     const allCode = getAllChunkCode(output);
     expect(allCode).toContain('loadShare');
-    expect(allCode).toContain('defu');
+    expect(allCode).toContain('pathe');
   });
 
   it('keeps remoteEntry free of eager loadShare imports', async () => {
     const output = await buildFixture({
       fixture: 'shared-remote',
-      mfOptions: { ...SHARED_BASE_MF_OPTIONS, shared: { defu: {} } },
+      mfOptions: { ...SHARED_BASE_MF_OPTIONS, shared: { pathe: {} } },
     });
     const remoteEntry = findChunk(output, 'remoteEntry');
     expect(remoteEntry).toBeDefined();
@@ -41,7 +41,7 @@ describe('shared dependencies', () => {
       fixture: 'shared-remote',
       mfOptions: {
         ...SHARED_BASE_MF_OPTIONS,
-        shared: { defu: { singleton: true } },
+        shared: { pathe: { singleton: true } },
       },
     });
     const localSharedImportMap = findChunk(output, 'localSharedImportMap');
@@ -55,12 +55,12 @@ describe('shared dependencies', () => {
       fixture: 'shared-remote',
       mfOptions: {
         ...SHARED_BASE_MF_OPTIONS,
-        shared: { defu: { requiredVersion: '^6.0.0' } },
+        shared: { pathe: { requiredVersion: '^2.0.0' } },
       },
     });
     const localSharedImportMap = findChunk(output, 'localSharedImportMap');
     expect(localSharedImportMap).toBeDefined();
-    expect(localSharedImportMap!.code).toContain('^6.0.0');
+    expect(localSharedImportMap!.code).toContain('^2.0.0');
   });
 
   it('generates host-must-provide error when import is false', async () => {
@@ -68,7 +68,7 @@ describe('shared dependencies', () => {
       fixture: 'shared-remote',
       mfOptions: {
         ...SHARED_BASE_MF_OPTIONS,
-        shared: { defu: { import: false } },
+        shared: { pathe: { import: false } },
       },
     });
     const localSharedImportMap = findChunk(output, 'localSharedImportMap');
@@ -86,7 +86,7 @@ describe('shared dependencies', () => {
       mfOptions: {
         ...SHARED_BASE_MF_OPTIONS,
         manifest: true,
-        shared: { defu: {} },
+        shared: { pathe: {} },
       },
     });
     const manifest = parseManifest(output) as Record<string, unknown>;
@@ -94,9 +94,9 @@ describe('shared dependencies', () => {
     expect(manifest).toHaveProperty('shared');
 
     const shared = manifest.shared as Array<{ name: string; version: string }>;
-    const defuEntry = shared.find((s) => s.name === 'defu');
-    expect(defuEntry).toBeDefined();
-    expect(defuEntry!.version).toBeTruthy();
+    const patheEntry = shared.find((s) => s.name === 'pathe');
+    expect(patheEntry).toBeDefined();
+    expect(patheEntry!.version).toBeTruthy();
   });
 
   it('includes singleton in manifest shared entries', async () => {
@@ -105,15 +105,15 @@ describe('shared dependencies', () => {
       mfOptions: {
         ...SHARED_BASE_MF_OPTIONS,
         manifest: true,
-        shared: { defu: { singleton: true } },
+        shared: { pathe: { singleton: true } },
       },
     });
     const manifest = parseManifest(output) as Record<string, unknown>;
     expect(manifest).toBeDefined();
 
     const shared = manifest.shared as Array<{ name: string; singleton?: boolean }>;
-    const defuEntry = shared.find((s) => s.name === 'defu');
-    expect(defuEntry).toBeDefined();
-    expect(defuEntry?.singleton).toBe(true);
+    const patheEntry = shared.find((s) => s.name === 'pathe');
+    expect(patheEntry).toBeDefined();
+    expect(patheEntry?.singleton).toBe(true);
   });
 });

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@changesets/cli": "^2.30.0",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.3",
-    "defu": "^6.1.4",
     "husky": "^9.1.7",
     "oxfmt": "^0.36.0",
     "rollup": "^4.47.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "@module-federation/runtime": "2.3.3",
     "@module-federation/sdk": "2.3.3",
     "@rollup/pluginutils": "^5.3.0",
-    "defu": "^6.1.4",
     "es-module-lexer": "^2.0.0",
     "estree-walker": "^3.0.3",
     "magic-string": "^0.30.21",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@changesets/cli": "^2.30.0",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.3",
+    "defu": "^6.1.4",
     "husky": "^9.1.7",
     "oxfmt": "^0.36.0",
     "rollup": "^4.47.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@rollup/pluginutils':
         specifier: ^5.3.0
         version: 5.3.0(rollup@4.47.1)
-      defu:
-        specifier: ^6.1.4
-        version: 6.1.4
       es-module-lexer:
         specifier: ^2.0.0
         version: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
-      defu:
-        specifier: ^6.1.4
-        version: 6.1.4
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import defu from 'defu';
 import { readFileSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'pathe';
@@ -904,11 +903,9 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           find: '@module-federation/runtime',
           replacement: implementation,
         });
-        config.build = defu(config.build || {}, {
-          commonjsOptions: {
-            strictRequires: 'auto',
-          },
-        });
+        config.build ||= {};
+        config.build.commonjsOptions ||= {};
+        config.build.commonjsOptions.strictRequires ??= 'auto';
         const virtualDir = options.virtualModuleDir;
         config.optimizeDeps ||= {};
         config.optimizeDeps.include ||= [];
@@ -943,7 +940,8 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
 
         if (isRolldown) {
           // Vite 8+: virtual modules use ESM.
-          config.build = defu(config.build || {}, { target: 'esnext' });
+          config.build ??= {};
+          config.build.target ??= 'esnext';
         } else {
           // Vite 5-7: virtual modules use CJS for dev, need interop
           config.optimizeDeps.needsInterop ||= [];


### PR DESCRIPTION
Even thought `defu` is great, small and self-contained I think the current usage doesn't justify the additional dependency and we can drop it.