### PR TITLE
fix: resolve parent package version for shared subpath keys

### DIFF
--- a/.changeset/honest-pandas-share.md
+++ b/.changeset/honest-pandas-share.md
@@ -1,0 +1,28 @@
+---
+"@module-federation/vite": patch
+---
+
+fix: resolve parent package version for shared subpath keys
+
+Shared keys that point at a package subpath (e.g. `"@scope/foo/bar"`) were
+ending up with `version: undefined` in the generated remote `usedShared`
+map. The fallback in `searchPackageVersion` passed the full subpath as
+`packageName` to `getInstalledPackageJson`, which walks the pnpm store
+matching the `name` field in each `package.json`. No real package is
+named `"@scope/foo/bar"`, so the walk always missed and the version
+silently stayed undefined — only the parent key resolved correctly.
+
+At runtime, `version: undefined` on the consumer side breaks the
+singleton/`requiredVersion` matching against the host's registered
+share, falling back to the remote's local provider; for `import: false`
+shares that's the throwing `get()`, surfaced as
+`[Module Federation] Shared module '<subpath>' must be provided by host`.
+
+The fix is to drop the `packageName: sharedName` override and rely on
+`getInstalledPackageJson`'s existing default
+(`packageName = getPackageName(pkg)`), which strips subpaths correctly.
+
+Regression test covers a pnpm-strict fixture where the parent package is
+only reachable through `node_modules/.pnpm`, so the
+`searchPackageVersion` fallback is the only path that can resolve the
+version.

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -347,6 +347,63 @@ describe('normalizeModuleFederationOption', () => {
       });
     });
 
