### PR TITLE
fix: walk static-import graph when collecting expose async assets

### DIFF
--- a/src/utils/__tests__/cssModuleHelpers.test.ts
+++ b/src/utils/__tests__/cssModuleHelpers.test.ts
@@ -184,9 +184,16 @@ describe('cssModuleHelpers', () => {
         },
         'sibling.js': {
           ...createChunk('sibling.js'),
+          imports: ['nested.js'],
           dynamicImports: ['async.js'],
         },
+        'nested.js': {
+          ...createChunk('nested.js'),
+          imports: ['entry.js'],
+          dynamicImports: ['nested-async.js'],
+        },
         'async.js': createChunk('async.js'),
+        'nested-async.js': createChunk('nested-async.js'),
       } satisfies Record<string, OutputBundleItem>;
 
       const filesMap = {};
@@ -196,7 +203,7 @@ describe('cssModuleHelpers', () => {
 
       expect(filesMap).toEqual({
         module1: {
-          js: { sync: ['entry.js'], async: ['async.js'] },
+          js: { sync: ['entry.js'], async: ['async.js', 'nested-async.js'] },
           css: { sync: [], async: [] },
         },
       });

--- a/src/utils/__tests__/cssModuleHelpers.test.ts
+++ b/src/utils/__tests__/cssModuleHelpers.test.ts
@@ -173,6 +173,35 @@ describe('cssModuleHelpers', () => {
       });
     });
 
