### PR TITLE
fix: host bootstrap respects shareStrategy and tolerates offline remotes

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -17,6 +17,26 @@ vi.mock('../../utils/packageUtils', () => ({
   hasPackageDependency: () => true,
 }));
 
+const mockMfOptions = vi.hoisted(() => ({
+  shareStrategy: 'version-first' as 'version-first' | 'loaded-first',
+}));
+
+vi.mock('../../utils/normalizeModuleFederationOptions', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../utils/normalizeModuleFederationOptions')
+  >('../../utils/normalizeModuleFederationOptions');
+  return {
+    ...actual,
+    getNormalizeModuleFederationOptions: () => ({
+      shareStrategy: mockMfOptions.shareStrategy,
+      shared: {},
+      remotes: {},
+      internalName: 'host',
+      name: 'host',
+    }),
+  };
+});
+
 import addEntry from '../pluginAddEntry';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 import { addUsedRemote } from '../../virtualModules/virtualRemotes';
@@ -85,6 +105,7 @@ function runGenerateBundle(
 describe('pluginAddEntry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMfOptions.shareStrategy = 'version-first';
   });
 
   for (const testCase of [
@@ -189,7 +210,7 @@ describe('pluginAddEntry', () => {
     )) as { code: string } | undefined;
 
     expect(result?.code).toContain('const { initHost } = await import("/virtual/hostInit.js");');
-    expect(result?.code).toContain('const runtime = await initHost();');
+    expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain('})().then(() => import("/src/main.tsx?mf-entry-bootstrap"));');
     expect(result?.code).not.toContain('globalThis.System.import(src)');
   });
@@ -223,7 +244,7 @@ describe('pluginAddEntry', () => {
     )) as { code: string } | undefined;
 
     expect(result?.code).toContain('const { initHost } = await import("/virtual/hostInit.js");');
-    expect(result?.code).toContain('const runtime = await initHost();');
+    expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain(
       '})().then(() => import("/virtual/client-entry.tsx?mf-entry-bootstrap"));'
     );