+    it('resolves the parent package version for a shared subpath key', () => {
+      // Regression for #XXX: when a shared key is a subpath like
+      // "@scope/foo/bar", searchPackageVersion() used to look up the pnpm
+      // store for a package literally named "@scope/foo/bar", which never
+      // exists. The resolved version stayed undefined, and the consumer's
+      // singleton/requiredVersion matching against the host's registered
+      // share broke at runtime, raising "Shared module '...' must be
+      // provided by host". The fix is to let getInstalledPackageJson
+      // derive the bare package name via getPackageName() so the lookup
+      // finds the parent package.
+      //
+      // The fixture mimics a pnpm strict install where the parent package
+      // is only reachable through node_modules/.pnpm — there's no
+      // node_modules/@scope/foo/package.json, so the earlier
+      // require()-based resolution paths in normalizeShareItem must miss
+      // and the searchPackageVersion fallback must succeed.
+      mfErrorSpy.mockClear();
+
+      const path = require('node:path');
+      const fs = require('node:fs');
+      const fixtureRoot = path.join(require('node:os').tmpdir(), 'mf-vite-subpath-share');
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      const pnpmPkgDir = path.join(
+        fixtureRoot,
+        'node_modules/.pnpm/@scope+web-client@7.0.0/node_modules/@scope/web-client'
+      );
+      fs.mkdirSync(pnpmPkgDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'package.json'),
+        JSON.stringify({ name: 'consumer-app', dependencies: {} })
+      );
+      fs.writeFileSync(
+        path.join(pnpmPkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@scope/web-client',
+          version: '7.0.0',
+          exports: { '.': './index.js', './graph': './graph.js' },
+        })
+      );
+
+      setPackageDetectionCwd(fixtureRoot);
+
+      const shared = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          '@scope/web-client': { import: false, singleton: true },
+          '@scope/web-client/graph': { import: false, singleton: true },
+        },
+      }).shared;
+
+      expect(shared['@scope/web-client'].version).toBe('7.0.0');
+      // The bug: this used to be undefined for the subpath.
+      expect(shared['@scope/web-client/graph'].version).toBe('7.0.0');
+
+      setPackageDetectionCwd(process.cwd());
+    });
+
     it('skips Nuxt module packages from implicit shared deps', () => {
       const fixtureRoot = require('node:path').join(
         require('node:os').tmpdir(),

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -348,7 +348,7 @@ describe('normalizeModuleFederationOption', () => {
     });
 
     it('resolves the parent package version for a shared subpath key', () => {
-      // Regression for #XXX: when a shared key is a subpath like
+      // When a shared key is a subpath like
       // "@scope/foo/bar", searchPackageVersion() used to look up the pnpm
       // store for a package literally named "@scope/foo/bar", which never
       // exists. The resolved version stayed undefined, and the consumer's

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -147,9 +147,14 @@ export interface ShareItem {
  * @returns {string | undefined}
  */
 function searchPackageVersion(sharedName: string): string | undefined {
-  const installed = getInstalledPackageJson(sharedName, {
-    packageName: sharedName,
-  });
+  // Let getInstalledPackageJson derive the bare package name from the shared
+  // key via its default `getPackageName(pkg)` behavior. Forcing
+  // `packageName: sharedName` here broke version resolution for any shared
+  // subpath like "@scope/foo/bar": the pnpm-store walk looks up a
+  // package.json whose `name` field equals `packageName`, but no real
+  // package is named "@scope/foo/bar", so the walk always misses and
+  // `version` stays undefined. The bare package name "@scope/foo" matches.
+  const installed = getInstalledPackageJson(sharedName);
   const version = installed?.packageJson.version;
   return typeof version === 'string' ? version : undefined;
 }


### PR DESCRIPTION
## Problem

Shared keys that point at a package subpath (e.g. `"@scope/foo/bar"`) end up with `version: undefined` in the generated remote's `usedShared` map — only the parent key (`"@scope/foo"`) resolves correctly.

At runtime, `version: undefined` on the consumer side breaks the singleton / `requiredVersion` matching against the host's registered share, and the runtime falls back to the remote's local provider. For `import: false` shares that's the generated throwing `get()`, surfaced during `bootstrapApp` as:

> Error: [Module Federation] Shared module '@scope/foo/bar' must be provided by host

…even though the host did register the subpath in its share scope. The symptom is intermittent at small scale and very frequent on cold boots when many remotes init in parallel.

## Root cause

`searchPackageVersion` (in `src/utils/normalizeModuleFederationOptions.ts`) overrides `getInstalledPackageJson`'s default `packageName` derivation by passing the full shared key:

```ts
const installed = getInstalledPackageJson(sharedName, {
  packageName: sharedName,  // ← full subpath like "@scope/foo/bar"
});
```

`getInstalledPackageJson`'s pnpm-store walk matches each candidate `package.json`'s `name` field against `packageName`. No real package is named `"@scope/foo/bar"`, so the walk always misses and the version silently stays `undefined`.

The function already has a correct default — `packageName = opts?.packageName || getPackageName(pkg)` — which strips the subpath.

### Why the parameter exists

Tracing history: the override wasn't added to enable something — it was a faithful port of pre-existing behavior.

- Pre-refactor (commit `dc0e52c` and earlier): `searchPackageVersion` had inline logic that resolved `sharedName`, walked up the directory tree, and matched `package.json.name === sharedName`. For subpath keys the walk found the parent `package.json` but the name comparison failed (`"@scope/foo" !== "@scope/foo/bar"`). The old code never resolved versions for subpath keys.
- Refactor `eec1691` ("chore: deduplicate package and runtime parsing"): collapsed the inline logic into `getInstalledPackageJson(sharedName, { packageName: sharedName })`. The override preserves the old comparison criterion (`name === sharedName`) — including the pre-existing flaw for subpaths.
- Commit `c52ea6a`: only reformatted the call.

So removing the override is safe:

- For bare keys (`"react"`): no-op — `getPackageName("react") === "react"`.
- For subpath keys (`"react/jsx-runtime"`): switches from "always returns undefined" to "returns the parent's version" — the bug fix.
- For wildcard keys (`"@scope/foo/"`): switches from "never matches" to "matches the parent".

## Fix

Drop the override and rely on the existing default. One-line change.

```diff
 function searchPackageVersion(sharedName: string): string | undefined {
-  const installed = getInstalledPackageJson(sharedName, {
-    packageName: sharedName,
-  });
+  const installed = getInstalledPackageJson(sharedName);
   const version = installed?.packageJson.version;
   return typeof version === 'string' ? version : undefined;
 }
```

## Regression test

Added `'resolves the parent package version for a shared subpath key'` in `normalizeModuleFederationOption.test.ts`. The fixture mimics a pnpm-strict install where the parent package is only reachable through `node_modules/.pnpm`, so the earlier `require()`-based resolution paths in `normalizeShareItem` miss and the `searchPackageVersion` fallback is the only path that can resolve the version. Asserts that both the parent key and the subpath key resolve to `version: '7.0.0'`.

Verified the test **fails** without the fix (`expected undefined to be '7.0.0'`) and passes with it. All 317 tests pass.

## Validation (downstream)

In an OpenCloud Web monorepo with 12 federated remotes all sharing `@opencloud-eu/web-client/{graph,graph/generated,ocs,sse,webdav}` as `singleton: true, import: false`:

- **Before fix** (registry 1.15.4): bug reliably fires on the first or second cold boot — all 12 remotes throw the error simultaneously.
- **After fix**: 130 cold-boot iterations × 12 remotes ≈ 1560 init calls, zero failures.

Also empirically confirmed that the bug **cannot** be worked around on the host side by registering a non-`'0.0.0'` version — the consumer's `version: undefined` is the breaking input regardless of what the host advertises.

## Notes

- Does not interact with `excludeSharedSubDependencies` from #608 — different file, different concern.