### PR TITLE
fix: restore async loadShare fallback for import:false shared modules

### DIFF
--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -96,7 +96,8 @@ describe('shared dependencies', () => {
     expect(remoteEntry).toBeDefined();
     expect(loadShare).toBeDefined();
     expect(remoteEntry!.code).toContain('const versions =');
-    expect(remoteEntry!.code).toContain('shared[pkg]');
+    expect(remoteEntry!.code).toContain('[pkg]');
+    expect(remoteEntry!.code).toContain('const provider = versions && versions[Object.keys(versions)[0]]');
     expect(remoteEntry!.code).toContain('__mfModuleCache.share[pkg]');
     expect(remoteEntry!.code).not.toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');

--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -80,6 +80,33 @@ describe('shared dependencies', () => {
     expect(localSharedImportMap!.code).toContain('import: false');
   });
 
+  it('supports import:false named imports with runtime-registered host shares', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: {
+        ...SHARED_BASE_MF_OPTIONS,
+        shared: { pathe: { import: false, singleton: true } },
+      },
+    });
+
+    const allCode = getAllChunkCode(output);
+    const remoteEntry = findChunk(output, 'remoteEntry');
+    const loadShare = findChunk(output, /loadShare.*pathe/);
+
+    expect(remoteEntry).toBeDefined();
+    expect(loadShare).toBeDefined();
+    expect(remoteEntry!.code).toContain('const versions =');
+    expect(remoteEntry!.code).toContain('shared[pkg]');
+    expect(remoteEntry!.code).toContain('__mfModuleCache.share[pkg]');
+    expect(remoteEntry!.code).not.toContain('initRes.loadShare(pkg');
+    expect(loadShare!.code).toContain('initPromise.then');
+    expect(loadShare!.code).toContain('__mfModuleCache.share["pathe"]');
+    expect(loadShare!.code).toContain('join');
+    expect(loadShare!.code).not.toContain('await initPromise');
+    expect(allCode).not.toContain('from"pathe"');
+    expect(allCode).not.toContain('from "pathe"');
+  });
+
   it('includes shared deps in manifest', async () => {
     const output = await buildFixture({
       fixture: 'shared-remote',

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -310,7 +310,7 @@ describe('normalizeModuleFederationOption', () => {
       // Should resolve version from react's package.json
       expect(result['react'].version).toBeDefined();
       expect(result['react'].version).not.toBe('0');
-      expect(result['react'].shareConfig.requiredVersion).toMatch(/^\^/);
+      expect(result['react'].shareConfig.requiredVersion).toBe('*');
       expect(result['react'].shareConfig.import).toBe(false);
       expect(result['react'].shareConfig.singleton).toBe(true);
     });

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -251,7 +251,8 @@ function normalizeShareItem(
     shareConfig: {
       import: shareItem.import,
       singleton: shareItem.singleton || false,
-      requiredVersion: shareItem.requiredVersion || (version ? `^${version}` : '*'),
+      requiredVersion:
+        shareItem.requiredVersion || (isImportFalse ? '*' : version ? `^${version}` : '*'),
       strictVersion: !!shareItem.strictVersion,
     },
   };

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -368,6 +368,64 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
   });
 
+  it('loads import:false shared modules during remoteEntry init', async () => {
+    normalizedSharedMock.mockReturnValue({
+      'host-only-dep': {
+        name: 'host-only-dep',
+        from: '',
+        version: '4.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          import: false,
+          requiredVersion: '^4.0.0',
+          strictVersion: false,
+        },
+      },
+      'local-dep': {
+        name: 'local-dep',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^1.0.0',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('host-only-dep');
+    mod.addUsedShares('local-dep');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        remotes: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+
+    const importFalseSection = code.slice(
+      code.indexOf('const importFalseShared ='),
+      code.indexOf('for (const [pkg, share] of Object.entries(importFalseShared))')
+    );
+
+    expect(code).toContain('const importFalseShared =');
+    expect(importFalseSection).toContain('"host-only-dep"');
+    expect(importFalseSection).not.toContain('"local-dep"');
+    expect(code).toContain('await initRes.loadShare(pkg');
+    expect(code).toContain('__mfModuleCache.share[pkg] = resolved');
+  });
+
   it('does not eagerly preload remotes during host auto init', async () => {
     usedRemotesMapMock.mockReturnValue({
       remote: new Set(['remote', 'remote/remote-app']),

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -364,6 +364,9 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('const {usedShared, usedRemotes} = await getLocalSharedImportMap()');
     expect(code).toContain('const exposesMap = await getExposesMap()');
     expect(code).toContain('const mfName = "__mfe_internal__host"');
+    expect(code).toContain('share.shareConfig?.import !== false');
+    expect(code).toContain('const versions = shared?.[pkg]');
+    expect(code).not.toContain('initRes.loadShare(pkg');
     expect(code).not.toContain('import exposesMap from');
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
   });

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -368,64 +368,6 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
   });
 
-  it('loads import:false shared modules during remoteEntry init', async () => {
-    normalizedSharedMock.mockReturnValue({
-      'host-only-dep': {
-        name: 'host-only-dep',
-        from: '',
-        version: '4.0.0',
-        scope: 'default',
-        shareConfig: {
-          singleton: true,
-          import: false,
-          requiredVersion: '^4.0.0',
-          strictVersion: false,
-        },
-      },
-      'local-dep': {
-        name: 'local-dep',
-        from: '',
-        version: '1.0.0',
-        scope: 'default',
-        shareConfig: {
-          singleton: true,
-          requiredVersion: '^1.0.0',
-          strictVersion: false,
-        },
-      },
-    });
-    const mod = await import('../virtualRemoteEntry');
-
-    mod.getUsedShares().clear();
-    mod.addUsedShares('host-only-dep');
-    mod.addUsedShares('local-dep');
-
-    const code = mod.generateRemoteEntry(
-      {
-        internalName: '__mfe_internal__remote',
-        name: 'remote',
-        filename: 'remoteEntry.js',
-        remotes: {},
-        runtimePlugins: [],
-        shareScope: 'default',
-        shareStrategy: 'version-first',
-      } as any,
-      'virtual:exposes',
-      'build'
-    );
-
-    const importFalseSection = code.slice(
-      code.indexOf('const importFalseShared ='),
-      code.indexOf('for (const [pkg, share] of Object.entries(importFalseShared))')
-    );
-
-    expect(code).toContain('const importFalseShared =');
-    expect(importFalseSection).toContain('"host-only-dep"');
-    expect(importFalseSection).not.toContain('"local-dep"');
-    expect(code).toContain('await initRes.loadShare(pkg');
-    expect(code).toContain('__mfModuleCache.share[pkg] = resolved');
-  });
-
   it('does not eagerly preload remotes during host auto init', async () => {
     usedRemotesMapMock.mockReturnValue({
       remote: new Set(['remote', 'remote/remote-app']),

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -717,8 +717,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('export *');
     expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
-    expect(generatedCode).toContain('await initPromise');
-    expect(generatedCode).toContain('shareScopeMap');
+    expect(generatedCode).not.toContain('await ');
     expect(generatedCode).toContain('export default exportModule');
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -717,8 +717,9 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('export *');
     expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
-    expect(generatedCode).toContain('await initPromise');
-    expect(generatedCode).toContain('shareScopeMap');
+    expect(generatedCode).not.toContain('await ');
+    expect(generatedCode).not.toContain('initPromise');
+    expect(generatedCode).not.toContain('shareScopeMap');
     expect(generatedCode).toContain('export default exportModule');
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -717,7 +717,8 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('export *');
     expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
-    expect(generatedCode).not.toContain('await ');
+    expect(generatedCode).toContain('await initPromise');
+    expect(generatedCode).toContain('shareScopeMap');
     expect(generatedCode).toContain('export default exportModule');
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -691,7 +691,7 @@ describe('writeLoadShareModule', () => {
     // Should not have export * (no local source to re-export from)
     expect(generatedCode).not.toContain('export *');
     expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
-    expect(generatedCode).toContain('export default exportModule.default ?? exportModule');
+    expect(generatedCode).toContain('export { __mf_default as default }');
   });
 
   it('does not reference prebuild modules when import: false in build mode', () => {
@@ -718,7 +718,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('export *');
     expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
     expect(generatedCode).not.toContain('await ');
-    expect(generatedCode).toContain('export default exportModule');
+    expect(generatedCode).toContain('export { __mf_default as default }');
   });
 
   it('generates named re-exports for import: false when package is installed as devDependency', () => {
@@ -749,7 +749,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('__mf_0 as delete');
     expect(generatedCode).toContain('__mf_1 as get');
     expect(generatedCode).toContain('__mf_2 as request');
-    expect(generatedCode).toContain('export default exportModule');
+    expect(generatedCode).toContain('export { __mf_default as default }');
   });
 
   it('prefers browser conditional exports when detecting shared ESM named exports', () => {
@@ -820,9 +820,9 @@ describe('writeLoadShareModule', () => {
 
     // No named export destructuring — package not installed, can't detect exports
     expect(generatedCode).not.toMatch(/const\s*\{.*__mf_\d+/);
-    expect(generatedCode).not.toContain('export {');
+    expect(generatedCode).not.toContain('__mf_0 as');
     // Only default export
-    expect(generatedCode).toContain('export default exportModule');
+    expect(generatedCode).toContain('export { __mf_default as default }');
     // Should warn about missing named exports in ESM build
     expect(mfWarnSpy).toHaveBeenCalledWith(expect.stringContaining('not installed locally'));
     expect(mfWarnSpy).toHaveBeenCalledWith(
@@ -878,7 +878,7 @@ describe('writeLoadShareModule', () => {
       expect.stringContaining('__TYPE_ONLY_EXPORT__'),
       expect.anything()
     );
-    expect(generatedCode).toContain('const { SharedCounter2: __mf_0 } = exportModule;');
+    expect(generatedCode).toContain('__mf_0 = exportModule["SharedCounter2"];');
     expect(generatedCode).toContain('export { __mf_0 as SharedCounter2 };');
     expect(generatedCode).not.toContain('as type');
     expect(mfWarnSpy).not.toHaveBeenCalled();
@@ -903,7 +903,8 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const { type: __mf_0, other: __mf_1 } = exportModule;');
+    expect(generatedCode).toContain('__mf_0 = exportModule["type"];');
+    expect(generatedCode).toContain('__mf_1 = exportModule["other"];');
     expect(generatedCode).toContain('export { __mf_0 as type, __mf_1 as other };');
   });
 
@@ -926,7 +927,8 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const { type: __mf_0, other: __mf_1 } = exportModule;');
+    expect(generatedCode).toContain('__mf_0 = exportModule["type"];');
+    expect(generatedCode).toContain('__mf_1 = exportModule["other"];');
     expect(generatedCode).toContain('export { __mf_0 as type, __mf_1 as other };');
   });
 
@@ -949,7 +951,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const { loader: __mf_0 } = exportModule;');
+    expect(generatedCode).toContain('__mf_0 = exportModule["loader"];');
     expect(generatedCode).toContain('export { __mf_0 as loader };');
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -717,9 +717,8 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('export *');
     expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
-    expect(generatedCode).not.toContain('await ');
-    expect(generatedCode).not.toContain('initPromise');
-    expect(generatedCode).not.toContain('shareScopeMap');
+    expect(generatedCode).toContain('await initPromise');
+    expect(generatedCode).toContain('shareScopeMap');
     expect(generatedCode).toContain('export default exportModule');
   });
 

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -190,6 +190,25 @@ function generateUsedSharedPreloadConfig() {
     }`;
 }
 
+function generateImportFalseSharedPreloadConfig() {
+  return `{
+      ${getOrderedUsedShares()
+        .map((pkg) => {
+          const shareItem = getShareItemForPreload(pkg);
+          if (!shareItem || shareItem.shareConfig.import !== false) return null;
+          return `${JSON.stringify(pkg)}: {
+            shareConfig: {
+              singleton: ${shareItem.shareConfig.singleton},
+              requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
+              import: false,
+            }
+          }`;
+        })
+        .filter((item) => item !== null)
+        .join(',\n')}
+    }`;
+}
+
 function getOrderedUsedShares() {
   const shares = new Set(getUsedShares());
   try {
@@ -399,6 +418,20 @@ export function generateRemoteEntry(
       });
     } catch (e) {
       console.error('[Module Federation]', e)
+    }
+    const importFalseShared = ${generateImportFalseSharedPreloadConfig()};
+    for (const [pkg, share] of Object.entries(importFalseShared)) {
+      if (__mfModuleCache.share[pkg] !== undefined) {
+        continue;
+      }
+      await initRes.loadShare(pkg, {
+        customShareInfo: { shareConfig: share.shareConfig }
+      }).then((factory) => {
+        const mod = typeof factory === "function" ? factory() : factory;
+        return Promise.resolve(mod).then((resolved) => {
+          __mfModuleCache.share[pkg] = resolved;
+        });
+      });
     }
     return initRes
   }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -190,25 +190,6 @@ function generateUsedSharedPreloadConfig() {
     }`;
 }
 
-function generateImportFalseSharedPreloadConfig() {
-  return `{
-      ${getOrderedUsedShares()
-        .map((pkg) => {
-          const shareItem = getShareItemForPreload(pkg);
-          if (!shareItem || shareItem.shareConfig.import !== false) return null;
-          return `${JSON.stringify(pkg)}: {
-            shareConfig: {
-              singleton: ${shareItem.shareConfig.singleton},
-              requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
-              import: false,
-            }
-          }`;
-        })
-        .filter((item) => item !== null)
-        .join(',\n')}
-    }`;
-}
-
 function getOrderedUsedShares() {
   const shares = new Set(getUsedShares());
   try {
@@ -418,20 +399,6 @@ export function generateRemoteEntry(
       });
     } catch (e) {
       console.error('[Module Federation]', e)
-    }
-    const importFalseShared = ${generateImportFalseSharedPreloadConfig()};
-    for (const [pkg, share] of Object.entries(importFalseShared)) {
-      if (__mfModuleCache.share[pkg] !== undefined) {
-        continue;
-      }
-      await initRes.loadShare(pkg, {
-        customShareInfo: { shareConfig: share.shareConfig }
-      }).then((factory) => {
-        const mod = typeof factory === "function" ? factory() : factory;
-        return Promise.resolve(mod).then((resolved) => {
-          __mfModuleCache.share[pkg] = resolved;
-        });
-      });
     }
     return initRes
   }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -400,6 +400,15 @@ export function generateRemoteEntry(
     } catch (e) {
       console.error('[Module Federation]', e)
     }
+    for (const [pkg, share] of Object.entries(usedShared)) {
+      if (share.shareConfig?.import !== false || __mfModuleCache.share[pkg] !== undefined) continue;
+      const versions = shared?.[pkg];
+      const provider = versions && versions[Object.keys(versions)[0]];
+      if (!provider) continue;
+      const factory = provider.lib || (provider.loading ? await provider.loading : await provider.get?.());
+      const mod = typeof factory === "function" ? factory() : factory;
+      __mfModuleCache.share[pkg] = await Promise.resolve(mod);
+    }
     return initRes
   }
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -21,7 +21,10 @@ import {
   getPackageName,
 } from '../utils/packageUtils';
 import VirtualModule from '../utils/VirtualModule';
-import { getRuntimeModuleCacheBootstrapCode } from './virtualRuntimeInitStatus';
+import {
+  getRuntimeInitPromiseBootstrapCode,
+  getRuntimeModuleCacheBootstrapCode,
+} from './virtualRuntimeInitStatus';
 
 const JS_IDENTIFIER_REGEX = new RegExp(
   '^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$',
@@ -385,24 +388,44 @@ export function writeLoadShareModule(
     const namedExports = getPackageNamedExports(pkg);
     let exportLine: string;
     if (namedExports.length > 0) {
-      const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(', ')} } = exportModule;`;
+      const declarations = namedExports.map((_name, i) => `let __mf_${i};`).join('\n    ');
+      const assignments = namedExports
+        .map((name, i) => `__mf_${i} = exportModule[${escapeGeneratedStringLiteral(name)}];`)
+        .join('\n      ');
       const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(', ')} };`;
-      exportLine = `export default exportModule.default ?? exportModule;\n    ${destructure}\n    ${namedExportLine}`;
+      exportLine = `${declarations}
+    let __mf_default;
+    const __mf_assign_exports = () => {
+      ${assignments}
+      __mf_default = exportModule.default ?? exportModule;
+    };
+    __mf_init_export_module.then(__mf_assign_exports);
+    export { __mf_default as default };
+    ${namedExportLine}`;
     } else {
       mfWarn(
         `Shared dependency "${pkg}" has import: false but is not installed locally.\n` +
           `  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n` +
           `  Install it as a devDependency to enable named export detection.`
       );
-      exportLine = 'export default exportModule.default ?? exportModule';
+      exportLine = `let __mf_default;
+    __mf_init_export_module.then(() => {
+      __mf_default = exportModule.default ?? exportModule;
+    });
+    export { __mf_default as default };`;
     }
     loadShareCacheMap[pkg].writeSync(
       `
     ${importLine}
-    const exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
-    if (exportModule === undefined) {
-      throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.")
-    }
+    ${getRuntimeInitPromiseBootstrapCode()}
+    let exportModule;
+    const __mf_init_export_module = initPromise.then(() => {
+      exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
+      if (exportModule === undefined) {
+        throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.")
+      }
+      return exportModule
+    });
     ${exportLine}
   `,
       true

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -21,10 +21,7 @@ import {
   getPackageName,
 } from '../utils/packageUtils';
 import VirtualModule from '../utils/VirtualModule';
-import {
-  getRuntimeModuleCacheBootstrapCode,
-  getRuntimeInitPromiseBootstrapCode,
-} from './virtualRuntimeInitStatus';
+import { getRuntimeModuleCacheBootstrapCode } from './virtualRuntimeInitStatus';
 
 const JS_IDENTIFIER_REGEX = new RegExp(
   '^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$',
@@ -402,30 +399,7 @@ export function writeLoadShareModule(
     loadShareCacheMap[pkg].writeSync(
       `
     ${importLine}
-    ${getRuntimeInitPromiseBootstrapCode()}
-    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
-    if (exportModule === undefined) {
-      const runtime = await initPromise;
-      const scope = runtime.shareScopeMap?.["default"]?.[${escapeGeneratedStringLiteral(pkg)}];
-      if (scope) {
-        for (const entry of Object.values(scope)) {
-          if (entry.lib) {
-            exportModule = typeof entry.lib === "function" ? entry.lib() : entry.lib;
-            break;
-          }
-          if (entry.get) {
-            try {
-              const factory = await entry.get();
-              exportModule = typeof factory === "function" ? factory() : factory;
-              break;
-            } catch {}
-          }
-        }
-      }
-      if (exportModule !== undefined) {
-        __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}] = exportModule;
-      }
-    }
+    const exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
     if (exportModule === undefined) {
       throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.")
     }

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -21,7 +21,10 @@ import {
   getPackageName,
 } from '../utils/packageUtils';
 import VirtualModule from '../utils/VirtualModule';
-import { getRuntimeModuleCacheBootstrapCode } from './virtualRuntimeInitStatus';
+import {
+  getRuntimeModuleCacheBootstrapCode,
+  getRuntimeInitPromiseBootstrapCode,
+} from './virtualRuntimeInitStatus';
 
 const JS_IDENTIFIER_REGEX = new RegExp(
   '^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$',
@@ -399,7 +402,30 @@ export function writeLoadShareModule(
     loadShareCacheMap[pkg].writeSync(
       `
     ${importLine}
-    const exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
+    ${getRuntimeInitPromiseBootstrapCode()}
+    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
+    if (exportModule === undefined) {
+      const runtime = await initPromise;
+      const scope = runtime.shareScopeMap?.["default"]?.[${escapeGeneratedStringLiteral(pkg)}];
+      if (scope) {
+        for (const entry of Object.values(scope)) {
+          if (entry.lib) {
+            exportModule = typeof entry.lib === "function" ? entry.lib() : entry.lib;
+            break;
+          }
+          if (entry.get) {
+            try {
+              const factory = await entry.get();
+              exportModule = typeof factory === "function" ? factory() : factory;
+              break;
+            } catch {}
+          }
+        }
+      }
+      if (exportModule !== undefined) {
+        __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}] = exportModule;
+      }
+    }
     if (exportModule === undefined) {
       throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.")
     }

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -367,6 +367,31 @@ export function getLoadShareModulePath(pkg: string, isRolldown: boolean): string
   const filepath = loadShareCacheMap[pkg].getPath();
   return filepath;
 }
+
+function generateDeferredHostProvidedExports(namedExports: string[]) {
+  const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+  const declarations = ['let __mf_default;', ...namedExportVars.map((name) => `let ${name};`)].join(
+    '\n    '
+  );
+  const assignments = [
+    ...namedExports.map(
+      (name, i) => `${namedExportVars[i]} = exportModule[${escapeGeneratedStringLiteral(name)}];`
+    ),
+    '__mf_default = exportModule.default ?? exportModule;',
+  ].join('\n      ');
+  const namedExportLine =
+    namedExports.length > 0
+      ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(', ')} };`
+      : '';
+
+  return `${declarations}
+    const __mf_assign_exports = () => {
+      ${assignments}
+    };
+    __mf_init_export_module.then(__mf_assign_exports);
+    export { __mf_default as default };${namedExportLine}`;
+}
+
 export function writeLoadShareModule(
   pkg: string,
   shareItem: ShareItem,
@@ -388,31 +413,14 @@ export function writeLoadShareModule(
     const namedExports = getPackageNamedExports(pkg);
     let exportLine: string;
     if (namedExports.length > 0) {
-      const declarations = namedExports.map((_name, i) => `let __mf_${i};`).join('\n    ');
-      const assignments = namedExports
-        .map((name, i) => `__mf_${i} = exportModule[${escapeGeneratedStringLiteral(name)}];`)
-        .join('\n      ');
-      const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(', ')} };`;
-      exportLine = `${declarations}
-    let __mf_default;
-    const __mf_assign_exports = () => {
-      ${assignments}
-      __mf_default = exportModule.default ?? exportModule;
-    };
-    __mf_init_export_module.then(__mf_assign_exports);
-    export { __mf_default as default };
-    ${namedExportLine}`;
+      exportLine = generateDeferredHostProvidedExports(namedExports);
     } else {
       mfWarn(
         `Shared dependency "${pkg}" has import: false but is not installed locally.\n` +
           `  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n` +
           `  Install it as a devDependency to enable named export detection.`
       );
-      exportLine = `let __mf_default;
-    __mf_init_export_module.then(() => {
-      __mf_default = exportModule.default ?? exportModule;
-    });
-    export { __mf_default as default };`;
+      exportLine = generateDeferredHostProvidedExports([]);
     }
     loadShareCacheMap[pkg].writeSync(
       `


### PR DESCRIPTION
This is a follow-up for https://github.com/module-federation/vite/issues/660. After updating to `v1.15.2`, I found some more issues in our setup related to the refactor in d7d1b4d.

It replaced the async `loadShare` approach for `import:false` shared modules with a synchronous check on the global module cache. This works when the host uses `@module-federation/vite` (which generates `hostAutoInit` to pre-populate the cache), but breaks when the host uses `@module-federation/runtime` directly.

Restore top-level await with `initPromise` as a fallback: first check the cache (fast path), and if empty, await the runtime and call `loadShare()` to resolve the module from the host's registered shared.

I'm not sure if this is the best solution, but it works for our setup. I created a minimal reproduction repo in case you want to test it yourself: https://github.com/JammingBen/mf-vite-import-repro