### PR TITLE
fix(vite): preserve singleton:true packages in excludeSharedSubDependencies

### DIFF
--- a/.changeset/lucky-lions-rest.md
+++ b/.changeset/lucky-lions-rest.md
@@ -1,0 +1,14 @@
+---
+"@module-federation/vite": patch
+---
+
+fix: preserve `singleton: true` shared packages in `excludeSharedSubDependencies`
+
+The dev-mode heuristic that auto-removes shared sub-dependencies (to prevent
+initialization-order issues such as `lit`/`lit-html`) was also silently removing
+packages explicitly declared with `singleton: true` — for example `react` and
+`react-dom` when a company SDK or wrapper library lists them in its `dependencies`.
+This caused multiple React instances to load across host and remotes, breaking all hooks.
+
+The fix adds a `singleton: true` guard alongside the existing `import: false` guard
+so that explicitly-declared singletons are never auto-excluded.

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -688,21 +688,21 @@ describe('pluginProxySharedModule_preBuild', () => {
         from: '',
         version: '3.3.2',
         scope: 'default',
-        shareConfig: { singleton: true, requiredVersion: '^3.3.2', strictVersion: false },
+        shareConfig: { singleton: false, requiredVersion: '^3.3.2', strictVersion: false },
       },
       'lit-element': {
         name: 'lit-element',
         from: '',
         version: '4.2.2',
         scope: 'default',
-        shareConfig: { singleton: true, requiredVersion: '^4.2.2', strictVersion: false },
+        shareConfig: { singleton: false, requiredVersion: '^4.2.2', strictVersion: false },
       },
       '@lit/reactive-element': {
         name: '@lit/reactive-element',
         from: '',
         version: '2.1.0',
         scope: 'default',
-        shareConfig: { singleton: true, requiredVersion: '^2.1.0', strictVersion: false },
+        shareConfig: { singleton: false, requiredVersion: '^2.1.0', strictVersion: false },
       },
     };
 
@@ -855,6 +855,130 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(shared).toHaveProperty('pinia');
     expect(consoleWarnSpy).not.toHaveBeenCalled();
 
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
+  it('preserves singleton: true shared sub-dependencies in dev mode without warning', () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    existsSyncMock.mockImplementation(
+      (p: string) => p === '/repo/apps/remote/node_modules/my-react-lib/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p === '/repo/apps/remote/node_modules/my-react-lib/package.json') {
+        return JSON.stringify({
+          name: 'my-react-lib',
+          dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0' },
+        });
+      }
+      return '{}';
+    });
+
+    const shared: NormalizedShared = {
+      'my-react-lib': {
+        name: 'my-react-lib',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: false, requiredVersion: '^1.0.0', strictVersion: false },
+      },
+      react: {
+        name: 'react',
+        from: '',
+        version: '18.3.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '^18.0.0', strictVersion: false },
+      },
+      'react-dom': {
+        name: 'react-dom',
+        from: '',
+        version: '18.3.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '^18.0.0', strictVersion: false },
+      },
+    };
+
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta() } as unknown as ConfigPluginContext,
+      config,
+      { command: 'serve', mode: 'development' } as ConfigEnv
+    );
+
+    expect(shared).toHaveProperty('my-react-lib');
+    expect(shared).toHaveProperty('react');
+    expect(shared).toHaveProperty('react-dom');
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
+  it('still removes non-singleton sub-dependencies when sibling singletons are preserved', () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    existsSyncMock.mockImplementation(
+      (p: string) => p === '/repo/apps/remote/node_modules/my-react-lib/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p === '/repo/apps/remote/node_modules/my-react-lib/package.json') {
+        return JSON.stringify({
+          name: 'my-react-lib',
+          dependencies: { react: '^18.0.0', 'some-util': '^1.0.0' },
+        });
+      }
+      return '{}';
+    });
+
+    const shared: NormalizedShared = {
+      'my-react-lib': {
+        name: 'my-react-lib',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: false, requiredVersion: '^1.0.0', strictVersion: false },
+      },
+      react: {
+        name: 'react',
+        from: '',
+        version: '18.3.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '^18.0.0', strictVersion: false },
+      },
+      'some-util': {
+        name: 'some-util',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: false, requiredVersion: '^1.0.0', strictVersion: false },
+      },
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta() } as unknown as ConfigPluginContext,
+      config,
+      { command: 'serve', mode: 'development' } as ConfigEnv
+    );
+
+    expect(shared).toHaveProperty('react');
+    expect(shared).not.toHaveProperty('some-util');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"some-util" is a dependency of shared package "my-react-lib"')
+    );
+
+    warnSpy.mockRestore();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
   });

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -127,7 +127,10 @@ function excludeSharedSubDependencies(shared: NormalizedShared): void {
     for (const dep of deps) {
       const depKey = sharedKeyByBase.get(dep);
       if (depKey && depKey !== parentKey) {
-        if (shared[depKey]?.shareConfig.import === false) {
+        if (
+          shared[depKey]?.shareConfig.singleton === true ||
+          shared[depKey]?.shareConfig.import === false
+        ) {
           continue;
         }
 


### PR DESCRIPTION
## Summary

Closes #680

`excludeSharedSubDependencies` is a dev-mode heuristic that auto-removes shared packages that are sub-dependencies of other shared packages, to prevent initialization-order issues (e.g. `lit` depending on `lit-html`).

However, the function was also silently removing packages explicitly declared with `singleton: true` — such as `react` and `react-dom` — when a company SDK or wrapper library lists them in its `dependencies`. This created multiple React instances across host and remotes, breaking all hooks with `Cannot read properties of null`.

The function already skips packages with `import: false`. This PR adds the same guard for `singleton: true`.

## Changes

- **`src/plugins/pluginProxySharedModule_preBuild.ts`** — one-line fix: add `singleton === true` guard in `excludeSharedSubDependencies`
- **`src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts`**:
  - Update existing `'excludes shared sub-dependencies in dev mode and warns'` test: change lit sub-packages from `singleton: true` → `singleton: false` (they were using `singleton: true` but asserting removal, which would now fail correctly)
  - Add `'preserves singleton: true shared sub-dependencies in dev mode without warning'` — asserts react/react-dom are NOT removed when a wrapper lib lists them as deps
  - Add `'still removes non-singleton sub-dependencies when sibling singletons are preserved'` — asserts the original lit-style behavior is preserved for non-singleton sub-deps
- **`.changeset/lucky-lions-rest.md`** — patch changeset

## Test plan

- [x] All 302 existing tests pass (`pnpm test`)
- [x] New tests cover: singleton sub-dep preserved, non-singleton sub-dep still removed
- [x] TypeScript type-check passes (`pnpm typecheck`)
- [x] Formatting check passes (`pnpm fmt.check`)