### PR TITLE
fix(ssr): load federated remotes in general Vite SSR setups

### DIFF
--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -391,7 +391,35 @@ describe('pluginSSRRemoteEntry', () => {
       expect(emitFile).not.toHaveBeenCalled();
     });
 
-    it('skips emit in non-client environments', () => {
+    it('emits in the ssr environment when environments.ssr is configured', () => {
+      getIsRolldownMock.mockReturnValue(true);
+      const emitFile = makeEmitFile();
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        environments: { client: {}, ssr: {} },
+      } as unknown as ResolvedConfig);
+
+      callHook(
+        mainPlugin.buildStart,
+        {
+          meta: makePluginMeta(true),
+          emitFile,
+          environment: { name: 'ssr' },
+        } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+
+      expect(emitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'chunk',
+          fileName: 'remoteEntry.ssr.js',
+        })
+      );
+    });
+
+    it('skips emit in the ssr environment when only a client environment exists', () => {
       const emitFile = makeEmitFile();
       const plugins = pluginSSRRemoteEntry(makeOptions());
       const mainPlugin = plugins[1];

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -3,13 +3,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 import { normalizeModuleFederationOptions } from '../../utils/normalizeModuleFederationOptions';
 
-const { getIsRolldownMock } = vi.hoisted(() => ({
+const { getIsRolldownMock, hasPackageDependencyMock } = vi.hoisted(() => ({
   getIsRolldownMock: vi.fn<(ctx: unknown) => boolean>(() => false),
+  hasPackageDependencyMock: vi.fn<(pkg: string, cwd?: string) => boolean>(() => false),
 }));
 
 vi.mock('../../utils/packageUtils', () => ({
   getIsRolldown: getIsRolldownMock,
-  hasPackageDependency: vi.fn(() => false),
+  hasPackageDependency: hasPackageDependencyMock,
   getPackageDetectionCwd: vi.fn(() => '/mock/cwd'),
   setPackageDetectionCwd: vi.fn(),
   getPackageName: vi.fn((s: string) => s.split('/')[0]),
@@ -68,6 +69,7 @@ describe('pluginSSRRemoteEntry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getIsRolldownMock.mockReturnValue(false);
+    hasPackageDependencyMock.mockReturnValue(false);
   });
 
   it('returns two plugins with correct names and enforce', () => {
@@ -407,6 +409,59 @@ describe('pluginSSRRemoteEntry', () => {
           meta: makePluginMeta(true),
           emitFile,
           environment: { name: 'ssr' },
+        } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+
+      expect(emitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'chunk',
+          fileName: 'remoteEntry.ssr.js',
+        })
+      );
+    });
+
+    it('skips emit in the client environment when environments.ssr is configured', () => {
+      getIsRolldownMock.mockReturnValue(true);
+      const emitFile = makeEmitFile();
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        environments: { client: {}, ssr: {} },
+      } as unknown as ResolvedConfig);
+
+      callHook(
+        mainPlugin.buildStart,
+        {
+          meta: makePluginMeta(true),
+          emitFile,
+          environment: { name: 'client' },
+        } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+
+      expect(emitFile).not.toHaveBeenCalled();
+    });
+
+    it('still emits in the client environment for Nuxt when environments.ssr is configured', () => {
+      hasPackageDependencyMock.mockImplementation((pkg: string, _cwd?: string) => pkg === 'nuxt');
+      getIsRolldownMock.mockReturnValue(true);
+      const emitFile = makeEmitFile();
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        root: '/app',
+        environments: { client: {}, ssr: {} },
+      } as unknown as ResolvedConfig);
+
+      callHook(
+        mainPlugin.buildStart,
+        {
+          meta: makePluginMeta(true),
+          emitFile,
+          environment: { name: 'client' },
         } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
       );

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -3,14 +3,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 import { normalizeModuleFederationOptions } from '../../utils/normalizeModuleFederationOptions';
 
-const { getIsRolldownMock, hasPackageDependencyMock } = vi.hoisted(() => ({
+const { getIsRolldownMock, hasPackageDependencyMock, isNuxtProjectRootMock } = vi.hoisted(() => ({
   getIsRolldownMock: vi.fn<(ctx: unknown) => boolean>(() => false),
   hasPackageDependencyMock: vi.fn<(pkg: string, cwd?: string) => boolean>(() => false),
+  isNuxtProjectRootMock: vi.fn<(root: string) => boolean>(() => false),
 }));
 
 vi.mock('../../utils/packageUtils', () => ({
   getIsRolldown: getIsRolldownMock,
   hasPackageDependency: hasPackageDependencyMock,
+  isNuxtProjectRoot: isNuxtProjectRootMock,
   getPackageDetectionCwd: vi.fn(() => '/mock/cwd'),
   setPackageDetectionCwd: vi.fn(),
   getPackageName: vi.fn((s: string) => s.split('/')[0]),
@@ -70,6 +72,7 @@ describe('pluginSSRRemoteEntry', () => {
     vi.clearAllMocks();
     getIsRolldownMock.mockReturnValue(false);
     hasPackageDependencyMock.mockReturnValue(false);
+    isNuxtProjectRootMock.mockReturnValue(false);
   });
 
   it('returns two plugins with correct names and enforce', () => {
@@ -445,7 +448,7 @@ describe('pluginSSRRemoteEntry', () => {
     });
 
     it('still emits in the client environment for Nuxt when environments.ssr is configured', () => {
-      hasPackageDependencyMock.mockImplementation((pkg: string, _cwd?: string) => pkg === 'nuxt');
+      isNuxtProjectRootMock.mockReturnValue(true);
       getIsRolldownMock.mockReturnValue(true);
       const emitFile = makeEmitFile();
       const plugins = pluginSSRRemoteEntry(makeOptions());

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -16,7 +16,7 @@ import {
   type PreloadMap,
   processModuleAssets,
 } from '../utils/cssModuleHelpers';
-import { isNuxtClientBase, resolvePublicPath } from '../utils/pathNormalization';
+import { resolvePublicPath } from '../utils/pathNormalization';
 import { getSsrRemoteEntryFileName } from '../virtualModules/virtualRemoteEntrySSR';
 
 /**
@@ -119,7 +119,7 @@ const Manifest = (): Plugin[] => {
                   },
                   ssrRemoteEntry: {
                     name: getSsrRemoteEntryFileName(filename),
-                    path: isNuxtClientBase(viteConfig?.base) ? '/__mf_ssr__/' : '',
+                    path: '/__mf_ssr__/',
                     type: 'module',
                   },
                   varRemoteEntry: varFilename
@@ -269,7 +269,7 @@ const Manifest = (): Plugin[] => {
     };
     const ssrRemoteEntry = {
       name: ssrRemoteEntryFile || getSsrRemoteEntryFileName(filename),
-      path: _command === 'serve' && isNuxtClientBase(viteConfig?.base) ? '/__mf_ssr__/' : '',
+      path: _command === 'serve' ? '/__mf_ssr__/' : '',
       type: 'module',
     };
 

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -317,8 +317,11 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
 
         // Environment API (client + ssr): emit only in the ssr environment so exposes
         // are bundled with the Node SSR graph (nested loadRemote stays on the server).
+        // Nuxt only runs the client Vite graph for federation output (dist/client);
+        // skipping the client pass leaves no remoteEntry.ssr.js in .output/public and
+        // the host falls back to the browser remoteEntry (SourceTextModule errors).
         if (hasSsrEnvironment) {
-          if (environmentName !== 'ssr') return;
+          if (environmentName !== 'ssr' && !isNuxtProject) return;
         } else if (isLegacySsrBuild) {
           // Legacy `vite build --ssr` pass (e.g. vue-ssr dual build:server).
         } else if (environmentName && environmentName !== 'client') {

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -1,6 +1,6 @@
 import { Plugin, ResolvedConfig } from 'vite';
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
-import { getIsRolldown, hasPackageDependency } from '../utils/packageUtils';
+import { getIsRolldown, isNuxtProjectRoot } from '../utils/packageUtils';
 import { getBasePath, isNuxtClientBase } from '../utils/pathNormalization';
 import { generateExposesSSR, getVirtualExposesSSRId } from '../virtualModules/virtualExposesSSR';
 import {
@@ -135,9 +135,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
 
       configResolved(config) {
         viteConfig = config;
-        isNuxtProject =
-          hasPackageDependency('nuxt', config.root) ||
-          hasPackageDependency('nuxt-nightly', config.root);
+        isNuxtProject = isNuxtProjectRoot(config.root);
       },
 
       configureServer(server) {
@@ -321,7 +319,14 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         // skipping the client pass leaves no remoteEntry.ssr.js in .output/public and
         // the host falls back to the browser remoteEntry (SourceTextModule errors).
         if (hasSsrEnvironment) {
-          if (environmentName !== 'ssr' && !isNuxtProject) return;
+          // Non-Nuxt: SSR entry belongs in the dedicated `ssr` environment build.
+          // Nuxt: federation assets land in `dist/client` only — emit there (or the
+          // unnamed client pass), never in the Nitro `ssr` pass (wrong output dir).
+          if (isNuxtProject) {
+            if (environmentName === 'ssr') return;
+          } else if (environmentName !== 'ssr') {
+            return;
+          }
         } else if (isLegacySsrBuild) {
           // Legacy `vite build --ssr` pass (e.g. vue-ssr dual build:server).
         } else if (environmentName && environmentName !== 'client') {

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -310,9 +310,20 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         ssrOutputFilename = getSsrRemoteEntryFileName(options.filename);
 
         const environmentName = (this as { environment?: { name?: string } }).environment?.name;
-        // Only emit in the client environment — the SSR module runner shouldn't
-        // produce a second SSR entry.
-        if (environmentName && environmentName !== 'client') return;
+        const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
+        const isLegacySsrBuild = Boolean(
+          (this as { environment?: { config?: ResolvedConfig } }).environment?.config?.build?.ssr
+        );
+
+        // Environment API (client + ssr): emit only in the ssr environment so exposes
+        // are bundled with the Node SSR graph (nested loadRemote stays on the server).
+        if (hasSsrEnvironment) {
+          if (environmentName !== 'ssr') return;
+        } else if (isLegacySsrBuild) {
+          // Legacy `vite build --ssr` pass (e.g. vue-ssr dual build:server).
+        } else if (environmentName && environmentName !== 'client') {
+          return;
+        }
 
         if (Object.keys(options.exposes).length === 0) return;
 

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -122,12 +122,17 @@ describe('ssrEntryLoaderPlugin — manifest URL derivation', () => {
 // ---------------------------------------------------------------------------
 
 describe('ssrEntryLoaderPlugin — URL convention fallback', () => {
-  it('tries the .ssr.js convention first', async () => {
+  it('prefers the /__mf_server__/ SSR entry when available', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
     (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
     const fetch = makeFetchMock({
       'http://localhost:5001/mf-manifest.json': { ok: false },
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js': {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+        text: 'export async function init() {} export async function get() {}',
+      },
       'http://localhost:5001/remoteEntry.ssr.js': {
         ok: true,
         headers: { 'content-type': 'application/javascript' },
@@ -140,12 +145,40 @@ describe('ssrEntryLoaderPlugin — URL convention fallback', () => {
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
     });
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
-    expect(heads.map((c) => c[0])).toEqual(['http://localhost:5001/remoteEntry.ssr.js']);
+    expect(heads.map((c) => c[0])).toEqual([
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js',
+    ]);
+  });
+
+  it('tries the .ssr.js convention when /__mf_server__/ is absent', async () => {
+    const fsMock = await import('fs');
+    (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    const fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': { ok: false },
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js': { ok: false },
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+        text: 'export async function init() {} export async function get() {}',
+      },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+    await factory().loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
+    });
+    const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
+    expect(heads.map((c) => c[0])).toEqual([
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js',
+      'http://localhost:5001/remoteEntry.ssr.js',
+    ]);
   });
 
   it('falls back to the dev SSR middleware when root .ssr.js is HTML', async () => {
     const fetch = makeFetchMock({
       'http://localhost:5001/mf-manifest.json': { ok: false },
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js': { ok: false },
       'http://localhost:5001/remoteEntry.ssr.js': {
         ok: true,
         headers: { 'content-type': 'text/html' },
@@ -163,6 +196,7 @@ describe('ssrEntryLoaderPlugin — URL convention fallback', () => {
     });
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
     expect(heads.map((c) => c[0])).toEqual([
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js',
       'http://localhost:5001/remoteEntry.ssr.js',
       'http://localhost:5001/__mf_ssr__/remoteEntry.ssr.js',
     ]);
@@ -171,6 +205,7 @@ describe('ssrEntryLoaderPlugin — URL convention fallback', () => {
   it('rejects HTML fallback responses', async () => {
     const fetch = makeFetchMock({
       'http://localhost:5001/mf-manifest.json': { ok: false },
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js': { ok: false },
       'http://localhost:5001/remoteEntry.ssr.js': {
         ok: true,
         headers: { 'content-type': 'text/html' },
@@ -187,6 +222,7 @@ describe('ssrEntryLoaderPlugin — URL convention fallback', () => {
   it('returns undefined when no SSR entry is discoverable', async () => {
     const fetch = makeFetchMock({
       'http://localhost:5001/mf-manifest.json': { ok: false },
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js': { ok: false },
       'http://localhost:5001/remoteEntry.ssr.js': { ok: false },
     });
     global.fetch = fetch as unknown as typeof globalThis.fetch;
@@ -203,11 +239,12 @@ describe('ssrEntryLoaderPlugin — URL convention fallback', () => {
 // ---------------------------------------------------------------------------
 
 describe('ssrEntryLoaderPlugin — manifest SSR entry resolution', () => {
-  it('uses ssrRemoteEntry from manifest without convention HEAD requests', async () => {
+  it('uses ssrRemoteEntry from manifest after probing /__mf_server__', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
     (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
     const fetch = makeFetchMock({
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js': { ok: false },
       'http://localhost:5001/mf-manifest.json': {
         ok: true,
         json: {
@@ -226,7 +263,9 @@ describe('ssrEntryLoaderPlugin — manifest SSR entry resolution', () => {
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
     });
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
-    expect(heads.length).toBe(0);
+    expect(heads.map((c) => c[0])).toEqual([
+      'http://localhost:5001/__mf_server__/remoteEntry.ssr.js',
+    ]);
   });
 
   it('resolves SSR entry URL with path prefix from manifest', async () => {

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -286,6 +286,20 @@ export function getIsRolldown(ctx: unknown): boolean {
   return (Number.isFinite(viteMajor) && viteMajor >= 8) || !!(ctx as any)?.meta?.rolldownVersion;
 }
 
+/** Walk up from Vite `config.root` (Nuxt may point at `.nuxt` cache dirs). */
+export function isNuxtProjectRoot(root: string): boolean {
+  let dir = root;
+  for (let i = 0; i < 8; i++) {
+    if (hasPackageDependency('nuxt', dir) || hasPackageDependency('nuxt-nightly', dir)) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
+}
+
 export function hasPackageDependency(
   dependencyName: string,
   cwd = packageDetectionCwd || process.cwd()

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -181,8 +181,24 @@ function resolveSSREntryUrl(
  * remoteEntry.js → /__mf_ssr__/remoteEntry.ssr.js (dev middleware)
  * Returns the first URL that responds with a 200.
  */
+async function headCheckSsrEntry(candidate: {
+  url: string;
+  type: string;
+}): Promise<{ url: string; type: string } | null> {
+  try {
+    const res = await fetch(candidate.url, { method: 'HEAD' });
+    const ct = res.headers.get('content-type') ?? '';
+    // Reject SPA index.html fallbacks — only accept JS/text responses.
+    if (res.ok && !ct.includes('text/html')) return candidate;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
 async function getSSREntryByConvention(
-  remoteEntryUrl: string
+  remoteEntryUrl: string,
+  options: { skipServerBuild?: boolean } = {}
 ): Promise<{ url: string; type: string } | null> {
   const base = remoteEntryUrl.replace(/\.[^.]+$/, '');
   const remoteOrigin = remoteEntryUrl.replace(/\/[^/]+$/, '');
@@ -192,23 +208,36 @@ async function getSSREntryByConvention(
       .pop()
       ?.replace(/\.[^.]+$/, '') ?? 'remoteEntry';
   const candidates = [
+    // SSR graph from a dedicated server build (Environment API or `vite build --ssr`).
+    // Must be tried before the client-emitted .ssr.js entry, which pulls browser
+    // loadRemote chunks and can recurse indefinitely for nested remotes.
+    ...(options.skipServerBuild
+      ? []
+      : [{ url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`, type: 'module' as const }]),
     { url: `${base}.ssr.js`, type: 'module' },
     { url: `${remoteOrigin}/__mf_ssr__/${filename}.ssr.js`, type: 'module' },
   ];
   for (const candidate of candidates) {
-    try {
-      const res = await fetch(candidate.url, { method: 'HEAD' });
-      const ct = res.headers.get('content-type') ?? '';
-      // Reject SPA index.html fallbacks — only accept JS/text responses.
-      if (res.ok && !ct.includes('text/html')) return candidate;
-    } catch {
-      // ignore — try next
-    }
+    const hit = await headCheckSsrEntry(candidate);
+    if (hit) return hit;
   }
   return null;
 }
 
 async function getSSREntry(remoteEntryUrl: string): Promise<{ url: string; type: string } | null> {
+  const remoteOrigin = remoteEntryUrl.replace(/\/[^/]+$/, '');
+  const filename =
+    remoteEntryUrl
+      .split('/')
+      .pop()
+      ?.replace(/\.[^.]+$/, '') ?? 'remoteEntry';
+  // Prefer a server-build SSR entry when the remote serves dist/server (preview/production).
+  const fromServerBuild = await headCheckSsrEntry({
+    url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
+    type: 'module',
+  });
+  if (fromServerBuild) return fromServerBuild;
+
   const manifestUrl = getManifestUrl(remoteEntryUrl);
   if (!manifestCache.has(manifestUrl)) {
     manifestCache.set(
@@ -219,7 +248,7 @@ async function getSSREntry(remoteEntryUrl: string): Promise<{ url: string; type:
           if (fromManifest) return fromManifest;
         }
         // Manifest absent or has no ssrRemoteEntry — fall back to URL convention.
-        return getSSREntryByConvention(remoteEntryUrl);
+        return getSSREntryByConvention(remoteEntryUrl, { skipServerBuild: true });
       })
     );
   }
@@ -375,6 +404,10 @@ async function fetchEsmToTempFile(
   return promise;
 }
 
+async function importTempModule(filePath: string): Promise<{ init: unknown; get: unknown }> {
+  return (await import(/* @vite-ignore */ filePath)) as { init: unknown; get: unknown };
+}
+
 async function loadSSRRemoteEntry(
   ssrEntry: { url: string; type: string },
   resolvedShared: Record<string, string> = {}
@@ -440,7 +473,7 @@ async function loadSSRRemoteEntry(
 
     try {
       const tmpFile = await fetchEsmToTempFile(url, cacheDir, new Map(), sharedPkgMap);
-      return (await import(tmpFile)) as { init: unknown; get: unknown };
+      return await importTempModule(tmpFile);
     } catch {
       return null;
     }

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -231,25 +231,27 @@ async function getSSREntry(remoteEntryUrl: string): Promise<{ url: string; type:
       .split('/')
       .pop()
       ?.replace(/\.[^.]+$/, '') ?? 'remoteEntry';
-  // Prefer a server-build SSR entry when the remote serves dist/server (preview/production).
-  const fromServerBuild = await headCheckSsrEntry({
-    url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
-    type: 'module',
-  });
-  if (fromServerBuild) return fromServerBuild;
 
   const manifestUrl = getManifestUrl(remoteEntryUrl);
   if (!manifestCache.has(manifestUrl)) {
     manifestCache.set(
       manifestUrl,
-      fetchManifest(manifestUrl).then(async (manifest) => {
+      (async () => {
+        // Prefer a server-build SSR entry when the remote serves dist/server (preview/production).
+        const fromServerBuild = await headCheckSsrEntry({
+          url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
+          type: 'module',
+        });
+        if (fromServerBuild) return fromServerBuild;
+
+        const manifest = await fetchManifest(manifestUrl);
         if (manifest) {
           const fromManifest = resolveSSREntryUrl(manifest, manifestUrl);
           if (fromManifest) return fromManifest;
         }
         // Manifest absent or has no ssrRemoteEntry — fall back to URL convention.
         return getSSREntryByConvention(remoteEntryUrl, { skipServerBuild: true });
-      })
+      })()
     );
   }
   return manifestCache.get(manifestUrl)!;


### PR DESCRIPTION
## Summary

PR #722  improved Nuxt SSR, but SSR can still break in the common Vite federation setup where remotes are **served separately** and apps use **normal federation imports** (e.g. `import Feature from 'remote_a/Feature'`) instead of importing remote source from disk.

This PR closes that gap for plain Vite SSR: discover SSR remote entries reliably, emit them from the correct build graph, and load them on the server in dev and preview/production.

## Problem

Today, SSR often only works when:

- host and remotes live in the same monorepo (nuxt demo), and
- the server imports remote files by relative path, bypassing federation.

That is not the integration model most Vite + Module Federation users expect. We need SSR to work when:

- each app runs on its own origin/port
- the host loads remotes through federation only
- nested remotes SSR correctly (e.g. `host → remote_a → remote_b`)

## Result

Users can:
1. Use the same federation imports on client and server
2. Run host and remotes as separate apps without monorepo file imports on the server