### PR TITLE
fix: isolate __vite_preload helper into its own chunk to break shared-singleton loadShare deadlock

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -348,8 +348,9 @@ describe('module-federation-esm-shims', () => {
       : undefined;
   };
 
-  it('removes codeSplitting false, warns once, and installs federation groups', () => {
+  it('removes codeSplitting false, warns once, and installs bundler-appropriate isolation', () => {
     const plugin = getEsmShimsPlugin();
+    const runtimeInitId = virtualRuntimeInitStatus.getImportId();
     const config: any = {
       build: {
         rollupOptions: { output: { codeSplitting: false } },
@@ -359,9 +360,16 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    // `codeSplitting: false` is replaced with the federation groups.
-    expect(Array.isArray(config.build.rollupOptions.output.codeSplitting.groups)).toBe(true);
+    // Rollup (Vite 5–7) gets `manualChunks` and never `codeSplitting` (which Rollup
+    // rejects as an unknown output option).
+    expect(config.build.rollupOptions.output.codeSplitting).toBeUndefined();
+    expect(typeof config.build.rollupOptions.output.manualChunks).toBe('function');
+    expect(config.build.rollupOptions.output.manualChunks(`/virtual/${runtimeInitId}`)).toBe(
+      'runtimeInit'
+    );
+    // Rolldown (Vite 8+) gets the `codeSplitting` groups and no `manualChunks`.
     expect(Array.isArray(config.build.rolldownOptions.output.codeSplitting.groups)).toBe(true);
+    expect(config.build.rolldownOptions.output.manualChunks).toBeUndefined();
     expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
@@ -421,21 +429,25 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    // User manualChunks is removed in favor of federation codeSplitting groups.
-    expect(functionOutput.manualChunks).toBeUndefined();
-    expect(objectOutput.manualChunks).toBeUndefined();
-
-    // Federation chunks are still isolated via the name() group.
-    const nameFn = federationNameFn(functionOutput);
-    expect(nameFn(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
-    expect(nameFn(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
+    // Rollup output (Vite 5–7): user's manualChunks is replaced by the plugin's,
+    // and no codeSplitting is set.
+    expect(functionOutput.codeSplitting).toBeUndefined();
+    expect(typeof functionOutput.manualChunks).toBe('function');
+    expect(functionOutput.manualChunks(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
+    expect(functionOutput.manualChunks(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
       `react${LOAD_SHARE_TAG}chunk.js`
     );
-    // Non-federation modules are left to automatic chunking.
-    expect(nameFn('/src/custom.ts')).toBeNull();
+    // Non-federation modules are left to automatic chunking (and it is not the
+    // user's original function, which would have returned 'existing-fn-chunk').
+    expect(functionOutput.manualChunks('/src/custom.ts')).toBeUndefined();
 
-    // The preload helper is isolated into its own chunk.
-    expect(preloadHelperGroup(functionOutput)).toBeDefined();
+    // Rolldown output (Vite 8+): user's manualChunks is removed in favor of the
+    // federation codeSplitting groups, with the preload helper isolated.
+    expect(objectOutput.manualChunks).toBeUndefined();
+    const nameFn = federationNameFn(objectOutput);
+    expect(nameFn(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
+    expect(nameFn('/src/custom.ts')).toBeNull();
+    expect(preloadHelperGroup(objectOutput)).toBeDefined();
 
     // Warning was emitted (once for both outputs)
     expect(mfWarn).toHaveBeenCalled();

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -327,7 +327,28 @@ describe('module-federation-esm-shims', () => {
     ]);
   });
 
-  it('removes codeSplitting false and warns once', () => {
+  // Resolves the federation `name(id)` group function installed on an output.
+  const federationNameFn = (output: any): ((id: string) => string | null) => {
+    const groups = output?.codeSplitting?.groups;
+    if (!Array.isArray(groups)) {
+      throw new Error('expected federation codeSplitting groups to be installed');
+    }
+    const group = groups.find((g: any) => typeof g?.name === 'function');
+    if (!group) {
+      throw new Error('expected a federation name() group');
+    }
+    return group.name;
+  };
+
+  // Resolves the isolated preload-helper group installed on an output.
+  const preloadHelperGroup = (output: any): any => {
+    const groups = output?.codeSplitting?.groups;
+    return Array.isArray(groups)
+      ? groups.find((g: any) => g?.name === 'vite-preload-helper')
+      : undefined;
+  };
+
+  it('removes codeSplitting false, warns once, and installs federation groups', () => {
     const plugin = getEsmShimsPlugin();
     const config: any = {
       build: {
@@ -338,13 +359,15 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    expect(config.build.rollupOptions.output.codeSplitting).toBeUndefined();
-    expect(config.build.rolldownOptions.output.codeSplitting).toBeUndefined();
+    // `codeSplitting: false` is replaced with the federation groups.
+    expect(Array.isArray(config.build.rollupOptions.output.codeSplitting.groups)).toBe(true);
+    expect(Array.isArray(config.build.rolldownOptions.output.codeSplitting.groups)).toBe(true);
     expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
-  it('removes codeSplitting groups and warns once', () => {
+  it('replaces user codeSplitting groups with federation groups and warns once', () => {
     const plugin = getEsmShimsPlugin();
+    const runtimeInitId = virtualRuntimeInitStatus.getImportId();
     const config: any = {
       build: {
         rolldownOptions: {
@@ -364,17 +387,27 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    expect(config.build.rolldownOptions.output.codeSplitting).toBeUndefined();
+    const groups = config.build.rolldownOptions.output.codeSplitting.groups;
+    // User's 'react' group is dropped; federation groups take over.
+    expect(groups.find((g: any) => g.name === 'react')).toBeUndefined();
+    const helper = preloadHelperGroup(config.build.rolldownOptions.output);
+    expect(helper).toBeDefined();
+    // Matches Rolldown's injected helper id, not arbitrary user files.
+    expect(helper.test.test('\0vite/preload-helper.js')).toBe(true);
+    expect(helper.test.test('/src/preload-helper.ts')).toBe(false);
+    expect(federationNameFn(config.build.rolldownOptions.output)(`/virtual/${runtimeInitId}`)).toBe(
+      'runtimeInit'
+    );
     expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
   it('ignores user manualChunks and warns, keeps federation chunks isolated', () => {
     const plugin = getEsmShimsPlugin();
     const runtimeInitId = virtualRuntimeInitStatus.getImportId();
-    const functionOutput = {
+    const functionOutput: any = {
       manualChunks: vi.fn((_id: string) => 'existing-fn-chunk'),
     };
-    const objectOutput = {
+    const objectOutput: any = {
       manualChunks: {
         vendor: ['react'],
       },
@@ -388,27 +421,27 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    // Federation chunks are still isolated
-    expect(functionOutput.manualChunks(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
-    expect(functionOutput.manualChunks(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
+    // User manualChunks is removed in favor of federation codeSplitting groups.
+    expect(functionOutput.manualChunks).toBeUndefined();
+    expect(objectOutput.manualChunks).toBeUndefined();
+
+    // Federation chunks are still isolated via the name() group.
+    const nameFn = federationNameFn(functionOutput);
+    expect(nameFn(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
+    expect(nameFn(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
       `react${LOAD_SHARE_TAG}chunk.js`
     );
-    // User's manualChunks is ignored — non-federation modules return undefined
-    expect(functionOutput.manualChunks('/src/custom.ts')).toBeUndefined();
+    // Non-federation modules are left to automatic chunking.
+    expect(nameFn('/src/custom.ts')).toBeNull();
 
-    const objectManualChunks: unknown = objectOutput.manualChunks;
-    expect(typeof objectManualChunks).toBe('function');
-    if (typeof objectManualChunks !== 'function') {
-      throw new Error('manualChunks should be patched into a function');
-    }
-    expect(objectManualChunks('/src/react/index.ts')).toBeUndefined();
-    expect(objectManualChunks('/src/other/index.ts')).toBeUndefined();
+    // The preload helper is isolated into its own chunk.
+    expect(preloadHelperGroup(functionOutput)).toBeDefined();
 
     // Warning was emitted (once for both outputs)
     expect(mfWarn).toHaveBeenCalled();
   });
 
-  it('patches manualChunks and removes codeSplitting groups for rolldown output arrays', () => {
+  it('installs federation groups and removes manualChunks for rolldown output arrays', () => {
     const plugin = getEsmShimsPlugin();
     const runtimeInitId = virtualRuntimeInitStatus.getImportId();
     const config: any = {
@@ -437,17 +470,19 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    expect(config.build.rolldownOptions.output[0].codeSplitting).toBeUndefined();
-    const patchedManualChunks = config.build.rolldownOptions.output[1].manualChunks;
-    expect(typeof patchedManualChunks).toBe('function');
-    if (typeof patchedManualChunks !== 'function') {
-      throw new Error('manualChunks should be patched into a function');
-    }
-    expect(patchedManualChunks(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
-    expect(patchedManualChunks(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
+    const out0 = config.build.rolldownOptions.output[0];
+    const out1 = config.build.rolldownOptions.output[1];
+    // User's 'react' group is dropped; preload helper isolated on out0.
+    expect(out0.codeSplitting.groups.find((g: any) => g.name === 'react')).toBeUndefined();
+    expect(preloadHelperGroup(out0)).toBeDefined();
+    // User's manualChunks removed; federation groups installed on out1.
+    expect(out1.manualChunks).toBeUndefined();
+    const nameFn = federationNameFn(out1);
+    expect(nameFn(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
+    expect(nameFn(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
       `react${LOAD_SHARE_TAG}chunk.js`
     );
-    expect(patchedManualChunks('/src/other/index.ts')).toBeUndefined();
+    expect(nameFn('/src/other/index.ts')).toBeNull();
     expect(mfWarn).toHaveBeenCalledTimes(2);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -691,7 +691,11 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         };
 
         let warnedAboutManualChunks = false;
-        const applyManualChunks = (output: MutableBundlerOutput) => {
+        // `useCodeSplitting` selects the bundler-appropriate isolation mechanism:
+        // Rolldown (Vite 8+) supports `codeSplitting` (and needs it to relocate the
+        // injected preload helper), while Rollup (Vite 5–7) only understands
+        // `manualChunks` and rejects `codeSplitting` as an unknown output option.
+        const applyManualChunks = (output: MutableBundlerOutput, useCodeSplitting: boolean) => {
           ensureCodeSplitting(output);
           const isPatchedByPlugin =
             typeof output.manualChunks === 'function' &&
@@ -718,10 +722,23 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
             return null;
           };
           patchedManualChunks.add(mfChunkName);
-          // `manualChunks` cannot relocate the injected preload helper (Rolldown
-          // ignores its placement), so use `codeSplitting` instead: a dynamic
-          // `name()` group reproduces the runtimeInit/loadShare isolation, and a
-          // higher-priority `test` group pulls the preload helper into its own
+
+          if (!useCodeSplitting) {
+            // Rollup (Vite 5–7): `codeSplitting` is rejected as an unknown output
+            // option, and the hoisted-preload-helper deadlock is Rolldown-specific,
+            // so keep the original `manualChunks` isolation of runtimeInit/loadShare.
+            const mfManualChunks = function (id: string) {
+              return mfChunkName(id) ?? undefined;
+            };
+            patchedManualChunks.add(mfManualChunks);
+            output.manualChunks = mfManualChunks;
+            return;
+          }
+
+          // Rolldown (Vite 8+): `manualChunks` cannot relocate the injected preload
+          // helper (Rolldown ignores its placement), so use `codeSplitting` instead:
+          // a dynamic `name()` group reproduces the runtimeInit/loadShare isolation,
+          // and a higher-priority `test` group pulls the preload helper into its own
           // chunk (the helper is only matched by `test`, never the `name()` fn).
           const groups: CodeSplittingGroup[] = [
             { name: PRELOAD_HELPER_CHUNK, test: PRELOAD_HELPER_TEST, priority: 100 },
@@ -734,14 +751,19 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         config.build.rollupOptions = config.build.rollupOptions || {};
         const rollupOutput = config.build.rollupOptions.output;
         if (Array.isArray(rollupOutput)) {
-          rollupOutput.forEach((output) => applyManualChunks(output as MutableBundlerOutput));
+          rollupOutput.forEach((output) =>
+            applyManualChunks(output as MutableBundlerOutput, false)
+          );
         } else {
-          applyManualChunks((config.build.rollupOptions.output ||= {}) as MutableBundlerOutput);
+          applyManualChunks(
+            (config.build.rollupOptions.output ||= {}) as MutableBundlerOutput,
+            false
+          );
         }
 
-        // Vite 8+ reads build.rolldownOptions instead of rollupOptions.
-        // Apply the same split there so runtimeInit and loadShare stay isolated
-        // under both bundlers.
+        // Vite 8+ reads build.rolldownOptions instead of rollupOptions. Apply the
+        // same runtimeInit/loadShare isolation there, but via `codeSplitting` so the
+        // Rolldown-injected preload helper can also be pulled into its own chunk.
         const buildWithRolldown = config.build as typeof config.build & {
           rolldownOptions?: RolldownOptionsLike;
         };
@@ -756,11 +778,12 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           assetFileNames: output.assetFileNames,
         });
         if (Array.isArray(rolldownOutput)) {
-          rolldownOutput.forEach((output) => applyManualChunks(output));
+          rolldownOutput.forEach((output) => applyManualChunks(output, true));
           desiredRolldownOutput = rolldownOutput.map((output) => snapshotRolldownOutput(output));
         } else {
           applyManualChunks(
-            (buildWithRolldown.rolldownOptions.output ||= {}) as MutableBundlerOutput
+            (buildWithRolldown.rolldownOptions.output ||= {}) as MutableBundlerOutput,
+            true
           );
           // Vite 8's Rolldown build path overwrites output options like
           // entryFileNames/chunkFileNames/assetFileNames. Keep only those

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,24 @@ import {
 
 const patchedManualChunks = new WeakSet<Function>();
 
+// Rolldown injects the `__vite_preload` helper as a special runtime module and,
+// left to automatic chunking, hoists it into whichever loadShare chunk first uses
+// it. When that shared singleton's source statically imports another shared
+// singleton, the resulting cross-loadShare static import closes a top-level-await
+// cycle and the host deadlocks on bootstrap. Isolate the helper into its own
+// dependency-free, TLA-free chunk so no loadShare chunk imports it from a sibling.
+const PRELOAD_HELPER_CHUNK = 'vite-preload-helper';
+// Matches Rolldown's injected helper module id (`\0vite/preload-helper.js`).
+// Anchored on the `vite/` segment so a user module merely named "preload-helper"
+// isn't pulled into this chunk; the leading virtual-module NUL is optional.
+const PRELOAD_HELPER_TEST = /\0?vite\/preload-helper/;
+
+type CodeSplittingGroup = {
+  name: string | ((id: string) => string | null);
+  test?: RegExp;
+  priority?: number;
+};
+
 function normalizeVinextRscPreloadHints(code: string): string {
   return code
     .replace(/(:HL\[[^\]\n]*?,)"stylesheet"/g, '$1"style"')
@@ -645,6 +663,20 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           if (!output?.codeSplitting || typeof output.codeSplitting !== 'object') return;
           if (!('groups' in output.codeSplitting)) return;
 
+          // Don't strip the groups we set ourselves in applyManualChunks — they
+          // isolate the loadShare/runtimeInit wrappers and the preload helper.
+          const groups = output.codeSplitting.groups;
+          if (
+            Array.isArray(groups) &&
+            groups.some(
+              (group) =>
+                typeof (group as Partial<CodeSplittingGroup>)?.name === 'function' &&
+                patchedManualChunks.has((group as { name: Function }).name)
+            )
+          ) {
+            return;
+          }
+
           delete output.codeSplitting.groups;
           if (Object.keys(output.codeSplitting).length === 0) {
             delete output.codeSplitting;
@@ -673,7 +705,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
                 'the application to silently hang.'
             );
           }
-          const mfManualChunks = function (id: string) {
+          const mfChunkName = function (id: string): string | null {
             // Keep runtimeInitStatus in its own chunk to break init deadlock
             if (id.includes(runtimeInitId)) {
               return 'runtimeInit';
@@ -683,9 +715,20 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
               const match = id.match(/([^/\\]+__loadShare__[^/\\]+)/);
               return match ? match[1] : 'loadShare';
             }
+            return null;
           };
-          patchedManualChunks.add(mfManualChunks);
-          output.manualChunks = mfManualChunks;
+          patchedManualChunks.add(mfChunkName);
+          // `manualChunks` cannot relocate the injected preload helper (Rolldown
+          // ignores its placement), so use `codeSplitting` instead: a dynamic
+          // `name()` group reproduces the runtimeInit/loadShare isolation, and a
+          // higher-priority `test` group pulls the preload helper into its own
+          // chunk (the helper is only matched by `test`, never the `name()` fn).
+          const groups: CodeSplittingGroup[] = [
+            { name: PRELOAD_HELPER_CHUNK, test: PRELOAD_HELPER_TEST, priority: 100 },
+            { name: mfChunkName },
+          ];
+          output.codeSplitting = { ...(output.codeSplitting || {}), groups };
+          delete output.manualChunks;
         };
 
         config.build.rollupOptions = config.build.rollupOptions || {};


### PR DESCRIPTION
Fixes #762.

## The bug

When one shared `singleton` module statically imports **another** shared `singleton`, the host hangs forever during bootstrap: it loads `mf-entry-bootstrap` → `hostInit` → both `loadShare` virtual modules, then deadlocks — `loadRemote` is never reached, `remoteEntry.js` is never requested, nothing is logged. A silent hang.

Regressed in **1.15.0** (last good: 1.14.5). The 1.15.0 `loadShare` rewrite (#638 / #645) removed the `customResolver` and introduced the top-level-`await` form of the local fallback, which is what closes the cycle described below.

## Root cause

Rolldown injects the `__vite_preload` helper as a special runtime module. Left to automatic chunking, it **hoists the helper into whichever shared-singleton `loadShare` chunk first uses it**. Each workspace-source singleton's `loadShare` wrapper does a top-level `await import(localSource)` (the `usesLazyLocalFallback` path), and that singleton's source statically imports the other singleton. The hoisted helper adds a static import from one `loadShare` chunk to the sibling, closing a ring of three top-level-await modules:

```
i18n loadShare chunk ──(static import, only to get the __vite_preload helper)──▶ api loadShare chunk
        ▲                                                                              │
        │                                                          (TLA: await import(api's own source))
        └──────────────(static import)──────── api source ◀────────────────────────────┘
                                          (api's source statically imports @byte/i18n)
```

Three top-level-await modules in a static-import cycle → none of their evaluation promises can resolve → deadlock. The lethal ingredient is **TLA inside the cycle** (plain cyclic imports are fine); the rewrite added the TLA and the hoisted-helper static edge closed the ring.

**Precondition (why it's rarely reported):** both modules must be shared `singleton` **and** consumed as workspace source — `exports` pointing at TS source (`"exports": { "import": "./src/index.ts" }`), which routes them through the `usesLazyLocalFallback` TLA path. Projects that share built npm packages take the non-TLA path and never hit this. This is a legitimate, common monorepo setup, not a misconfiguration.

## The fix

Isolate the `__vite_preload` helper into its **own** dependency-free, TLA-free chunk so no `loadShare` chunk statically imports it from a sibling — the ring never closes. Implemented by migrating the plugin's chunking from `manualChunks` to `codeSplitting` (all in `src/index.ts`):

- A high-priority `test`-based group pulls the preload helper into its own `vite-preload-helper` chunk.
- A dynamic `name(id)` group reproduces the existing `runtimeInit` / `loadShare` isolation.
- `ensureCodeSplitting` gains a guard so it strips user-supplied `codeSplitting.groups` (as before) but never the plugin's own groups.

### Why not `manualChunks`?

`manualChunks` **cannot** relocate the preload helper — Rolldown treats it as a special runtime module whose placement `manualChunks` does not govern (verified on rolldown 1.0.2: returning a name for the helper from `manualChunks` produced byte-identical output). Only `codeSplitting` / `advancedChunks` can move it. Within `codeSplitting`, the helper is captured by a `test` group but is **not** passed to the dynamic `name()` function, so the helper must be its own `test` group.

## Validation

- `pnpm typecheck` clean; `pnpm test` **425 passed** (29 files); `pnpm test:integration` **34 passed** (9 files).
- **Minimal repro** (https://github.com/falldowngoboone/mf-vite-shared-singleton-deadlock): deadlocks deterministically on the pre-fix plugin and passes on the fixed plugin, on both Chromium and WebKit. Same repo, same machine, only the plugin version swapped:

  | Plugin | isolated `vite-preload-helper` chunk? | Playwright (Chromium + WebKit) |
  |---|---|---|
  | pre-fix | no | 2 failed (deadlock, 30s timeout both browsers) |
  | this fix | yes | 2 passed |

- **Real ~26-singleton host:** built on this fix and inspected the actual chunks — `vite-preload-helper` chunk created (dependency-free, no TLA), all cross-`loadShare` cycle edges removed, all 37 `loadShare` chunks preserved; e2e (chromium + webkit) green.

## Related

- #369 — prior precedent: isolating the preload helper to prevent a shared-module deadlock (Vite-7 era). This is the Rolldown-era re-introduction of that class of bug.
- #638 / #645 — the 1.15.0 `loadShare` rewrite that introduced the regression.
