### PR TITLE
revert: replace deprecated init helper

### DIFF
--- a/examples/vite-webpack-rspack/host/src/App.tsx
+++ b/examples/vite-webpack-rspack/host/src/App.tsx
@@ -1,3 +1,4 @@
+import { registerRemotes } from '@module-federation/runtime';
 import React, { lazy, StrictMode, Suspense, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Footer } from './components/Footer';
@@ -5,7 +6,6 @@ import { Header } from './components/Header';
 import { Toggle } from './components/Toggle';
 import { useDynamicImport } from './hooks/useDynamicImport';
 import './index.css';
-import { mfRuntime } from './mfRuntime';
 
 import _ from 'lodash';
 _.VERSION;
@@ -63,7 +63,9 @@ const TestsScreen = lazyWithRetry(
     import('testsRemote/TestsScreen')
 );
 
-mfRuntime.registerRemotes([
+// if module federation is already setup through plugin in vite.config.js,
+// there is no need to call init() from '@module-federation/runtime' here
+registerRemotes([
   {
     name: 'dynamicRemote',
     entry: 'http://localhost:4002/remoteEntry.js',

--- a/examples/vite-webpack-rspack/host/src/hooks/useDynamicImport.tsx
+++ b/examples/vite-webpack-rspack/host/src/hooks/useDynamicImport.tsx
@@ -1,5 +1,5 @@
+import { loadRemote } from '@module-federation/runtime';
 import { ElementType, useEffect, useState } from 'react';
-import { mfRuntime } from '../mfRuntime';
 
 interface DynamicImportProps {
   module: string;
@@ -12,7 +12,7 @@ async function loadRemoteWithRetry(id: string, retries = 20, delayMs = 500) {
   let lastError: unknown;
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
-      return await mfRuntime.loadRemote(id);
+      return await loadRemote(id);
     } catch (error) {
       lastError = error;
       if (attempt < retries) {

--- a/examples/vite-webpack-rspack/host/src/main.jsx
+++ b/examples/vite-webpack-rspack/host/src/main.jsx
@@ -1,3 +1,8 @@
-import './mfRuntime';
+import { init } from '@module-federation/runtime';
+
+init({
+  name: 'host',
+  remotes: [],
+});
 
 import('./App');

--- a/examples/vite-webpack-rspack/host/src/mfRuntime.js
+++ b/examples/vite-webpack-rspack/host/src/mfRuntime.js
@@ -1,6 +1,0 @@
-import { createInstance } from '@module-federation/runtime';
-
-export const mfRuntime = createInstance({
-  name: 'host',
-  remotes: [],
-});

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -270,7 +270,7 @@ describe('virtualRemoteEntry', () => {
     );
     // Shim must appear before any imports so it's defined when component code executes
     const shimIndex = code.indexOf('__VUE_HMR_RUNTIME__');
-    const importIndex = code.indexOf('import {createInstance');
+    const importIndex = code.indexOf('import {init as runtimeInit');
     expect(shimIndex).toBeLessThan(importIndex);
   });
 

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -315,7 +315,7 @@ export function generateRemoteEntry(
   if (typeof __VUE_HMR_RUNTIME__ === 'undefined') {
     globalThis.__VUE_HMR_RUNTIME__ = { createRecord() {}, rerender() {}, reload() {} };
   }
-  import {createInstance, loadRemote} from "@module-federation/runtime";
+  import {init as runtimeInit, loadRemote} from "@module-federation/runtime";
   ${pluginImportNames.map((item) => item[1]).join('\n')}
   ${
     command === 'build'
@@ -326,7 +326,6 @@ export function generateRemoteEntry(
   const initTokens = {}
   const shareScopeName = ${JSON.stringify(options.shareScope)}
   const mfName = ${JSON.stringify(options.internalName)}
-  let runtimeInstance
   let localSharedImportMapPromise
   let exposesMapPromise
   const shouldRetrySharedInitError = ${command !== 'build'} && ((error) => {
@@ -369,19 +368,13 @@ export function generateRemoteEntry(
   async function init(shared = {}, initScope = []) {
     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
     ${generateDirectSharedCacheSeedCode(command)}
-    const runtimeOptions = {
+    const initRes = runtimeInit({
       name: mfName,
       remotes: usedRemotes,
       shared: usedShared,
       plugins: [${pluginImportNames.map((item) => `${item[0]}(${item[2]})`).join(', ')}],
       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ''}
-    };
-    if (!runtimeInstance) {
-      runtimeInstance = createInstance(runtimeOptions);
-    } else {
-      runtimeInstance.initOptions(runtimeOptions);
-    }
-    const initRes = runtimeInstance;
+    });
     // handling circular init calls
     var initToken = initTokens[shareScopeName];
     if (!initToken)


### PR DESCRIPTION
Close #675

Reverts module-federation/vite#658

Deprecation has been reverted in https://github.com/module-federation/core/pull/4703 so It's safer to undo this change as well.