### PR TITLE
perf: materialize each shared source's loadShare artifacts at most once

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -8,10 +8,24 @@ import type {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 
-const { hasPackageDependencyMock, existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
+const {
+  hasPackageDependencyMock,
+  existsSyncMock,
+  readFileSyncMock,
+  addUsedSharesMock,
+  refreshHostAutoInitMock,
+  writeLoadShareModuleMock,
+  writeLocalSharedImportMapMock,
+  writePreBuildLibPathMock,
+} = vi.hoisted(() => ({
   hasPackageDependencyMock: vi.fn<(pkg: string) => boolean>(),
   existsSyncMock: vi.fn<(path: string) => boolean>(() => false),
   readFileSyncMock: vi.fn<(path: string) => string>(() => '{}'),
+  addUsedSharesMock: vi.fn<(pkg: string) => void>(),
+  refreshHostAutoInitMock: vi.fn<() => void>(),
+  writeLoadShareModuleMock: vi.fn(),
+  writeLocalSharedImportMapMock: vi.fn<() => void>(),
+  writePreBuildLibPathMock: vi.fn(),
 }));
 
 vi.mock('fs', async (importOriginal) => {
@@ -139,10 +153,28 @@ vi.mock('../../virtualModules', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../virtualModules')>();
   return {
     ...actual,
+    addUsedShares: (pkg: string) => {
+      addUsedSharesMock(pkg);
+      return actual.addUsedShares(pkg);
+    },
+    refreshHostAutoInit: () => {
+      refreshHostAutoInitMock();
+      return actual.refreshHostAutoInit();
+    },
+    writeLoadShareModule: (
+      pkg: string,
+      shareItem: NormalizedShared[string],
+      command: string,
+      useRolldown: boolean
+    ) => {
+      writeLoadShareModuleMock(pkg, shareItem, command, useRolldown);
+      return actual.writeLoadShareModule(pkg, shareItem, command, useRolldown);
+    },
     writePreBuildLibPath: (pkg: string, shareItem?: NormalizedShared[string]) => {
+      writePreBuildLibPathMock(pkg, shareItem);
       preBuildShareItemMap.set(pkg, shareItem);
     },
-    writeLocalSharedImportMap: vi.fn(),
+    writeLocalSharedImportMap: writeLocalSharedImportMapMock,
     getPreBuildShareItem: (pkg: string) => preBuildShareItemMap.get(pkg),
     getConcreteSharedImportSource: (pkg: string, shareItem?: NormalizedShared[string]) =>
       typeof shareItem?.shareConfig.import === 'string'
@@ -217,6 +249,11 @@ function makeShared(): NormalizedShared {
 describe('pluginProxySharedModule_preBuild', () => {
   beforeEach(() => {
     hasPackageDependencyMock.mockReset();
+    addUsedSharesMock.mockReset();
+    refreshHostAutoInitMock.mockReset();
+    writeLoadShareModuleMock.mockReset();
+    writeLocalSharedImportMapMock.mockReset();
+    writePreBuildLibPathMock.mockReset();
     preBuildShareItemMap.clear();
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
@@ -433,6 +470,49 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     expect((resolution as { id: string }).id).toBeDefined();
     expect(preBuildShareItemMap.has('vue')).toBe(true);
+  });
+
+  it('materializes repeated loadShare resolutions once per shared source', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+    const resolveMock = vi.fn(async (id: string) => ({ id: `/resolved/${id}` }));
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: resolveMock,
+      } as unknown as ConfigPluginContext,
+      config,
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: resolveMock } as any,
+      'vue',
+      '/src/entry-a.ts',
+      { isEntry: false }
+    );
+    await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: resolveMock } as any,
+      'vue',
+      '/src/entry-b.ts',
+      { isEntry: false }
+    );
+
+    expect(writeLoadShareModuleMock).toHaveBeenCalledTimes(1);
+    expect(writeLoadShareModuleMock).toHaveBeenCalledWith('vue', makeShared().vue, 'build', false);
+    expect(writePreBuildLibPathMock).toHaveBeenCalledTimes(1);
+    expect(addUsedSharesMock).toHaveBeenCalledTimes(1);
+    expect(writeLocalSharedImportMapMock).toHaveBeenCalledTimes(1);
+    expect(refreshHostAutoInitMock).toHaveBeenCalledTimes(1);
+    expect(resolveMock).toHaveBeenCalledTimes(2);
   });
 
   it('skips prebuild for import: false shared deps in configResolved', () => {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -166,6 +166,12 @@ export function proxySharedModule(options: {
   let useRolldown = false;
   const savePrebuild = new PromiseStore<string>();
   let devServer: ViteDevServer | undefined;
+  // resolveId fires once per importing module. The loadShare virtual module,
+  // prebuild path, import map, and host-auto-init are a pure function of the
+  // shared source, so regenerating them on every resolution is redundant — a
+  // singleton imported by N modules would rewrite all of it N times. Track which
+  // sources have been materialized so the heavy writes happen at most once each.
+  const materializedLoadShareSources = new Set<string>();
 
   return [
     {
@@ -275,13 +281,16 @@ export function proxySharedModule(options: {
               ? getCommonSharedSubpathFromNodeModulePath(source, key) || key
               : source;
         const loadSharePath = getLoadShareModulePath(shareSource, useRolldown);
-        writeLoadShareModule(shareSource, shared[key], _command, useRolldown);
-        if (shared[key].shareConfig.import !== false) {
-          writePreBuildLibPath(shareSource, shared[key]);
+        if (!materializedLoadShareSources.has(shareSource)) {
+          materializedLoadShareSources.add(shareSource);
+          writeLoadShareModule(shareSource, shared[key], _command, useRolldown);
+          if (shared[key].shareConfig.import !== false) {
+            writePreBuildLibPath(shareSource, shared[key]);
+          }
+          addUsedShares(shareSource);
+          writeLocalSharedImportMap();
+          refreshHostAutoInit();
         }
-        addUsedShares(shareSource);
-        writeLocalSharedImportMap();
-        refreshHostAutoInit();
         return this.resolve(loadSharePath, importer, { skipSelf: true });
       },
     },


### PR DESCRIPTION
## Summary

`proxyPreBuildShared:resolve-shared-loadShare` is a `resolveId` hook (`enforce: 'pre'`), so it fires **once per importing module** for the whole build. On every call that matches a shared key it regenerates all of:

- `writeLoadShareModule` (the `__loadShare__` virtual module),
- `writePreBuildLibPath` (the `__prebuild__` fallback),
- `writeLocalSharedImportMap` (the **entire** local-shared import map), and
- `refreshHostAutoInit`,

and then redirects via `this.resolve`. These artifacts are a **pure function of the shared source**, so a singleton imported by N modules rewrites all of it N times — an `O(modules × shared)` cost that dominates builds for shared-heavy hosts.

This PR memoizes the heavy writes per shared source with a `Set<string>` on the plugin closure: the writes run **at most once per source**, while the import redirect (`getLoadShareModulePath` + `this.resolve`) still runs on **every** resolution, so resolution behavior is unchanged. Net change is 15 lines in one file.

## Why this is more than a micro-optimization

The redundant work isn't cheap. Each materialization calls `getPackageNamedExports()` (in `virtualShared_preBuild.ts`), which is **uncached** and `require()`s the package to introspect its exports — and it's called **twice** per materialization (once via `writeLoadShareModule`, once via `writePreBuildLibPath`). On top of that, `writeLocalSharedImportMap` regenerates by sorting and stringifying **every** used share on each call. Multiplying that by every importing module is where the time goes.

This is a regression introduced by the 1.15 rewrite. Dropping `customResolver` was the right call (and Vite 9 requires it anyway); this just closes the one hot path that replacement opened.

## Measured impact

Real host with ~26 shared singletons, cold build, 3-run average:

| Config | Build |
|---|---|
| pre-1.15 (`customResolver`) | ~4.5s |
| current `main` | ~8.0s |
| this PR | ~2.0s |

`PLUGIN_TIMINGS` on `main` attributed ~30% to `resolve-shared-loadShare`, ~28% to `module-federation-virtual-modules`, ~15% to `resolve-prebuild`. With this change the "spent significant time in plugins" warning disappears entirely. (The wall-clock numbers are from a private host, but the structural argument above is reproducible from the source alone — the cost scales with singleton count × importing modules.)

## Why it's safe

- **Output is byte-identical.** Same chunk count, same manifest — verified against `main`. The change only removes redundant regeneration; it never changes *what* gets written.
- **The skipped writes are idempotent.** `writeLoadShareModule`/`writePreBuildLibPath` are keyed by the same source and produce identical content on repeat; `addUsedShares` is a `Set.add`; `writeLocalSharedImportMap`/`refreshHostAutoInit` regenerate purely from the accumulated `usedShares` set, so re-running them when nothing new was added yields identical output. (`writeLocalSharedImportMap` already had a content-diff guard, so it never re-invalidated redundantly — this just also skips paying the regeneration cost.)
- **The memo key maps to a stable payload.** The `shareSource` is a pure function of `(source, key)`, and the share key is itself derived deterministically from the source, so a given `shareSource` always pairs with the same `ShareItem` config — there's no path where one source memoizes another's config.

## Anticipated questions

**Why a `Set` on the closure instead of memoizing inside `writeLoadShareModule`/`writePreBuildLibPath`?**
Those two could memoize their own content by key, but `writeLocalSharedImportMap` and `refreshHostAutoInit` are *aggregate* regenerators (they rebuild from all used shares), so they can't be memoized by a single source key at that level. Gating the whole block once per source is the change that actually removes the aggregate-regeneration cost, and it keeps the fix to one file. Pushing per-call memoization down into the writers as well would be a fine follow-up but isn't required for the win.

**`configResolved` already materializes every top-level shared key — could the hook skip those entirely (1→0 instead of N→1)?**
Yes, in principle: seeding the set with the keys `configResolved` writes would let the hook do zero work for plain top-level singletons and only materialize genuinely-new subpath sources. I left that out deliberately — it couples two currently-independent hooks and has to mirror `configResolved`'s skip predicate exactly (the `key.endsWith('/')` and direct-React cases). Happy to add it if you'd prefer, but the minimal change already captures the bulk of the regression.

**Does this affect dev/HMR?**
No. Shared config isn't hot-editable, and the existing `VirtualModule` object caches already assume that stability, so memoizing per source is consistent with current behavior. The set lives on the plugin closure, so it's per-build and cleared on each new build.

**Relationship to the deadlock work in #762?**
Orthogonal. This was found while investigating #762 and lives in the same area (`virtualShared_preBuild` resolve path), but it touches a different file and a different phase (resolution vs. chunk output) and produces identical output — there's no ordering dependency between them.

## Testing

- `pnpm typecheck` clean
- `pnpm test` — 425 passing
- `pnpm test:integration` — 34 passing