+    it('tracks dynamic imports reachable through the static-import graph', () => {
+      const bundle = {
+        'entry.js': {
+          ...createChunk('entry.js'),
+          modules: {
+            module1: createRenderedModule(),
+          },
+          imports: ['sibling.js'],
+        },
+        'sibling.js': {
+          ...createChunk('sibling.js'),
+          dynamicImports: ['async.js'],
+        },
+        'async.js': createChunk('async.js'),
+      } satisfies Record<string, OutputBundleItem>;
+
+      const filesMap = {};
+      const moduleMatcher = (path: string) => path;
+
+      processModuleAssets(bundle, filesMap, moduleMatcher);
+
+      expect(filesMap).toEqual({
+        module1: {
+          js: { sync: ['entry.js'], async: ['async.js'] },
+          css: { sync: [], async: [] },
+        },
+      });
+    });
+
     it('tracks CSS assets from viteMetadata.importedCss', () => {
       const bundle = {
         'App-abc123.js': {

--- a/src/utils/cssModuleHelpers.ts
+++ b/src/utils/cssModuleHelpers.ts
@@ -184,14 +184,25 @@ export const processModuleAssets = (
         }
       }
 
-      // Handle dynamic imports
-      if (fileData.dynamicImports) {
-        for (const dynamicImport of fileData.dynamicImports) {
-          const importData = bundle[dynamicImport];
-          if (!importData) continue;
+      // Handle dynamic imports reachable through the static-import graph
+      const visited = new Set<string>();
+      const queue: string[] = [fileName];
+      while (queue.length) {
+        const cur = queue.shift()!;
+        if (visited.has(cur)) continue;
+        visited.add(cur);
+        const chunk = bundle[cur];
+        if (!chunk || chunk.type !== 'chunk') continue;
 
-          const isCss = isCSSFile(dynamicImport);
-          trackAsset(filesMap, matchKey, dynamicImport, true, isCss ? 'css' : 'js');
+        if (chunk.dynamicImports) {
+          for (const dynamicImport of chunk.dynamicImports) {
+            if (!bundle[dynamicImport]) continue;
+            const isCss = isCSSFile(dynamicImport);
+            trackAsset(filesMap, matchKey, dynamicImport, true, isCss ? 'css' : 'js');
+          }
+        }
+        if (chunk.imports) {
+          for (const imp of chunk.imports) queue.push(imp);
         }
       }
     }

--- a/src/utils/cssModuleHelpers.ts
+++ b/src/utils/cssModuleHelpers.ts
@@ -184,11 +184,11 @@ export const processModuleAssets = (
         }
       }
 
-      // Handle dynamic imports reachable through the static-import graph
+      // Handle dynamic imports from static chunks reachable from the matched expose chunk
       const visited = new Set<string>();
       const queue: string[] = [fileName];
-      while (queue.length) {
-        const cur = queue.shift()!;
+      for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+        const cur = queue[queueIndex];
         if (visited.has(cur)) continue;
         visited.add(cur);
         const chunk = bundle[cur];


### PR DESCRIPTION
Fixes #770.

## Problem

`processModuleAssets` (`src/utils/cssModuleHelpers.ts`) was only inspecting the **matched chunk's direct** `dynamicImports`. When Rollup splits the expose entry into multiple sibling chunks reachable via static imports — a common shape when the expose entry re-exports from a larger routes/config module that owns the `lazy()` declarations — sibling chunks carry the dynamic-import edges, but the matcher never visits them under the expose's `matchKey`. Result: `mf-manifest.json` emits empty `exposes[*].assets.js.async` arrays despite Vite producing real async chunks in `dist/assets/`.

Downstream: `@module-federation/runtime`'s `preloadRemote({ resourceCategory: 'all' })` has nothing to preload — lazy chunks fetch on demand at navigation time instead of in parallel with the sync burst.

Full repro: https://github.com/DanBeckDev/mfevite-async-chunk-repro (linked from the issue).

## Change

Switch the one-level `dynamicImports` scan to a BFS from the matched chunk through `chunk.imports` (static-import graph), accumulating each visited chunk's `dynamicImports` as async assets under the expose's `matchKey`. `visited: Set<string>` guards against cycles.

- Strictly additive — only adds entries to `async` arrays
- Sync arrays unchanged
- No behavior change for the single-chunk case (the existing `'processes module assets'` test still passes verbatim)

```diff
-      // Handle dynamic imports
-      if (fileData.dynamicImports) {
-        for (const dynamicImport of fileData.dynamicImports) {
-          const importData = bundle[dynamicImport];
-          if (!importData) continue;
+      // Handle dynamic imports reachable through the static-import graph
+      const visited = new Set<string>();
+      const queue: string[] = [fileName];
+      while (queue.length) {
+        const cur = queue.shift()!;
+        if (visited.has(cur)) continue;
+        visited.add(cur);
+        const chunk = bundle[cur];
+        if (!chunk || chunk.type !== 'chunk') continue;

-          const isCss = isCSSFile(dynamicImport);
-          trackAsset(filesMap, matchKey, dynamicImport, true, isCss ? 'css' : 'js');
+        if (chunk.dynamicImports) {
+          for (const dynamicImport of chunk.dynamicImports) {
+            if (!bundle[dynamicImport]) continue;
+            const isCss = isCSSFile(dynamicImport);
+            trackAsset(filesMap, matchKey, dynamicImport, true, isCss ? 'css' : 'js');
+          }
+        }
+        if (chunk.imports) {
+          for (const imp of chunk.imports) queue.push(imp);
         }
       }
```

## Test

New regression test in `src/utils/__tests__/cssModuleHelpers.test.ts` (`'tracks dynamic imports reachable through the static-import graph'`) covers the transitive case: matched chunk with `imports: ['sibling.js']`, sibling chunk with `dynamicImports: ['async.js']`. Without the patch the test fails with `async: []`; with the patch it passes with `async: ['async.js']`.

Verified locally:

- Full suite: 426/426 pass (425 existing + 1 new)
- Same suite with patch reverted (test alone, not source): the new test fails as expected, all 425 existing pass — confirms no regression in existing coverage and the new test catches the bug
- Empirical end-to-end: compiled `.mjs` patched in the repro's `node_modules`; manifest's `async[]` goes from `[]` to listing all 6 lazy page chunks; chunk hashes unchanged