@@ -393,6 +414,64 @@ describe('pluginAddEntry', () => {
     expect(result?.code).toContain('__mfPreloadRemote("@scope/remote/Button")');
     expect(result?.code).not.toContain('__mfPreloadRemote("@scope/remote")');
     expect(result?.code).toContain('runtime.loadRemote(remote)');
+    // A preload failure must not abort host bootstrap.
+    expect(result?.code).toContain('await Promise.allSettled(__mfRemotePreloads);');
+    expect(result?.code).not.toContain('Promise.all(__mfRemotePreloads)');
+  });
+
+  it('skips remote preload in the host bootstrap when shareStrategy is loaded-first', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-loaded-first-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'index.html'),
+      [
+        '<!doctype html>',
+        '<html>',
+        '  <body>',
+        '    <script type="module" src="/src/main.ts"></script>',
+        '  </body>',
+        '</html>',
+      ].join('\n')
+    );
+    addUsedRemote('employees', 'employees/staff');
+    mockMfOptions.shareStrategy = 'loaded-first';
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(buildPlugin, 'export const app = true;', '/src/main.ts')) as
+      | { code: string }
+      | undefined;
+
+    // loaded-first defers remote loading to the runtime — the host bootstrap
+    // must not preload, so an offline remote can never blank the host.
+    expect(result?.code).not.toContain('__mfPreloadRemote');
+    expect(result?.code).not.toContain('loadRemote');
+    expect(result?.code).not.toContain('__mfRemotePreloads');
+    expect(result?.code).toContain('await initHost();');
+    expect(result?.code).toContain('})().then(() => import("/src/main.ts?mf-entry-bootstrap"));');
   });
 
   it('rewrites dev html entry scripts to external proxy modules instead of inline scripts', async () => {

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../utils/normalizeModuleFederationOptions', async () => {
 
 import addEntry from '../pluginAddEntry';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
-import { addUsedRemote } from '../../virtualModules/virtualRemotes';
+import { addUsedRemote, getUsedRemotesMap } from '../../virtualModules/virtualRemotes';
 
 type AddEntryPlugin = ReturnType<typeof addEntry>[number];
 
@@ -102,10 +102,18 @@ function runGenerateBundle(
   callHook(plugin.generateBundle, ctx, outputOptions, bundle, isWrite);
 }
 
+function clearUsedRemotes() {
+  const usedRemotesMap = getUsedRemotesMap();
+  for (const remoteKey of Object.keys(usedRemotesMap)) {
+    delete usedRemotesMap[remoteKey];
+  }
+}
+
 describe('pluginAddEntry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMfOptions.shareStrategy = 'version-first';
+    clearUsedRemotes();
   });
 
   for (const testCase of [
@@ -594,7 +602,7 @@ describe('pluginAddEntry', () => {
     // The proxy module must import both init and entry as resolvable paths
     // (no base prefix — Vite's server-side resolver handles base itself)
     expect(code).toContain('const { initHost } = await import("/@id/virtual:mf-host-init");');
-    expect(code).toContain('const runtime = await initHost();');
+    expect(code).toContain('await initHost();');
     expect(code).toContain('})().then(() => import("/src/main.tsx"));');
     expect(code).not.toContain('globalThis.System.import(src)');
     expect(code).not.toContain('/foo/');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -10,6 +10,7 @@ import {
 } from '../utils/htmlEntryUtils';
 import { mfWarn } from '../utils/logger';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import { getNormalizeModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
 import { getUsedRemotesMap } from '../virtualModules/virtualRemotes';
 import { getRuntimeModuleCacheBootstrapCode } from '../virtualModules/virtualRuntimeInitStatus';
@@ -183,21 +184,31 @@ const addEntry = ({
         ? `__mfImport(${JSON.stringify(src)})`
         : `import(${JSON.stringify(src)})`;
 
+    // Eagerly preloading remotes mirrors the federation runtime's own
+    // `version-first` behaviour, where `ShareHandler.initializeSharing()` loads
+    // every remote entry during startup. With `loaded-first` the runtime defers
+    // remote loading until a module is actually requested, so the host must NOT
+    // preload — otherwise an offline remote would block host bootstrap even
+    // though the user explicitly opted into the on-demand strategy.
+    const shouldPreloadRemotes =
+      getNormalizeModuleFederationOptions()?.shareStrategy !== 'loaded-first';
+
     // Keep only sub-path entries (e.g. "remote/App"); skip bare remote keys
     // ("remote" or scoped "@scope/remote") since they refer to the container
     // itself, not an exposed module. The previous `includes('/')` check
     // incorrectly matched scoped names like "@scope/remote".
-    const remotePreloads = Object.entries(getUsedRemotesMap())
-      .flatMap(([remoteKey, remotes]) =>
-        Array.from(remotes).filter((remote) => remote !== remoteKey)
-      )
-      .sort()
-      .map((remote) => `__mfPreloadRemote(${JSON.stringify(remote)})`)
-      .join(',');
+    const remotePreloads = shouldPreloadRemotes
+      ? Object.entries(getUsedRemotesMap())
+          .flatMap(([remoteKey, remotes]) =>
+            Array.from(remotes).filter((remote) => remote !== remoteKey)
+          )
+          .sort()
+          .map((remote) => `__mfPreloadRemote(${JSON.stringify(remote)})`)
+          .join(',')
+      : '';
 
-    return `${getRuntimeModuleCacheBootstrapCode()}
-${importHelper}(async () => {
-  const { initHost } = await ${importExpression(initSrc)};
+    const preloadBlock = remotePreloads
+      ? `
   const runtime = await initHost();
   const __mfPreloadRemote = (remote) => {
     const pendingKey = "__mf_pending__" + remote;
@@ -216,9 +227,17 @@ ${importHelper}(async () => {
     return __mfModuleCache.remote[pendingKey];
   };
   const __mfRemotePreloads = [${remotePreloads}];
-  await Promise.all(__mfRemotePreloads);
+  await Promise.allSettled(__mfRemotePreloads);`
+      : `await initHost();`;
+
+    const importCode = `
+(async () => {
+  const { initHost } = await ${importExpression(initSrc)};
+  ${preloadBlock}
 })().then(() => ${importExpression(entrySrc)});
 `;
+
+    return [getRuntimeModuleCacheBootstrapCode(), importHelper, importCode].join('\n');
   }
 
   function getSystemBootstrapSource(initSrc: string, entrySrc: string) {


### PR DESCRIPTION
## Problem

Run only the host in dev (without its remotes) and the host renders a **blank page** - even screens that use no remote. The console shows `RUNTIME-003: Failed to get manifest`.

## Why

The plugin's generated bootstrap eagerly loads every remote before importing the app entry:

```js
await Promise.all(remotes.map(r => runtime.loadRemote(r))); // fails here
import("/src/main.ts"); // never runs
```

Two bugs:

1. It preloads remotes even with `shareStrategy: 'loaded-first'`, which is meant to load remotes only on demand.
2. `Promise.all` makes one offline remote fatal – the bootstrap rejects and the app entry never loads.

## The fix

In `getBootstrapSource` (`src/plugins/pluginAddEntry.ts`):

1. With `shareStrategy: 'loaded-first'`, skip the preload – the host boots, each remote loads only when its screen opens.
2. With `version-first`, use `Promise.allSettled` so an offline remote can't abort startup.

This matches the official runtime: it preloads remotes only for `version-first` and skips failed ones instead of crashing.