### PR TITLE
fix: ensure getInstance works by using runtime init (fixes #675)

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -270,8 +270,33 @@ describe('virtualRemoteEntry', () => {
     );
     // Shim must appear before any imports so it's defined when component code executes
     const shimIndex = code.indexOf('__VUE_HMR_RUNTIME__');
-    const importIndex = code.indexOf('import {createInstance');
+    const importIndex = code.indexOf('import {init as runtimeInit');
     expect(shimIndex).toBeLessThan(importIndex);
+  });
+
+  it('initializes remoteEntry through runtime init so getInstance can retrieve the host instance', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        remotes: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).toContain(
+      'import {init as runtimeInit, loadRemote} from "@module-federation/runtime";'
+    );
+    expect(code).toContain('const initRes = runtimeInit({');
+    expect(code).not.toContain('createInstance');
+    expect(code).not.toContain('let runtimeInstance');
   });
 
   it('retries transient shared init module loading failures in serve remoteEntry', async () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -315,7 +315,7 @@ export function generateRemoteEntry(
   if (typeof __VUE_HMR_RUNTIME__ === 'undefined') {
     globalThis.__VUE_HMR_RUNTIME__ = { createRecord() {}, rerender() {}, reload() {} };
   }
-  import {createInstance, loadRemote} from "@module-federation/runtime";
+  import {init as runtimeInit, loadRemote} from "@module-federation/runtime";
   ${pluginImportNames.map((item) => item[1]).join('\n')}
   ${
     command === 'build'
@@ -326,7 +326,6 @@ export function generateRemoteEntry(
   const initTokens = {}
   const shareScopeName = ${JSON.stringify(options.shareScope)}
   const mfName = ${JSON.stringify(options.internalName)}
-  let runtimeInstance
   let localSharedImportMapPromise
   let exposesMapPromise
   const shouldRetrySharedInitError = ${command !== 'build'} && ((error) => {
@@ -369,19 +368,13 @@ export function generateRemoteEntry(
   async function init(shared = {}, initScope = []) {
     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
     ${generateDirectSharedCacheSeedCode(command)}
-    const runtimeOptions = {
+    const initRes = runtimeInit({
       name: mfName,
       remotes: usedRemotes,
       shared: usedShared,
       plugins: [${pluginImportNames.map((item) => `${item[0]}(${item[2]})`).join(', ')}],
       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ''}
-    };
-    if (!runtimeInstance) {
-      runtimeInstance = createInstance(runtimeOptions);
-    } else {
-      runtimeInstance.initOptions(runtimeOptions);
-    }
-    const initRes = runtimeInstance;
+    });
     // handling circular init calls
     var initToken = initTokens[shareScopeName];
     if (!initToken)


### PR DESCRIPTION
Close #675

Replace createInstance-based initialization with runtimeInit in virtualRemoteEntry so the host instance can be correctly retrieved via getInstance.

This removes the internal runtimeInstance state and aligns with the runtime API, preventing duplicated or inaccessible instances in shared/singleton scenarios.

Added regression test to ensure remoteEntry is initialized through runtime init.