### PR TITLE
fix: detect shared named exports from configured import source

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -166,7 +166,8 @@ vi.mock('fs', () => ({
       filePath.endsWith('node_modules/mock-package-browser-conditional/dist/server.js') ||
       filePath.endsWith('/mock-package-browser-conditional/dist/server.js') ||
       filePath.endsWith('/repo/packages/workspace-shared-lib/package.json') ||
-      filePath.endsWith('/repo/packages/workspace-name-mismatch/package.json')
+      filePath.endsWith('/repo/packages/workspace-name-mismatch/package.json') ||
+      filePath.endsWith('/repo/packages/custom-shared-source/index.ts')
   ),
   readFileSync: vi.fn((filePath: string) => {
     if (
@@ -307,6 +308,12 @@ export { type, other } from './foo';`;
     if (filePath.endsWith('/repo/packages/workspace-name-mismatch/package.json')) {
       return JSON.stringify({ name: 'different-package-name' });
     }
+    if (filePath.endsWith('/repo/packages/custom-shared-source/index.ts')) {
+      return `export const sharedValue = 'shared';
+              export function useSharedFeature() {
+                return sharedValue;
+              }`;
+    }
     throw new Error(`Unexpected readFileSync path: ${filePath}`);
   }),
   realpathSync: Object.assign(
@@ -325,6 +332,9 @@ export { type, other } from './foo';`;
       ),
     }
   ),
+  statSync: vi.fn(() => ({
+    isDirectory: () => false,
+  })),
 }));
 
 // Mock module/createRequire to return specific named exports
@@ -597,6 +607,37 @@ describe('writeLoadShareModule', () => {
     );
   });
 
+  it('detects prebuild named exports from shareConfig.import when it points at a non-package module', () => {
+    const pkg = '@repo/custom-shared-source';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/custom-shared-source',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writePreBuildLibPath(pkg, mockShareItem);
+
+    expect(writeSyncSpy).toHaveBeenCalled();
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'import * as __mfPrebuildNamespace from "/repo/packages/custom-shared-source";'
+    );
+    expect(generatedCode).toContain('const __mf_0 = __mfPrebuildExports["sharedValue"];');
+    expect(generatedCode).toContain('const __mf_1 = __mfPrebuildExports["useSharedFeature"];');
+    expect(generatedCode).toContain(
+      'export { __mf_0 as sharedValue, __mf_1 as useSharedFeature };'
+    );
+    expect(generatedCode).not.toContain('export * from "/repo/packages/custom-shared-source"');
+  });
+
   it('inlines a build-only cache bootstrap without importing runtimeInit', () => {
     const pkg = 'mock-package-with-reserved';
     const mockShareItem: ShareItem = {
@@ -689,6 +730,68 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('import * as __mfLocalShare from "/abs/pkg-b/dist/index.js";');
     expect(generatedCode).toContain('export * from "/abs/pkg-b/dist/index.js"');
     expect(generatedCode).not.toContain('import "mock-import-id";');
+  });
+
+  it('detects loadShare named exports from shareConfig.import when it points at a non-package module', () => {
+    const pkg = '@repo/custom-shared-source';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/custom-shared-source',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'import * as __mfLocalShare from "/repo/packages/custom-shared-source";'
+    );
+    expect(generatedCode).toContain(
+      'const { sharedValue: __mf_0, useSharedFeature: __mf_1 } = exportModule;'
+    );
+    expect(generatedCode).toContain(
+      'export { __mf_0 as sharedValue, __mf_1 as useSharedFeature };'
+    );
+    expect(generatedCode).not.toContain('export * from "/repo/packages/custom-shared-source"');
+    expect(generatedCode).not.toContain('mock-import-id');
+  });
+
+  it('falls back to package-based named export detection when shareConfig.import cannot be inspected', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/missing/mock-package-with-reserved/index.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'import * as __mfLocalShare from "/missing/mock-package-with-reserved/index.js";'
+    );
+    expect(generatedCode).toContain(
+      'const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;'
+    );
+    expect(generatedCode).toContain(
+      'export { __mf_0 as delete, __mf_1 as get, __mf_2 as request };'
+    );
   });
 
   it('uses cache-backed react output for Astro build output', () => {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -794,6 +794,33 @@ describe('writeLoadShareModule', () => {
     );
   });
 
+  it('detects named exports from the ESM entry of configured bare import sources', () => {
+    const pkg = 'mock-package-browser-conditional';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: pkg,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'import * as __mfLocalShare from "mock-package-browser-conditional";'
+    );
+    expect(generatedCode).toContain('const { clientOnly: __mf_0 } = exportModule;');
+    expect(generatedCode).toContain('export { __mf_0 as clientOnly };');
+    expect(generatedCode).not.toContain('serverOnly');
+  });
+
   it('uses cache-backed react output for Astro build output', () => {
     hasPackageDependencyMock.mockImplementation((pkg: string) => pkg === 'astro');
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -123,16 +123,19 @@ function resolveConfiguredImportPath(importSource: string): string | undefined {
     return resolveFileLikeModule(path.resolve(projectRoot, importSource));
   }
 
+  const esmEntry = getInstalledPackageEntry(importSource, {
+    conditions: ['browser', 'import', 'module', 'default'],
+    resolveSubpathWithRequire: false,
+  });
+  if (esmEntry) return esmEntry;
+
   try {
     const projectRequire = createRequire(
       new URL(`file://${path.join(projectRoot, 'package.json')}`)
     );
     return projectRequire.resolve(importSource);
   } catch {
-    return getInstalledPackageEntry(importSource, {
-      conditions: ['browser', 'import', 'module', 'default'],
-      resolveSubpathWithRequire: false,
-    });
+    return undefined;
   }
 }
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -83,11 +83,9 @@ function getPackageEsmEntryPath(pkg: string): string | undefined {
   );
 }
 
