### PR TITLE
fix: content-hash bootstrap entry asset

### DIFF
--- a/.changeset/hash-bootstrap-entry.md
+++ b/.changeset/hash-bootstrap-entry.md
@@ -1,0 +1,14 @@
+---
+"@module-federation/vite": patch
+---
+
+fix: content-hash the bootstrap entry asset
+
+The bootstrap entry emitted by the plugin was named `mf-entry-bootstrap-<index>.js`
+with no content hash. Because `index.html` references this file as the app entry,
+browsers and CDNs kept serving the stale bootstrap after a deploy, breaking app load
+until caches expired.
+
+The fix appends a short sha256 hash of the bootstrap source to the filename
+(`mf-entry-bootstrap-<index>-<hash>.js`) so the emitted asset participates in the
+normal cache-busting flow alongside every other built asset.

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -856,13 +856,19 @@ describe('pluginAddEntry', () => {
       bundle as unknown as Rollup.OutputBundle
     );
 
+    const bootstrapAsset = (emitted as Rollup.EmittedFile[]).find(
+      (item) =>
+        item.type === 'asset' &&
+        typeof item.fileName === 'string' &&
+        item.fileName.startsWith('mf-entry-bootstrap-')
+    ) as Rollup.EmittedAsset | undefined;
+    expect(bootstrapAsset?.fileName).toMatch(/^mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
     expect(emitted).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ type: 'chunk', id: '/virtual/hostInit.js' }),
-        expect.objectContaining({ type: 'asset', fileName: 'mf-entry-bootstrap-0.js' }),
       ])
     );
-    expect(bundle['indexProd.html'].source).toContain('mf-entry-bootstrap-0.js');
+    expect(bundle['indexProd.html'].source).toContain(bootstrapAsset!.fileName);
   });
 
   it('wraps SvelteKit static inline startup behind host init during build', () => {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'fs';
 import * as path from 'pathe';
 import type { Plugin } from 'vite';
@@ -538,11 +539,20 @@ const addEntry = ({
           let rewritten = false;
           htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
             rewritten = true;
-            const bootstrapFileName = `mf-entry-bootstrap-${bootstrapIndex++}.js`;
+            const bootstrapSource = getSystemBootstrapSource(initPath, entrySrc);
+            // Content-hash the bootstrap filename so browsers/CDNs invalidate
+            // the cache on deploy. Without a hash the file ships as
+            // `mf-entry-bootstrap-0.js` and stale caches serve the old
+            // bootstrap, breaking app load after a deploy.
+            const bootstrapHash = createHash('sha256')
+              .update(bootstrapSource)
+              .digest('hex')
+              .slice(0, 8);
+            const bootstrapFileName = `mf-entry-bootstrap-${bootstrapIndex++}-${bootstrapHash}.js`;
             const bootstrapRef = this.emitFile({
               type: 'asset',
               fileName: bootstrapFileName,
-              source: getSystemBootstrapSource(initPath, entrySrc),
+              source: bootstrapSource,
             });
             const bootstrapPath = viteConfig.base + this.getFileName(bootstrapRef);
             return scriptTag.replace(entrySrc, bootstrapPath);


### PR DESCRIPTION
## Summary

- Append a short sha256 hash of the bootstrap source to the emitted bootstrap filename so it participates in the standard cache-busting flow.
- Without the hash, `mf-entry-bootstrap-0.js` is referenced from `index.html` but never invalidates in browser/CDN caches after a deploy, breaking app load until caches expire.
- Update test for the new `mf-entry-bootstrap-<index>-<hash>.js` shape.

Fixes #750

## Before

```
dist/index.html               → <script src="/mf-entry-bootstrap-0.js">
dist/mf-entry-bootstrap-0.js  ← no hash, stale on deploy
```

## After

```
dist/index.html                        → <script src="/mf-entry-bootstrap-0-3f1c9a2b.js">
dist/mf-entry-bootstrap-0-3f1c9a2b.js  ← content-hashed, invalidates on deploy
```

## Test plan

- [x] `pnpm test` (417 passing)
- [x] `pnpm typecheck`
- [x] Existing `pluginAddEntry` build-mode test updated to assert the new filename shape and that the HTML references the hashed bootstrap