### PR TITLE
fix: resolve scoped remote names

### DIFF
--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -30,6 +30,13 @@ vi.mock('../../utils/normalizeModuleFederationOptions', () => ({
         entry: 'http://localhost:4174/remoteEntry.js',
         shareScope: 'default',
       },
+      'remote/sub': {
+        entryGlobalName: 'remote_sub',
+        name: 'remote/sub',
+        type: 'module',
+        entry: 'http://localhost:4176/remoteEntry.js',
+        shareScope: 'default',
+      },
       '@scope/remote': {
         entryGlobalName: 'scope_remote',
         name: '@scope/remote',
@@ -95,6 +102,16 @@ describe('generateRemotes', () => {
 
     expect(code).not.toContain('runtime.registerRemotes([');
     expect(code).toContain('runtime.loadRemote("@scope/unknown/Button")');
+  });
+
+  it('uses the most specific remote config when names overlap', () => {
+    mockOptions.shareStrategy = 'loaded-first';
+    const code = generateRemotes('remote/sub/Button', 'serve');
+
+    expect(code).toContain('runtime.registerRemotes([');
+    expect(code).toContain('"name":"remote/sub"');
+    expect(code).toContain('"entryGlobalName":"remote_sub"');
+    expect(code).toContain('"entry":"http://localhost:4176/remoteEntry.js"');
   });
 
   it('uses ESM remote wrapper exports in dev', () => {

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -30,6 +30,13 @@ vi.mock('../../utils/normalizeModuleFederationOptions', () => ({
         entry: 'http://localhost:4174/remoteEntry.js',
         shareScope: 'default',
       },
+      '@scope/remote': {
+        entryGlobalName: 'scope_remote',
+        name: '@scope/remote',
+        type: 'module',
+        entry: 'http://localhost:4175/remoteEntry.js',
+        shareScope: 'default',
+      },
     },
     shareStrategy: mockOptions.shareStrategy,
     virtualModuleDir: '__mf__virtual',
@@ -56,6 +63,38 @@ describe('generateRemotes', () => {
     expect(code).toContain('pendingPromise ||= __mfStartRemoteLoad();');
     expect(code).toContain('runtime.registerRemotes([');
     expect(code).not.toContain('__mfRemotePending = __mfStartRemoteLoad();');
+  });
+
+  it('loads a scoped remote module using its full id', () => {
+    const code = generateRemotes('@scope/remote/Button', 'serve');
+
+    expect(code).toContain('runtime.loadRemote("@scope/remote/Button")');
+  });
+
+  it('loads a scoped remote referenced by its bare name', () => {
+    const code = generateRemotes('@scope/remote', 'serve');
+
+    expect(code).toContain('runtime.loadRemote("@scope/remote")');
+  });
+
+  it('registers the scoped remote config for loaded-first', () => {
+    mockOptions.shareStrategy = 'loaded-first';
+    const code = generateRemotes('@scope/remote/Button', 'serve');
+
+    // The remote name contains a slash, so it must be matched against the
+    // configured remotes rather than naively split on the first path segment.
+    expect(code).toContain('runtime.registerRemotes([');
+    expect(code).toContain('"name":"@scope/remote"');
+    expect(code).toContain('"entryGlobalName":"scope_remote"');
+    expect(code).toContain('"entry":"http://localhost:4175/remoteEntry.js"');
+  });
+
+  it('skips remote registration when a scoped id matches no configured remote', () => {
+    mockOptions.shareStrategy = 'loaded-first';
+    const code = generateRemotes('@scope/unknown/Button', 'serve');
+
+    expect(code).not.toContain('runtime.registerRemotes([');
+    expect(code).toContain('runtime.loadRemote("@scope/unknown/Button")');
   });
 
   it('uses ESM remote wrapper exports in dev', () => {

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -1,8 +1,8 @@
-import { hasPackageDependency } from '../utils/packageUtils';
 import {
   getNormalizeModuleFederationOptions,
   type RemoteObjectConfig,
 } from '../utils/normalizeModuleFederationOptions';
+import { hasPackageDependency } from '../utils/packageUtils';
 import VirtualModule from '../utils/VirtualModule';
 import { getHostAutoInitPath } from './virtualRemoteEntry';
 import {
@@ -35,9 +35,9 @@ export function getUsedRemotesMap() {
 }
 
 export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
-  // 'remote1/App' => 'remote1'
-  // '@scope/remote1/App' => '@scope/remote1'
-  const remoteName = Object.keys(remotes).find((name) => id === name || id.startsWith(name + '/'));
+  const remoteName = Object.keys(remotes)
+    .filter((name) => id === name || id.startsWith(name + '/'))
+    .sort((a, b) => b.length - a.length)[0];
 
   return remoteName ? remotes[remoteName] : undefined;
 }

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -1,5 +1,8 @@
 import { hasPackageDependency } from '../utils/packageUtils';
-import { getNormalizeModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import {
+  getNormalizeModuleFederationOptions,
+  type RemoteObjectConfig,
+} from '../utils/normalizeModuleFederationOptions';
 import VirtualModule from '../utils/VirtualModule';
 import { getHostAutoInitPath } from './virtualRemoteEntry';
 import {
@@ -30,12 +33,20 @@ export function addUsedRemote(remoteKey: string, remoteModule: string) {
 export function getUsedRemotesMap() {
   return usedRemotesMap;
 }
+
+export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
+  // 'remote1/App' => 'remote1'
+  // '@scope/remote1/App' => '@scope/remote1'
+  const remoteName = Object.keys(remotes).find((name) => id === name || id.startsWith(name + '/'));
+
+  return remoteName ? remotes[remoteName] : undefined;
+}
+
 export function generateRemotes(id: string, command: string, enableSsrInit = false) {
   const useReactProxy = hasPackageDependency('react');
   const options = getNormalizeModuleFederationOptions();
   const isLoadedFirst = options.shareStrategy === 'loaded-first';
-  const remoteName = id.split('/')[0];
-  const remote = options.remotes[remoteName];
+  const remote = getRemoteFromId(id, options.remotes);
   const registerRemoteCode =
     isLoadedFirst && remote
       ? `runtime.registerRemotes([${JSON.stringify({


### PR DESCRIPTION
## Problem
If remote name `@scope/remote` contains a slash. The code took only the first path segment => `@scope`, which is not a configured remote 

## Fix
This is a quick fix. It can be optimized, but it will require major interface changes.