### PR TITLE
fix: support Yarn PnP for virtual module resolution

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,15 +7,16 @@ import type {
   UserConfig,
   ViteBuilder,
 } from 'vite';
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getLoadShareImportId,
   getLoadShareModulePath,
 } from '../virtualModules/virtualShared_preBuild';
 import type { PluginManifestOptions } from '../utils/normalizeModuleFederationOptions';
 
-const { hasPackageDependencyMock, mfWarn } = vi.hoisted(() => ({
+const { hasPackageDependencyMock, getIsYarnPnpMock, mfWarn } = vi.hoisted(() => ({
   hasPackageDependencyMock: vi.fn<(dependency: string) => boolean>((_dependency: string) => false),
+  getIsYarnPnpMock: vi.fn<() => boolean>(() => false),
   mfWarn: vi.fn(),
 }));
 
@@ -25,6 +26,7 @@ vi.mock('../utils/packageUtils', async () => {
   return {
     ...actual,
     hasPackageDependency: hasPackageDependencyMock,
+    getIsYarnPnp: getIsYarnPnpMock,
     setPackageDetectionCwd: vi.fn(),
   };
 });
@@ -886,6 +888,81 @@ describe('vite:module-federation-early-init', () => {
     expect(config.optimizeDeps.include).toContain('@module-federation/runtime');
     expect(config.optimizeDeps.include).not.toContain('__mf__virtual');
     expect(config.optimizeDeps.needsInterop).toBeUndefined();
+  });
+
+  describe('under Yarn PnP', () => {
+    beforeEach(() => {
+      getIsYarnPnpMock.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      getIsYarnPnpMock.mockReturnValue(false);
+    });
+
+    it('skips bare and virtual entries from optimizeDeps.include but keeps real packages', () => {
+      const plugin = getEarlyInitPlugin();
+      const config: any = {
+        root: process.cwd(),
+        optimizeDeps: {
+          include: [],
+        },
+      };
+
+      runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+        command: 'serve',
+        mode: 'test',
+      });
+
+      // Real packages (host's declared deps) still get included.
+      const include: string[] = config.optimizeDeps.include;
+      expect(include).not.toContain(virtualRuntimeInitStatus.getImportId());
+      expect(include).not.toContain(getPreBuildLibImportId('vue'));
+      expect(include).not.toContain(getLoadShareImportId('vue', false));
+      // No include entry should be a bare reference to the synthetic
+      // __mf__virtual package — Yarn PnP would reject it.
+      expect(include.some((entry) => entry === '__mf__virtual')).toBe(false);
+      expect(include.some((entry) => entry.startsWith('__mf__virtual/'))).toBe(false);
+    });
+
+    it('skips virtualDir bare include and needsInterop in non-Rolldown', () => {
+      const plugin = getModuleFederationVitePlugin();
+      const config: any = {
+        root: process.cwd(),
+        optimizeDeps: {
+          include: [],
+        },
+        resolve: {
+          alias: [],
+        },
+      };
+
+      runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+        command: 'serve',
+        mode: 'test',
+      });
+
+      expect(config.optimizeDeps.include).toContain('@module-federation/runtime');
+      expect(config.optimizeDeps.include).not.toContain('__mf__virtual');
+      expect(config.optimizeDeps.needsInterop).toBeUndefined();
+    });
+
+    it('still excludes bare remote ids from optimizeDeps under PnP', () => {
+      const plugin = getEarlyInitPlugin();
+      const config: any = {
+        root: process.cwd(),
+        optimizeDeps: {
+          include: [],
+          exclude: [],
+        },
+      };
+
+      runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+        command: 'serve',
+        mode: 'test',
+      });
+
+      expect(config.optimizeDeps.exclude).toContain('remoteApp');
+    });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,12 @@ import type {
 } from './utils/normalizeModuleFederationOptions';
 import { normalizeModuleFederationOptions } from './utils/normalizeModuleFederationOptions';
 import normalizeOptimizeDepsPlugin from './utils/normalizeOptimizeDeps';
