### PR TITLE
fix: handle cached shared subpath optimization

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,6 +11,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getLoadShareImportId,
   getLoadShareModulePath,
+  toViteOptimizedDepVirtualId,
 } from '../virtualModules/virtualShared_preBuild';
 import type { PluginManifestOptions } from '../utils/normalizeModuleFederationOptions';
 
@@ -719,6 +720,54 @@ describe('vite:module-federation-early-init', () => {
     expect(config.optimizeDeps.include).not.toContain(getPreBuildLibImportId('vue'));
     expect(config.optimizeDeps.include).not.toContain(getLoadShareImportId('vue', false));
     expect(config.optimizeDeps.include.join(',')).not.toContain('virtual:mf:');
+  });
+
+  it('uses Vite-resolvable loadShare ids in non-Rolldown optimized dep shared proxies', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        shared: {
+          'pkg-foo/': {
+            singleton: true,
+          },
+        },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: ['pkg-bar'],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const optimizeSharedProxy = config.optimizeDeps.esbuildOptions.plugins.find(
+      (entry: any) => entry.name === 'module-federation:optimize-shared-proxy'
+    );
+    const onResolveHandlers: any[] = [];
+    const onLoadHandlers: any[] = [];
+    optimizeSharedProxy.setup({
+      onResolve: (_options: unknown, handler: unknown) => onResolveHandlers.push(handler),
+      onLoad: (_options: unknown, handler: unknown) => onLoadHandlers.push(handler),
+    });
+
+    const result = onLoadHandlers[0]({ path: 'pkg-foo/a' });
+    const loadSharePath = getLoadShareModulePath('pkg-foo/a', false);
+    const optimizedLoadSharePath = toViteOptimizedDepVirtualId(loadSharePath);
+
+    expect(onResolveHandlers[0]({ path: optimizedLoadSharePath })).toEqual({
+      path: optimizedLoadSharePath,
+      external: true,
+    });
+    expect(result.contents).toContain(JSON.stringify(optimizedLoadSharePath));
+    expect(result.contents).not.toContain(`from ${JSON.stringify(loadSharePath)}`);
   });
 
   it('redirects System.register commonjs-proxy consumers to loadShare chunks', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ import { normalizeModuleFederationOptions } from './utils/normalizeModuleFederat
 import normalizeOptimizeDepsPlugin from './utils/normalizeOptimizeDeps';
 import { getIsRolldown, hasPackageDependency, setPackageDetectionCwd } from './utils/packageUtils';
 import { getCommonSharedSubpaths } from './utils/pathNormalization';
-import VirtualModule from './utils/VirtualModule';
+import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualModule';
 import {
   getHostAutoInitImportId,
   getHostAutoInitPath,
@@ -55,6 +55,8 @@ import { addUsedRemote } from './virtualModules/virtualRemotes';
 import { virtualRuntimeInitStatus } from './virtualModules/virtualRuntimeInitStatus';
 import {
   getLoadShareModulePath,
+  materializeCachedLoadShareModule,
+  toViteOptimizedDepVirtualId,
   writeLoadShareModule,
   writePreBuildLibPath,
 } from './virtualModules/virtualShared_preBuild';
@@ -306,10 +308,13 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
             optimizeDeps.esbuildOptions.plugins.push({
               name: 'module-federation:optimize-shared-proxy',
               setup(build: any) {
-                build.onResolve({ filter: /^virtual:mf:/ }, (args: any) => ({
-                  path: args.path,
-                  external: true,
-                }));
+                build.onResolve(
+                  { filter: createViteEncodedIdPrefixRegExp('virtual:mf:') },
+                  (args: any) => ({
+                    path: args.path,
+                    external: true,
+                  })
+                );
                 build.onResolve({ filter: /.*/ }, (args: any) => {
                   if (!args.importer || args.namespace === 'mf-shared') return;
                   if (isSharedResolverInternalImporter(args.importer)) return;
@@ -322,6 +327,7 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   if (!key) return;
                   const shareItem = shared[key];
                   const loadSharePath = getLoadShareModulePath(args.path, isRolldown);
+                  const optimizedLoadSharePath = toViteOptimizedDepVirtualId(loadSharePath);
                   writeLoadShareModule(args.path, shareItem, _command, isRolldown);
                   if (shareItem.shareConfig?.import !== false) {
                     writePreBuildLibPath(args.path, shareItem);
@@ -330,8 +336,8 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   return {
                     loader: 'js',
                     resolveDir: root,
-                    contents: `import * as __mfShared from ${JSON.stringify(loadSharePath)};
-export * from ${JSON.stringify(loadSharePath)};
+                    contents: `import * as __mfShared from ${JSON.stringify(optimizedLoadSharePath)};
+export * from ${JSON.stringify(optimizedLoadSharePath)};
 export default __mfShared.default ?? __mfShared;`,
                   };
                 });
@@ -491,7 +497,19 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       name: 'vite:module-federation-virtual-modules',
       enforce: 'pre',
       resolveId(id: string) {
-        const virtualModule = VirtualModule.findById(id);
+        let virtualModule = VirtualModule.findById(id);
+        if (!virtualModule) {
+          materializeCachedLoadShareModule({
+            id,
+            shared: options.shared,
+            command,
+            isRolldown: getIsRolldown(this),
+            findSharedKey,
+            addUsedShares,
+            writeLocalSharedImportMap,
+          });
+          virtualModule = VirtualModule.findById(id);
+        }
         if (!virtualModule) return;
         return virtualModule.getResolvedId();
       },

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { toViteEncodedId, VITE_ID_PREFIX } from '../../utils/VirtualModule';
 
 vi.mock('../../utils/packageUtils', () => ({
   hasPackageDependency: () => true,
@@ -367,7 +368,7 @@ describe('pluginAddEntry', () => {
       {} as IndexHtmlTransformContext
     )) as string;
 
-    expect(result).toContain('/@id/__x00__virtual:mf-html-entry-proxy?');
+    expect(result).toContain(toViteEncodedId('virtual:mf-html-entry-proxy?'));
     expect(result).toContain('init=%2F%40id%2Fvirtual%3Amf-host-init');
     expect(result).toContain('entry=%2F_nuxt%2Fentry.async.js');
   });
@@ -532,7 +533,7 @@ describe('pluginAddEntry', () => {
     if (typeof result !== 'string') throw new Error('transformIndexHtml should return html string');
 
     expect(result).toContain('src="/@vite/client"');
-    expect(result).toContain('src="/@id/__x00__virtual:mf-html-entry-proxy?');
+    expect(result).toContain(`src="${toViteEncodedId('virtual:mf-html-entry-proxy?')}`);
     expect(result).not.toContain('await import(');
     expect(result).not.toContain('<script type="module">');
   });
@@ -589,10 +590,13 @@ describe('pluginAddEntry', () => {
     // Vite client must not be rewritten
     expect(result).toContain('src="/foo/@vite/client"');
     // Entry script must be rewritten to use the proxy module
-    expect(result).toContain('src="/@id/__x00__virtual:mf-html-entry-proxy?');
+    expect(result).toContain(`src="${toViteEncodedId('virtual:mf-html-entry-proxy?')}`);
 
     // Extract the proxy module ID from the rewritten HTML and load it
-    const proxyIdMatch = result.match(/src="\/@id\/(__x00__virtual:mf-html-entry-proxy\?[^"]+)"/);
+    const proxyPrefix = toViteEncodedId('virtual:mf-html-entry-proxy?');
+    const proxyIdMatch = result.match(
+      new RegExp(`src="(${proxyPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*)"`)
+    );
     expect(proxyIdMatch).not.toBeNull();
     const proxyId = decodeURIComponent(proxyIdMatch![1]).replace(/&amp;/g, '&');
     const code = await runLoad(servePlugin, proxyId);
@@ -601,7 +605,9 @@ describe('pluginAddEntry', () => {
 
     // The proxy module must import both init and entry as resolvable paths
     // (no base prefix — Vite's server-side resolver handles base itself)
-    expect(code).toContain('const { initHost } = await import("/@id/virtual:mf-host-init");');
+    expect(code).toContain(
+      `const { initHost } = await import("${VITE_ID_PREFIX}virtual:mf-host-init");`
+    );
     expect(code).toContain('await initHost();');
     expect(code).toContain('})().then(() => import("/src/main.tsx"));');
     expect(code).not.toContain('globalThis.System.import(src)');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -13,6 +13,7 @@ import { mfWarn } from '../utils/logger';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { getNormalizeModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
+import { decodeViteId, toViteEncodedId, VITE_ID_PREFIX } from '../utils/VirtualModule';
 import { getUsedRemotesMap } from '../virtualModules/virtualRemotes';
 import { getRuntimeModuleCacheBootstrapCode } from '../virtualModules/virtualRuntimeInitStatus';
 
@@ -255,10 +256,7 @@ const addEntry = ({
   }
 
   function normalizeDevHtmlProxyId(id: string) {
-    return id
-      .replace(/^\0/, '')
-      .replace(/^\/@id\//, '')
-      .replace(/^__x00__/, '');
+    return decodeViteId(id).replace(/^\0/, '');
   }
 
   function normalizeModuleId(id: string) {
@@ -304,7 +302,7 @@ const addEntry = ({
         viteConfig = config;
         const resolvedEntryPath = getEntryPath();
         if (resolvedEntryPath.startsWith('virtual:mf')) {
-          devEntryPath = config.base + '@id/' + resolvedEntryPath;
+          devEntryPath = config.base + VITE_ID_PREFIX.slice(1) + resolvedEntryPath;
         } else {
           // Convert absolute filesystem path to root-relative URL path.
           // On Windows, naive drive-letter stripping leaves the full directory
@@ -369,7 +367,7 @@ const addEntry = ({
               init: sanitizeDevEntryPath(stripBase(devEntryPath)),
               entry: sanitizeDevEntryPath(stripBase(originalSrc)),
             }).toString();
-            return `/@id/__x00__${DEV_HTML_PROXY_PREFIX}${query}`;
+            return toViteEncodedId(`${DEV_HTML_PROXY_PREFIX}${query}`);
           });
           return html === c ? injectEntryScript(c, stripBase(devEntryPath)) : html;
         },

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -2,6 +2,7 @@ import { Plugin, ResolvedConfig } from 'vite';
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { getIsRolldown, isNuxtProjectRoot } from '../utils/packageUtils';
 import { getBasePath, isNuxtClientBase } from '../utils/pathNormalization';
+import { decodeViteId } from '../utils/VirtualModule';
 import { generateExposesSSR, getVirtualExposesSSRId } from '../virtualModules/virtualExposesSSR';
 import {
   generateRemoteEntrySSR,
@@ -232,7 +233,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
                 // SSR env failed to resolve — try externalising via Node require from
                 // the remote project root. This handles bare package specifiers like
                 // @module-federation/runtime that need to run as Node externals.
-                const bareId = id.startsWith('/@id/') ? id.slice(5).replace(/^__x00__/, '\0') : id;
+                const bareId = decodeViteId(id);
                 try {
                   const { createRequire } = await import('module');
                   const req = createRequire(

--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -24,6 +24,30 @@ const cacheMap: {
   };
 } = {};
 
+export const VITE_ID_PREFIX = '/@id/';
+export const VITE_NULL_BYTE_PLACEHOLDER = '__x00__';
+export const VITE_ENCODED_NULL_BYTE_PREFIX = `${VITE_ID_PREFIX}${VITE_NULL_BYTE_PLACEHOLDER}`;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function createViteEncodedIdPrefixRegExp(sourcePrefix = ''): RegExp {
+  return new RegExp(`^(?:${escapeRegExp(VITE_ENCODED_NULL_BYTE_PREFIX)})?${sourcePrefix}`);
+}
+
+export function toViteEncodedId(id: string): string {
+  return `${VITE_ENCODED_NULL_BYTE_PREFIX}${id}`;
+}
+
+export function decodeViteId(id: string): string {
+  if (!id.startsWith(VITE_ID_PREFIX)) return id;
+  const viteId = id.slice(VITE_ID_PREFIX.length);
+  return viteId.startsWith(VITE_NULL_BYTE_PLACEHOLDER)
+    ? `\0${viteId.slice(VITE_NULL_BYTE_PLACEHOLDER.length)}`
+    : viteId;
+}
+
 export function assertModuleFound(tag: string, str: string = ''): VirtualModule {
   const module = VirtualModule.findModule(tag, str);
   if (!module) {
@@ -34,6 +58,15 @@ export function assertModuleFound(tag: string, str: string = ''): VirtualModule 
   return module;
 }
 
+export function normalizeVirtualModuleId(id: string): string {
+  const decoded = decodeViteId(id).replace(/^\0+/, '');
+  const queryIndex = decoded.indexOf('?');
+  const hashIndex = decoded.indexOf('#');
+  const endIndex =
+    queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
+  return endIndex === -1 ? decoded : decoded.slice(0, endIndex);
+}
+
 export default class VirtualModule {
   name: string;
   tag: string;
@@ -41,21 +74,20 @@ export default class VirtualModule {
   inited: boolean = false;
   code: string | undefined;
 
-  static findModule(tag: string, str: string = ''): VirtualModule | undefined {
+  static findName(tag: string, str: string = ''): string | undefined {
     if (!patternMap[tag])
       patternMap[tag] = new RegExp(`(.*${packageNameEncode(tag)}(.+?)${packageNameEncode(tag)}.*)`);
-    const moduleName = (str.match(patternMap[tag]) || [])[2];
-    if (moduleName)
-      return cacheMap[tag][packageNameDecode(moduleName)] as VirtualModule | undefined;
-    return undefined;
+    const moduleName = (normalizeVirtualModuleId(str).match(patternMap[tag]) || [])[2];
+    return moduleName ? packageNameDecode(moduleName) : undefined;
+  }
+
+  static findModule(tag: string, str: string = ''): VirtualModule | undefined {
+    const moduleName = VirtualModule.findName(tag, str);
+    return moduleName ? (cacheMap[tag][moduleName] as VirtualModule | undefined) : undefined;
   }
 
   static findById(id: string): VirtualModule | undefined {
-    const normalized = id
-      .replace(/^\0+/, '')
-      .replace(/^\/@id\//, '')
-      .replace(/^__x00__/, '')
-      .replace(/[?#].*$/, '');
+    const normalized = normalizeVirtualModuleId(id);
     for (const modules of Object.values(cacheMap)) {
       for (const module of Object.values(modules)) {
         if (module.getImportId() === normalized) return module;

--- a/src/utils/__tests__/VirtualModule.test.ts
+++ b/src/utils/__tests__/VirtualModule.test.ts
@@ -1,4 +1,9 @@
-import VirtualModule, { getSuffix, assertModuleFound } from '../VirtualModule';
+import VirtualModule, {
+  getSuffix,
+  assertModuleFound,
+  normalizeVirtualModuleId,
+  toViteEncodedId,
+} from '../VirtualModule';
 import { normalizeModuleFederationOptions } from '../normalizeModuleFederationOptions';
 
 describe('getSuffix', () => {
@@ -66,6 +71,9 @@ describe('VirtualModule writeSync', () => {
     expect(vm.code).toBe('export default 1;');
     expect(VirtualModule.findById(vm.getResolvedId())).toBe(vm);
     expect(VirtualModule.findById(`\0\0${vm.getImportId()}?commonjs-proxy`)).toBe(vm);
+    const encodedId = `${toViteEncodedId(vm.getImportId())}?v=1`;
+    expect(normalizeVirtualModuleId(encodedId)).toBe(vm.getImportId());
+    expect(VirtualModule.findName('__loadShare__', encodedId)).toBe('mui/styles');
     expect(assertModuleFound('__loadShare__', vm.getImportId())).toBe(vm);
   });
 });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -13,7 +13,7 @@ import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'pathe';
 import { mfWarn } from '../utils/logger';
-import { ShareItem } from '../utils/normalizeModuleFederationOptions';
+import type { NormalizedShared, ShareItem } from '../utils/normalizeModuleFederationOptions';
 import {
   getInstalledPackageEntry,
   getInstalledPackageJson,
@@ -21,7 +21,7 @@ import {
   getPackageName,
   getSharedCacheKey,
 } from '../utils/packageUtils';
-import VirtualModule from '../utils/VirtualModule';
+import VirtualModule, { normalizeVirtualModuleId, toViteEncodedId } from '../utils/VirtualModule';
 import {
   getRuntimeInitPromiseBootstrapCode,
   getRuntimeModuleCacheBootstrapCode,
@@ -463,6 +463,42 @@ export function getLoadShareModulePath(pkg: string, isRolldown: boolean): string
   if (!loadShareCacheMap[pkg]) getLoadShareImportId(pkg, isRolldown);
   const filepath = loadShareCacheMap[pkg].getImportId();
   return filepath;
+}
+
+export function toViteOptimizedDepVirtualId(id: string): string {
+  return toViteEncodedId(id);
+}
+
+export function getCachedLoadSharePkg(id: string): string | undefined {
+  const normalized = normalizeVirtualModuleId(id);
+  if (!normalized.startsWith('virtual:mf:')) return;
+
+  const pkg = VirtualModule.findName(LOAD_SHARE_TAG, normalized);
+  if (!pkg) return;
+  return pkg;
+}
+
+export function materializeCachedLoadShareModule(options: {
+  id: string;
+  shared: NormalizedShared;
+  command: string;
+  isRolldown: boolean;
+  findSharedKey: (source: string, shared: NormalizedShared) => string | undefined;
+  addUsedShares: (pkg: string) => void;
+  writeLocalSharedImportMap: () => void;
+}): void {
+  const pkg = getCachedLoadSharePkg(options.id);
+  if (!pkg) return;
+  const key = options.findSharedKey(pkg, options.shared);
+  if (!key) return;
+
+  const shareItem = options.shared[key];
+  writeLoadShareModule(pkg, shareItem, options.command, options.isRolldown);
+  if (shareItem.shareConfig?.import !== false) {
+    writePreBuildLibPath(pkg, shareItem);
+  }
+  options.addUsedShares(pkg);
+  options.writeLocalSharedImportMap();
 }
 
 function generateDeferredHostProvidedExports(


### PR DESCRIPTION
Close #768

Fixes Vite dev cached dependency failures when an optimized dependency imports a shared subpath covered by a trailing-slash shared config.
Adds Vite-safe virtual ID handling for optimized deps, materializes cached loadShare modules on demand, and centralizes Vite virtual ID encode/decode helpers.