### PR TITLE
fix: skip host cache seeding for `import:false` modules during build

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -441,4 +441,75 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('await import("/repo/node_modules/wildcard-pkg/dist/button.js")');
     expect(code).not.toContain('__mfModuleCache.share["wildcard-pkg"]');
   });
+
+  it('does not seed import:false shared modules in hostAutoInit during build', async () => {
+    normalizedSharedMock.mockReturnValue({
+      vue: {
+        name: 'vue',
+        from: '',
+        version: '3.5.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          import: false,
+          requiredVersion: '^3.5.0',
+          strictVersion: false,
+        },
+      },
+      'some-dep': {
+        name: 'some-dep',
+        from: '',
+        version: '4.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          import: false,
+          requiredVersion: '^4.0.0',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('vue');
+    mod.addUsedShares('some-dep');
+
+    const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
+
+    // Build mode must NOT generate static imports for import:false modules
+    // to avoid bundler resolution failures on transitive dependencies.
+    expect(code).not.toContain('__mfModuleCache.share["some-dep"] === undefined');
+    expect(code).not.toContain('__mfModuleCache.share["vue"] === undefined');
+    expect(code).not.toContain('some-dep/dist');
+    // The runtime.loadShare loop should still be present
+    expect(code).toContain('runtime.loadShare(pkg');
+  });
+
+  it('seeds import:false shared modules in hostAutoInit during serve', async () => {
+    normalizedSharedMock.mockReturnValue({
+      'some-dep': {
+        name: 'some-dep',
+        from: '',
+        version: '4.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          import: false,
+          requiredVersion: '^4.0.0',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('some-dep');
+
+    const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'serve');
+
+    // Serve mode should still pre-seed the cache (dev server resolves on-demand)
+    expect(code).toContain('__mfModuleCache.share["some-dep"]');
+    expect(code).toContain('await import');
+  });
 });

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -270,7 +270,13 @@ function getHostAutoInitSharedSeedItems() {
     });
 }
 
-function generateHostAutoInitSharedCacheSeedCode() {
+function generateHostAutoInitSharedCacheSeedCode(command = 'build') {
+  // In build mode, skip seeding for import:false modules. The bundler would
+  // attempt to resolve their transitive dependencies which may not be
+  // accessible (e.g. under pnpm strict mode). The runtime.loadShare() loop
+  // that follows will handle acquiring these modules at runtime instead.
+  if (command === 'build') return '';
+
   return getHostAutoInitSharedSeedItems()
     .map(({ pkg, shareItem }) => {
       if (!shareItem) return null;
@@ -431,7 +437,7 @@ export function generateHostAutoInitCode(remoteEntryImport: string, _command = '
     async function initHost() {
       if (!hostInitPromise) {
         hostInitPromise = (async () => {
-          ${generateHostAutoInitSharedCacheSeedCode()}
+          ${generateHostAutoInitSharedCacheSeedCode(_command)}
           const remoteEntry = await import(${remoteEntryImport});
           const runtime = await remoteEntry.init();
           const usedShared = ${generateUsedSharedPreloadConfig()};


### PR DESCRIPTION
In build mode, `generateHostAutoInitSharedCacheSeedCode` was emitting static `import()` calls for shared modules with `import: false`. This caused the bundler to resolve those modules and their transitive dependencies, which fails under strict package managers like pnpm where transitive deps are not hoisted.

The fix skips cache seeding in build mode for `import:false` modules. The `runtime.loadShare()` loop that follows will handle acquiring these modules at runtime instead. Serve mode is unaffected since Vite's dev server resolves on-demand without requiring all transitive deps to be available at build time.

See here for a simple reproducer: https://github.com/JammingBen/mf-vite-seed-repro