### PR TITLE
feat: add createModuleFederationConfig helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ With **@module-federation/vite**, the process becomes delightfully simple, you w
 > This example is with [Vue.js](https://vuejs.org/)</br>
 > The @module-federation/vite configuration remains the same for different frameworks.
 
+## Dedicated configuration file
+
+You can keep Module Federation options in `module-federation.config.ts`.
+
+```ts
+import { createModuleFederationConfig } from '@module-federation/vite';
+
+export default createModuleFederationConfig({
+  name: 'remote',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './remote-app': './src/App.vue',
+  },
+  shared: ['vue'],
+});
+```
+
+```ts
+import { defineConfig } from 'vite';
+import { federation } from '@module-federation/vite';
+import moduleFederationConfig from './module-federation.config';
+
+export default defineConfig({
+  plugins: [federation(moduleFederationConfig)],
+});
+```
+
 ## The Remote Application configuration
 
 file: **remote/vite.config.ts**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1101,4 +1101,13 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
   ];
 }
 
-export { federation, type ModuleFederationOptions, type PluginManifestOptions };
+function createModuleFederationConfig(options: ModuleFederationOptions): ModuleFederationOptions {
+  return options;
+}
+
+export {
+  createModuleFederationConfig,
+  federation,
+  type ModuleFederationOptions,
+  type PluginManifestOptions,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'pathe';
-import { version as viteVersion } from 'vite';
 import type { ConfigEnv, Plugin, UserConfig } from 'vite';
+import { version as viteVersion } from 'vite';
 import addEntry from './plugins/pluginAddEntry';
 import { checkAliasConflicts } from './plugins/pluginCheckAliasConflicts';
 import pluginDevRemoteHmr, { shouldIgnoreFile } from './plugins/pluginDevRemoteHmr';
@@ -13,8 +13,8 @@ import pluginProxyRemoteEntry from './plugins/pluginProxyRemoteEntry';
 import pluginProxyRemotes from './plugins/pluginProxyRemotes';
 import { findSharedKey, proxySharedModule } from './plugins/pluginProxySharedModule_preBuild';
 import { pluginRemoteNamedExports } from './plugins/pluginRemoteNamedExports';
-import pluginVarRemoteEntry from './plugins/pluginVarRemoteEntry';
 import { pluginSSRRemoteEntry } from './plugins/pluginSSRRemoteEntry';
+import pluginVarRemoteEntry from './plugins/pluginVarRemoteEntry';
 import aliasToArrayPlugin from './utils/aliasToArrayPlugin';
 import {
   collectLoadShareProxyChunks,
@@ -1101,7 +1101,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
   ];
 }
 
-function createModuleFederationConfig(options: ModuleFederationOptions): ModuleFederationOptions {
+function createModuleFederationConfig<T extends ModuleFederationOptions>(options: T): T {
   return options;
 }
 


### PR DESCRIPTION
This PR adds `createModuleFederationConfig` helper for Vite config DX to further follow more the module federation recommendations to use the `module-federation.config.ts`file structure (https://module-federation.io/guide/build-plugins/plugins-rspack.html#create)

```ts
createModuleFederationConfig(options) => options
```

The goal is DX consistency with the official Module Federation integrations for Rspack, Rsbuild, and Rspress, where users are encouraged to define their federation config in a dedicated `module-federation.config.ts` file and pass that object into the bundler plugin.

# Why

- Aligns Vite with the existing Module Federation config-file convention.
- Gives users a simple, typed entry point for `module-federation.config.ts`.
- Improves discoverability and keeps docs/examples consistent across bundlers.
- Keeps Vite-specific typing by using `@module-federation/vite`'s own `ModuleFederationOptions` type instead of the generic SDK plugin type.

# Example

```ts
// module-federation.config.ts
import { createModuleFederationConfig } from '@module-federation/vite';

export default createModuleFederationConfig({
  name: 'remote_a',
  exposes: {
    './Feature': './src/Feature.tsx',
  },
});
```

```ts
// vite.config.ts
import { defineConfig } from 'vite';
import { federation } from '@module-federation/vite';
import moduleFederationConfig from './module-federation.config';

export default defineConfig({
  plugins: [federation(moduleFederationConfig)],
});
```