-import { getIsRolldown, hasPackageDependency, setPackageDetectionCwd } from './utils/packageUtils';
+import {
+  getIsRolldown,
+  getIsYarnPnp,
+  hasPackageDependency,
+  setPackageDetectionCwd,
+} from './utils/packageUtils';
 import { getCommonSharedSubpaths } from './utils/pathNormalization';
 import VirtualModule, { initVirtualModuleInfrastructure } from './utils/VirtualModule';
 import {
@@ -214,6 +219,7 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
       initVirtualModules(_command, getRemoteEntryId(options));
 
       const isRolldown = getIsRolldown(this);
+      const isYarnPnp = getIsYarnPnp();
 
       // Eagerly register configured remotes before localSharedImportMap is
       // first written. In build, remoteEntry can be traced before app modules
@@ -302,7 +308,9 @@ export default __mfShared.default ?? __mfShared;`,
           }
           // Include the runtimeInit virtual module so Vite pre-bundles it
           // upfront instead of discovering it at runtime via loadShare imports.
-          config.optimizeDeps.include.push(virtualRuntimeInitStatus.getImportId());
+          if (!isYarnPnp) {
+            config.optimizeDeps.include.push(virtualRuntimeInitStatus.getImportId());
+          }
         }
         for (const key of Object.keys(shared)) {
           const shareItem: ShareItem = shared[key];
@@ -313,7 +321,9 @@ export default __mfShared.default ?? __mfShared;`,
               for (const subpath of getCommonSharedSubpaths(key)) {
                 writePreBuildLibPath(subpath, shareItem);
                 optimizeDeps.include.push(subpath);
-                optimizeDeps.include.push(getPreBuildLibImportId(subpath));
+                if (!isYarnPnp) {
+                  optimizeDeps.include.push(getPreBuildLibImportId(subpath));
+                }
               }
             }
             continue;