-function getEsmNamedExports(pkg: string): string[] {
+function getEsmNamedExportsFromFile(entryPath: string | undefined): string[] {
   let source = '';
-  let entryPath: string | undefined;
   try {
-    entryPath = getPackageEsmEntryPath(pkg);
     if (!entryPath) return [];
 
     const { initSync, parse } = localRequire('es-module-lexer') as typeof import('es-module-lexer');
@@ -109,6 +107,50 @@ function getEsmNamedExports(pkg: string): string[] {
   } catch {
     return source ? getNamedExportsViaRegex(source, entryPath) : [];
   }
+}
+
+function getEsmNamedExports(pkg: string): string[] {
+  return getEsmNamedExportsFromFile(getPackageEsmEntryPath(pkg));
+}
+
+function resolveConfiguredImportPath(importSource: string): string | undefined {
+  if (path.isAbsolute(importSource)) {
+    return resolveFileLikeModule(importSource);
+  }
+
+  const projectRoot = getPackageDetectionCwd();
+  if (importSource.startsWith('.')) {
+    return resolveFileLikeModule(path.resolve(projectRoot, importSource));
+  }
+
+  try {
+    const projectRequire = createRequire(
+      new URL(`file://${path.join(projectRoot, 'package.json')}`)
+    );
+    return projectRequire.resolve(importSource);
+  } catch {
+    return getInstalledPackageEntry(importSource, {
+      conditions: ['browser', 'import', 'module', 'default'],
+      resolveSubpathWithRequire: false,
+    });
+  }
+}
+
+function resolveFileLikeModule(filePath: string): string | undefined {
+  if (existsSync(filePath) && !statSync(filePath).isDirectory()) return filePath;
+
+  const extensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.mts'];
+  for (const ext of extensions) {
+    const candidate = filePath + ext;
+    if (existsSync(candidate) && !statSync(candidate).isDirectory()) return candidate;
+  }
+
+  for (const ext of extensions) {
+    const candidate = path.join(filePath, 'index' + ext);
+    if (existsSync(candidate) && !statSync(candidate).isDirectory()) return candidate;
+  }
+
+  return undefined;
 }
 
 function resolveRelativeModule(filePath: string, specifier: string): string | undefined {
@@ -208,6 +250,17 @@ function getPackageNamedExports(pkg: string): string[] {
   } catch {
     return getEsmNamedExports(pkg);
   }
+}
+
+function getSharedNamedExports(pkg: string, shareItem?: ShareItem): string[] {
+  const configuredImport = shareItem?.shareConfig.import;
+  if (typeof configuredImport === 'string') {
+    const configuredImportPath = resolveConfiguredImportPath(configuredImport);
+    const configuredNamedExports = getEsmNamedExportsFromFile(configuredImportPath);
+    if (configuredNamedExports.length > 0) return configuredNamedExports;
+  }
+
+  return getPackageNamedExports(pkg);
 }
 
 export function getLocalProviderImportPath(pkg: string): string | undefined {
@@ -327,7 +380,7 @@ export function writePreBuildLibPath(pkg: string, shareItem?: ShareItem) {
     );
     return;
   }
-  const namedExports = getPackageNamedExports(pkg);
+  const namedExports = getSharedNamedExports(pkg, shareItem);
   if (namedExports.length > 0) {
     const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
     const declarations = namedExports
@@ -516,7 +569,7 @@ export function writeLoadShareModule(
     concreteSharedImportSource || localProviderPath || sharedImportSource;
   const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
   const usesLazyLocalFallback = isWorkspacePackage && shareItem.shareConfig.singleton === true;
-  const namedExports = getPackageNamedExports(pkg);
+  const namedExports = getSharedNamedExports(pkg, shareItem);
   let exportLine: string;
   if (namedExports.length > 0) {
     const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(', ')} } = exportModule;`;


### PR DESCRIPTION
## Summary

Fix named export detection for shared modules when `shareConfig.import` is explicitly configured.

Shared wrapper generation already uses `shareConfig.import` as the concrete source when provided, but named export detection previously still resolved exports from the shared package key. For explicit import paths that are not standalone package entries, this could cause named exports to be missed and the generated wrapper to fall back to a less precise export shape.

This change resolves and parses the configured import source first, then falls back to the existing package-based detection for backward compatibility.

## Problem

Given a shared config like:

```ts
shared: {
  '@repo/custom-shared-source': {
    import: '/repo/packages/custom-shared-source',
    singleton: true,
  },
}
```
the generated shared wrapper imports from the configured source:
```ts
'/repo/packages/custom-shared-source'
```
However, named export detection previously inspected only the shared key:
```ts
'@repo/custom-shared-source'
```
If that key is not a resolvable package entry, named export detection returns no exports even though the configured import source has valid named exports.

## Changes

- Added resolution for string `shareConfig.import` values during named export detection.
- Added file-like resolution for configured import paths, including extensionless paths and directory `index.*` entries.
- Reused the existing ESM export parsing logic for resolved configured import files.
- Preserved existing package-based named export detection as the fallback path.
- Left `import: false` behavior unchanged, since that mode has no local implementation source to inspect.
- Added unit coverage for:
  - named exports from explicit shareConfig.import sources
  - prebuild wrapper generation
  - loadShare wrapper generation
  - fallback to package-based detection
  - existing package-based behavior

## Why This Is Backward Compatible

- When `shareConfig.import` is not provided, behavior is unchanged.
- When `shareConfig.import` is provided but cannot be resolved or parsed, the implementation falls back to the existing package-based named export detection.
- `import: false` continues to use the existing package-based dev dependency detection behavior.