### PR TITLE
fix: preserve expose exports when rollup input matches expose entry

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -194,6 +194,40 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('globalThis.System.import(src)');
   });
 
+  it('skips host-init bootstrap on rollupOptions.input entries when the build has exposes (#724)', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-expose-input-'));
+    const exposePath = path.join(tempDir, 'src/expose.ts');
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+      forceClientInjected: true,
+    });
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: { input: exposePath } } },
+      { command: 'build', mode: 'production' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: { input: exposePath } },
+    } as unknown as ResolvedConfig);
+
+    const originalCode = 'export function render(root) { root.textContent = "hi" }';
+    const result = await runTransform(buildPlugin, originalCode, exposePath);
+
+    // The transform must skip — wrapping with the bootstrap IIFE would
+    // discard the named exports and virtualExposes' dynamic import of this
+    // same path would resolve to an empty namespace, breaking loadRemote.
+    expect(result).toBeUndefined();
+  });
+
   it('wraps hydration entry fallback behind host init during build', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-build-hydration-'));
     const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -553,8 +553,16 @@ ${importHelper}(async () => {
           /(?:^|\/)nuxt\/dist\/app\/entry\.async\.js(?:\?|$)/.test(id) &&
           code.includes('entry();');
 
+        // When `forceClientInjected` is true (currently set when the build has
+        // `exposes`), skip the rollupOptions.input wrap. Wrapping replaces the
+        // entry file's code with a host-init bootstrap IIFE that has no exports;
+        // if that same file is also an expose target, virtualExposes' dynamic
+        // import resolves to the wrapped chunk and `loadRemote` hands back an
+        // empty namespace (#724). For these builds, init is guaranteed via the
+        // `loadRemote -> virtualExposes -> remoteEntry.init` path, so the wrap
+        // is both redundant and lossy.
         const shouldInject =
-          (injectEntry() && entryFiles.some((file) => id.endsWith(file))) ||
+          (injectEntry() && entryFiles.some((file) => id.endsWith(file)) && !forceClientInjected) ||
           // Fallback for SSR frameworks (e.g. Nuxt) that bypass transformIndexHtml.
           (_command === 'serve' &&
             inject === 'html' &&


### PR DESCRIPTION
Fixes #724.

`pluginAddEntry`'s build-time transform wraps every `rollupOptions.input` entry with a host-init bootstrap IIFE that loads the original module only for its side-effects and discards the namespace. When the same file is also an `exposes` target, `virtualExposes`' dynamic `import(exposePath)` resolves to that wrapped chunk and `loadRemote("remote/Expose")` hands back an empty namespace.

The plugin already has a signal for "this build is a remote whose output is never browser-requested as a page entry": `forceClientInjected`, set whenever `Object.keys(options.exposes).length > 0`. It was being used to gate the SSR fallback but not the `rollupOptions.input` clause — so for a build with exposes, the rollup-input wrap fired anyway and clobbered the exposed module's exports.

Init for these builds is guaranteed via `loadRemote → virtualExposes → remoteEntry.init`, so the wrap is both redundant and lossy for them. Extending the existing `forceClientInjected` gate to cover the rollup-input clause restores 1.14.5 behavior without re-introducing the TLA / static-import patterns #638 removed.