@@ -342,16 +352,20 @@ export default __mfShared.default ?? __mfShared;`,
             if (shouldBypassOptimizeDep) {
               optimizeDeps.exclude.push(key);
             }
-            if (!isRolldown && !shouldBypassOptimizeDep) {
+            if (!isRolldown && !shouldBypassOptimizeDep && !isYarnPnp) {
               // In non-Rolldown Vite (< 8), loadShare modules are CJS, so the
               // dep optimizer handles them fine.
               optimizeDeps.include.push(getLoadShareImportId(key, isRolldown));
             }
-            optimizeDeps.include.push(getPreBuildLibImportId(key));
+            if (!isYarnPnp) {
+              optimizeDeps.include.push(getPreBuildLibImportId(key));
+            }
             for (const subpath of getCommonSharedSubpaths(key)) {
               writePreBuildLibPath(subpath, shareItem);
               optimizeDeps.include.push(subpath);
-              optimizeDeps.include.push(getPreBuildLibImportId(subpath));
+              if (!isYarnPnp) {
+                optimizeDeps.include.push(getPreBuildLibImportId(subpath));
+              }
             }
           }
         }
@@ -789,6 +803,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       _options: options,
       config(config: UserConfig, { command: _command }: { command: string }) {
         const isRolldown = getIsRolldown(this);
+        const isYarnPnp = getIsYarnPnp();
 
         // For Vite 8+, resolve to ESM entry
         // because Vite 8's internal bundler cannot parse dynamic import() in .cjs files
@@ -808,7 +823,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         config.optimizeDeps ||= {};
         config.optimizeDeps.include ||= [];
         config.optimizeDeps.include.push('@module-federation/runtime');
-        if (!isRolldown) {
+        if (!isRolldown && !isYarnPnp) {
           config.optimizeDeps.include.push(virtualDir);
         }
 
@@ -842,8 +857,10 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           // Vite 8+: virtual modules use ESM.
           config.build ??= {};
           config.build.target ??= 'esnext';
-        } else {
-          // Vite 5-7: virtual modules use CJS for dev, need interop
+        } else if (!isYarnPnp) {
+          // Vite 5-7: virtual modules use CJS for dev, need interop. Skip
+          // under Yarn PnP — virtuals aren't pre-bundled there, and the
+          // bare-name pattern wouldn't match the absolute paths we emit.
           config.optimizeDeps.needsInterop ||= [];
           config.optimizeDeps.needsInterop.push(virtualDir);
         }

--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, writeFile, writeFileSync } from 'fs';
 import { dirname, join, parse, resolve, basename } from 'pathe';
-import { packageNameDecode, packageNameEncode } from '../utils/packageUtils';
+import { getIsYarnPnp, packageNameDecode, packageNameEncode } from '../utils/packageUtils';
 import { createModuleFederationError } from './logger';
 import { getNormalizeModuleFederationOptions } from './normalizeModuleFederationOptions';
 
@@ -65,10 +65,6 @@ export function getSuffix(name: string): string {
   return '.js';
 }
 
-const patternMap: {
-  [tag: string]: RegExp;
-} = {};
-
 const cacheMap: {
   [tag: string]: {
     [name: string]: VirtualModule;
@@ -124,12 +120,26 @@ export default class VirtualModule {
   }
 
   static findModule(tag: string, str: string = ''): VirtualModule | undefined {
-    if (!patternMap[tag])
-      patternMap[tag] = new RegExp(`(.*${packageNameEncode(tag)}(.+?)${packageNameEncode(tag)}.*)`);
-    const moduleName = (str.match(patternMap[tag]) || [])[2];
-    if (moduleName)
-      return cacheMap[tag][packageNameDecode(moduleName)] as VirtualModule | undefined;
-    return undefined;
+    const tagModules = cacheMap[tag];
+    if (!tagModules) return undefined;
+
+    // Filenames have shape `<encode(mfName)><tag><encode(name)><suffix>`,
+    // possibly prefixed by a directory and possibly suffixed by a Vite query
+    // string. Reduce the input to the encoded core, then peel off the known
+    // `<encode(mfName)><tag>` prefix to recover the package name. No regex;
+    // encoding is char-wise and tags don't contain `@/-.`, so prefix matching
+    // is unambiguous.
+    const cleaned = str.split('?')[0];
+    const filename = basename(cleaned);
+    const lastDot = filename.lastIndexOf('.');
+    const core = lastDot > 0 ? filename.slice(0, lastDot) : filename;
+
+    const { internalName: mfName } = getNormalizeModuleFederationOptions();
+    const prefix = packageNameEncode(mfName) + tag;
+    if (!core.startsWith(prefix)) return undefined;
+
+    const encodedName = core.slice(prefix.length);
+    return tagModules[packageNameDecode(encodedName)] as VirtualModule | undefined;
   }
 
   constructor(name: string, tag: string = '__mf_v__', suffix = '') {
@@ -140,13 +150,21 @@ export default class VirtualModule {
     cacheMap[this.tag][this.name] = this;
   }
 
+  private getRelativeId() {
+    const { internalName: mfName, virtualModuleDir } = getNormalizeModuleFederationOptions();
+    return `${virtualModuleDir}/${packageNameEncode(mfName)}${this.tag}${packageNameEncode(this.name)}${this.suffix}`;
+  }
+
   getPath() {
-    return resolve(getNodeModulesDir(), this.getImportId());
+    return resolve(getNodeModulesDir(), this.getRelativeId());
   }
 
   getImportId() {
-    const { internalName: mfName, virtualModuleDir } = getNormalizeModuleFederationOptions();
-    return `${virtualModuleDir}/${packageNameEncode(`${mfName}${this.tag}${this.name}${this.tag}`)}${this.suffix}`;
+    // Under Yarn PnP, bare specifiers must be declared dependencies — the
+    // synthetic `__mf__virtual` package isn't, so referencing it by name fails.
+    // Use the absolute on-disk path instead, which bypasses PnP's manifest.
+    if (getIsYarnPnp()) return this.getPath();
+    return this.getRelativeId();
   }
 
   writeSync(code: string, force?: boolean) {

--- a/src/utils/__tests__/VirtualModule.test.ts
+++ b/src/utils/__tests__/VirtualModule.test.ts
@@ -55,6 +55,54 @@ describe('assertModuleFound', () => {
   });
 });
 
+describe('VirtualModule.findModule', () => {
+  beforeEach(() => {
+    normalizeModuleFederationOptions({ name: 'host' });
+  });
+
+  it('resolves a module from a bare specifier', () => {
+    const vm = new VirtualModule('react', '__loadShare__', '.mjs');
+    const id = vm.getImportId();
+    expect(VirtualModule.findModule('__loadShare__', id)).toBe(vm);
+  });
+
+  it('resolves a module from an absolute path', () => {
+    const vm = new VirtualModule('react', '__loadShare__', '.mjs');
+    expect(VirtualModule.findModule('__loadShare__', vm.getPath())).toBe(vm);
+  });
+
+  it('strips Vite-style query strings before lookup', () => {
+    const vm = new VirtualModule('react', '__loadShare__', '.mjs');
+    const idWithQuery = `${vm.getImportId()}?import&v=abc`;
+    expect(VirtualModule.findModule('__loadShare__', idWithQuery)).toBe(vm);
+  });
+
+  it('returns undefined when the tag does not match the registered module', () => {
+    new VirtualModule('react', '__loadShare__', '.mjs');
+    const vmPrebuild = new VirtualModule('react', '__prebuild__', '.js');
+    // Looking up the prebuild file under the loadShare tag must fail.
+    expect(VirtualModule.findModule('__loadShare__', vmPrebuild.getImportId())).toBeUndefined();
+  });
+
+  it('returns undefined when the input does not encode a known module', () => {
+    expect(VirtualModule.findModule('__loadShare__', 'totally-unrelated-string')).toBeUndefined();
+  });
+
+  it('decodes encoded subpath names like react/jsx-runtime', () => {
+    const vm = new VirtualModule('react/jsx-runtime', '__prebuild__', '.js');
+    expect(VirtualModule.findModule('__prebuild__', vm.getImportId())).toBe(vm);
+  });
+
+  it('round-trips package names that themselves contain the tag substring', () => {
+    // Names like `pkg-with__prebuild__inside` are technically valid npm names.
+    // The old regex-based parser would have mis-captured these; structural
+    // prefix matching anchors on the known mfName/tag and recovers the full
+    // suffix as the package name.
+    const vm = new VirtualModule('pkg-with__prebuild__inside', '__prebuild__', '.js');
+    expect(VirtualModule.findModule('__prebuild__', vm.getImportId())).toBe(vm);
+  });
+});
+
 describe('VirtualModule writeSync', () => {
   it('creates missing virtual module directories before writing', () => {
     const root = mkdtempSync(join(tmpdir(), 'mf-vm-'));
@@ -70,6 +118,77 @@ describe('VirtualModule writeSync', () => {
 
       expect(existsSync(vm.getPath())).toBe(true);
       expect(readFileSync(vm.getPath(), 'utf8')).toBe('export default 1;');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('VirtualModule getImportId', () => {
+  const originalPnp = (process.versions as { pnp?: string }).pnp;
+
+  afterEach(() => {
+    if (originalPnp === undefined) {
+      delete (process.versions as { pnp?: string }).pnp;
+    } else {
+      (process.versions as { pnp?: string }).pnp = originalPnp;
+    }
+  });
+
+  it('returns the bare specifier outside Yarn PnP', () => {
+    delete (process.versions as { pnp?: string }).pnp;
+
+    const root = mkdtempSync(join(tmpdir(), 'mf-vm-'));
+    try {
+      mkdirSync(join(root, 'node_modules'), { recursive: true });
+      normalizeModuleFederationOptions({ name: 'host' });
+      VirtualModule.setRoot(root);
+
+      const vm = new VirtualModule('react', '__loadShare__', '.mjs');
+      const id = vm.getImportId();
+
+      expect(id.startsWith('__mf__virtual/')).toBe(true);
+      expect(id.endsWith('.mjs')).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the absolute path under Yarn PnP so PnP cannot reject the bare specifier', () => {
+    (process.versions as { pnp?: string }).pnp = '3.0.0';
+
+    const root = mkdtempSync(join(tmpdir(), 'mf-vm-'));
+    try {
+      mkdirSync(join(root, 'node_modules'), { recursive: true });
+      normalizeModuleFederationOptions({ name: 'host' });
+      VirtualModule.setRoot(root);
+
+      const vm = new VirtualModule('react', '__loadShare__', '.mjs');
+      const id = vm.getImportId();
+
+      expect(id).toBe(vm.getPath());
+      expect(id.startsWith('__mf__virtual/')).toBe(false);
+      // The encoded module name is still embedded in the absolute path so
+      // VirtualModule.findModule's tag-based regex still matches it.
+      expect(id).toContain('__loadShare__');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still resolves the encoded module via findModule when the id is an absolute path', () => {
+    (process.versions as { pnp?: string }).pnp = '3.0.0';
+
+    const root = mkdtempSync(join(tmpdir(), 'mf-vm-'));
+    try {
+      mkdirSync(join(root, 'node_modules'), { recursive: true });
+      normalizeModuleFederationOptions({ name: 'host' });
+      VirtualModule.setRoot(root);
+
+      const vm = new VirtualModule('react', '__loadShare__', '.mjs');
+      const id = vm.getImportId();
+
+      expect(VirtualModule.findModule('__loadShare__', id)).toBe(vm);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/utils/__tests__/cssModuleHelpers.test.ts
+++ b/src/utils/__tests__/cssModuleHelpers.test.ts
@@ -275,11 +275,13 @@ describe('cssModuleHelpers', () => {
       vi.mock('../normalizeModuleFederationOptions', () => ({
         getNormalizeModuleFederationOptions: vi.fn(() => ({
           name: 'test-app',
+          internalName: '__mfe_internal__test_mf_2_app',
           virtualModuleDir: '__mf_virtual_test',
           bundleAllCSS: false,
         })),
         normalizeModuleFederationOptions: vi.fn((options) => ({
           name: 'test-app',
+          internalName: '__mfe_internal__test_mf_2_app',
           virtualModuleDir: '__mf_virtual_test',
           bundleAllCSS: options.bundleAllCSS || false,
         })),

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   getInstalledPackageEntry,
   getInstalledPackageJson,
+  getIsYarnPnp,
   getPackageNameFromNodeModulePath,
 } from '../packageUtils';
 
@@ -94,5 +95,27 @@ describe('getPackageNameFromNodeModulePath', () => {
 
   it('returns undefined for non-node_modules paths', () => {
     expect(getPackageNameFromNodeModulePath('/repo/vendor/vue.js')).toBeUndefined();
+  });
+});
+
+describe('getIsYarnPnp', () => {
+  const originalPnp = (process.versions as { pnp?: string }).pnp;
+
+  afterEach(() => {
+    if (originalPnp === undefined) {
+      delete (process.versions as { pnp?: string }).pnp;
+    } else {
+      (process.versions as { pnp?: string }).pnp = originalPnp;
+    }
+  });
+
+  it('returns false when process.versions.pnp is unset', () => {
+    delete (process.versions as { pnp?: string }).pnp;
+    expect(getIsYarnPnp()).toBe(false);
+  });
+
+  it('returns true when process.versions.pnp is set', () => {
+    (process.versions as { pnp?: string }).pnp = '3.0.0';
+    expect(getIsYarnPnp()).toBe(true);
   });
 });

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -277,6 +277,17 @@ export function getExtFromNpmPackage(packageString: string) {
 }
 
 /**
+ * Detect Yarn Plug'n'Play. Under PnP, bare specifier resolution is governed by
+ * `.pnp.cjs` and rejects packages that aren't declared dependencies — so the
+ * synthetic `node_modules/__mf__virtual/` package can't be imported by name.
+ * Callers reference virtual files by absolute path under PnP and skip pushing
+ * their bare specifiers into `optimizeDeps.include`.
+ */
+export function getIsYarnPnp(): boolean {
+  return !!(process.versions as { pnp?: string }).pnp;
+}
+
+/**
  * Detect whether the current runtime is Vite 8+ by checking for a Vite version flag
  * on the plugin hook context, with Rolldown metadata kept as a compatibility fallback.
  */


### PR DESCRIPTION
I thought I'm gonna take a stab at this 🙈 

- Detect PnP via `process.versions.pnp`. Under PnP, `VirtualModule.getImportId()` returns the absolute on-disk path instead of the bare `__mf__virtual/...` specifier — bypassing PnP's manifest entirely.
- Skip the bare/virtual entries from `optimizeDeps.include` and needsInterop under PnP (real packages and the dynamic optimize-shared-proxy esbuild plugin still cover them).
- Replaced the regex parser in `findModule` with structural prefix matching (<encode(mfName)><tag> anchor). Same behavior on common cases, strictly more correct on edge cases where a package name contains a tag-like substring.

Fixes [#693](https://github.com/module-federation/vite/issues/693).