### PR TITLE
fix: detect enum and destructuring exports when scanning shared named…

### DIFF
--- a/.changeset/enum-destructuring-shared-exports.md
+++ b/.changeset/enum-destructuring-shared-exports.md
@@ -1,0 +1,26 @@
+---
+"@module-federation/vite": patch
+---
+
+fix: detect `export enum` and destructuring exports when scanning shared named exports
+
+The static export scanner that builds the shared `loadShare` proxy
+(`getNamedExportsViaRegex`) only recognized `function | const | let | var | class`
+declarations. Two common forms reached through `export * from './...'` were
+therefore dropped from the proxy:
+
+- TypeScript `export enum` (and `export namespace`) declarations — runtime
+  values, not just types.
+- Destructuring exports such as `export const { addItem: createActionAddItem } = slice.actions;`,
+  the shape Redux Toolkit's `createSlice` produces. These match neither the
+  declaration regex (the next token is `{`/`[`) nor the `export { ... }` list
+  regex (the leading `const` breaks it).
+
+Importing those names across the Module Federation share boundary failed at
+runtime with `The requested module ... does not provide an export named '<name>'`.
+
+The fix adds `enum`/`namespace` to the declaration regex and a dedicated pass
+for object/array destructuring exports (handling renames, defaults and rest
+elements).
+
+Closes #780.

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -303,8 +303,10 @@ export { type, other } from './foo';`;
   Red = 'red',
   Blue = 'blue',
 }
-const actions = { addItem: () => {}, removeItem: () => {} };
-export const { addItem: createActionAddItem, removeItem: createActionRemoveItem } = actions;`;
+const actions = { addItem: () => {}, removeItem: () => {}, reset: () => {} };
+export const { addItem: createActionAddItem, removeItem: createActionRemoveItem, ...restActions } = actions;
+const tuple = [1, 2, 3];
+export const [firstItem, ...restItems] = tuple;`;
     }
     if (
       filePath.endsWith('node_modules/mock-package-browser-conditional/package.json') ||
@@ -1247,6 +1249,14 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('as createActionAddItem');
     expect(generatedCode).toContain('exportModule["createActionRemoveItem"]');
     expect(generatedCode).toContain('as createActionRemoveItem');
+    // Rest elements bind a real value and must be re-exported too.
+    expect(generatedCode).toContain('exportModule["restActions"]');
+    expect(generatedCode).toContain('as restActions');
+    // Array destructuring, including its rest element.
+    expect(generatedCode).toContain('exportModule["firstItem"]');
+    expect(generatedCode).toContain('as firstItem');
+    expect(generatedCode).toContain('exportModule["restItems"]');
+    expect(generatedCode).toContain('as restItems');
   });
 
   it('does not emit duplicate side-effect imports for workspace singletons in serve mode', () => {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -73,6 +73,12 @@ vi.mock('../../utils/packageUtils', () => ({
       return '/repo/apps/remote/node_modules/mock-package-generator-export/src/index.js';
     }
     if (
+      pkg === 'mock-package-enum-destructure' ||
+      pkg.startsWith('mock-package-enum-destructure/')
+    ) {
+      return '/repo/apps/remote/node_modules/mock-package-enum-destructure/src/index.js';
+    }
+    if (
       pkg === 'mock-package-browser-conditional' ||
       pkg.startsWith('mock-package-browser-conditional/')
     ) {
@@ -159,6 +165,8 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-reexport-type/package.json') ||
       filePath.endsWith('node_modules/mock-package-generator-export/package.json') ||
       filePath.endsWith('/mock-package-generator-export/package.json') ||
+      filePath.endsWith('node_modules/mock-package-enum-destructure/package.json') ||
+      filePath.endsWith('/mock-package-enum-destructure/package.json') ||
       filePath.endsWith('node_modules/mock-package-browser-conditional/package.json') ||
       filePath.endsWith('/mock-package-browser-conditional/package.json') ||
       filePath.endsWith('node_modules/mock-package-browser-conditional/dist/browser.js') ||
@@ -276,6 +284,27 @@ export { type, other } from './foo';`;
       return `export function*loader() {
   yield 1;
 }`;
+    }
+    if (
+      filePath.endsWith('node_modules/mock-package-enum-destructure/package.json') ||
+      filePath.endsWith('/mock-package-enum-destructure/package.json')
+    ) {
+      return JSON.stringify({
+        name: 'mock-package-enum-destructure',
+        type: 'module',
+        module: './src/index.js',
+        exports: {
+          '.': './src/index.js',
+        },
+      });
+    }
+    if (filePath.endsWith('node_modules/mock-package-enum-destructure/src/index.js')) {
+      return `export enum Color {
+  Red = 'red',
+  Blue = 'blue',
+}
+const actions = { addItem: () => {}, removeItem: () => {} };
+export const { addItem: createActionAddItem, removeItem: createActionRemoveItem } = actions;`;
     }
     if (
       filePath.endsWith('node_modules/mock-package-browser-conditional/package.json') ||
@@ -422,6 +451,14 @@ vi.mock('module', async (importOriginal) => {
         if (
           pkg === 'mock-package-generator-export' ||
           pkg.startsWith('mock-package-generator-export/')
+        ) {
+          const error = new Error('ERR_REQUIRE_ESM');
+          (error as Error & { code?: string }).code = 'ERR_REQUIRE_ESM';
+          throw error;
+        }
+        if (
+          pkg === 'mock-package-enum-destructure' ||
+          pkg.startsWith('mock-package-enum-destructure/')
         ) {
           const error = new Error('ERR_REQUIRE_ESM');
           (error as Error & { code?: string }).code = 'ERR_REQUIRE_ESM';
@@ -1181,6 +1218,35 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).toContain('__mf_0 = exportModule["loader"];');
     expect(generatedCode).toContain('export { __mf_0 as loader };');
+  });
+
+  it('detects enum and destructuring exports via regex fallback', () => {
+    const pkg = 'mock-package-enum-destructure';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // `export enum Color` is a runtime value and must be re-exported.
+    expect(generatedCode).toContain('exportModule["Color"]');
+    expect(generatedCode).toContain('as Color');
+    // Destructuring exports (e.g. createSlice actions) keep their bound names.
+    expect(generatedCode).toContain('exportModule["createActionAddItem"]');
+    expect(generatedCode).toContain('as createActionAddItem');
+    expect(generatedCode).toContain('exportModule["createActionRemoveItem"]');
+    expect(generatedCode).toContain('as createActionRemoveItem');
   });
 
   it('does not emit duplicate side-effect imports for workspace singletons in serve mode', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -196,9 +196,9 @@ function getNamedExportsViaRegex(
     if (isValidEsmExportName(name)) names.add(name);
   }
 
-  // Destructuring exports, e.g. `export const { a, b: alias } = obj;` or
-  // `export const [first] = arr;` — the shape Redux Toolkit's `createSlice`
-  // produces (`export const { addItem: createActionAddItem } = slice.actions`).
+  // Destructuring exports, e.g. `export const { a, b: alias, ...rest } = obj;`
+  // or `export const [first, ...others] = arr;` — the shape Redux Toolkit's
+  // `createSlice` produces (`export const { addItem: createActionAddItem } = slice.actions`).
   // These are matched by neither `declRegex` (the next token is `{`/`[`) nor the
   // `export { ... }` list regex below (the leading `const` breaks it).
   const destructureRegex = /export\s+(?:const|let|var)\s+(\{[^}]*\}|\[[^\]]*\])\s*=/g;
@@ -206,8 +206,11 @@ function getNamedExportsViaRegex(
   while ((match = destructureRegex.exec(source)) !== null) {
     const inner = match[1].slice(1, -1);
     for (const part of inner.split(',')) {
+      // strip a default value (`= ...`); rest elements (`...x`) never have one
       let token = part.split('=')[0].trim();
-      if (!token || token.startsWith('...')) continue;
+      // rest element `...rest` -> the bound name is `rest`
+      if (token.startsWith('...')) token = token.slice(3).trim();
+      if (!token) continue;
       // object rename `key: alias` -> the bound name is the alias
       if (token.includes(':')) token = token.slice(token.indexOf(':') + 1).trim();
       const bindingMatch = token.match(bindingNameRegex);

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -187,13 +187,32 @@ function getNamedExportsViaRegex(
   const declRegex = new RegExp(
     `export\\s+(?:async\\s+)?(?:` +
       `function(?:\\*\\s*|\\s+\\*?\\s*)` +
-      `|const\\s+|let\\s+|var\\s+|class\\s+)(${JS_IDENTIFIER_PATTERN})`,
+      `|const\\s+|let\\s+|var\\s+|class\\s+|enum\\s+|namespace\\s+)(${JS_IDENTIFIER_PATTERN})`,
     'gu'
   );
   let match: RegExpExecArray | null;
   while ((match = declRegex.exec(source)) !== null) {
     const name = match[1];
     if (isValidEsmExportName(name)) names.add(name);
+  }
+
+  // Destructuring exports, e.g. `export const { a, b: alias } = obj;` or
+  // `export const [first] = arr;` — the shape Redux Toolkit's `createSlice`
+  // produces (`export const { addItem: createActionAddItem } = slice.actions`).
+  // These are matched by neither `declRegex` (the next token is `{`/`[`) nor the
+  // `export { ... }` list regex below (the leading `const` breaks it).
+  const destructureRegex = /export\s+(?:const|let|var)\s+(\{[^}]*\}|\[[^\]]*\])\s*=/g;
+  const bindingNameRegex = new RegExp(`^(${JS_IDENTIFIER_PATTERN})`, 'u');
+  while ((match = destructureRegex.exec(source)) !== null) {
+    const inner = match[1].slice(1, -1);
+    for (const part of inner.split(',')) {
+      let token = part.split('=')[0].trim();
+      if (!token || token.startsWith('...')) continue;
+      // object rename `key: alias` -> the bound name is the alias
+      if (token.includes(':')) token = token.slice(token.indexOf(':') + 1).trim();
+      const bindingMatch = token.match(bindingNameRegex);
+      if (bindingMatch && isValidEsmExportName(bindingMatch[1])) names.add(bindingMatch[1]);
+    }
   }
 
   const listRegex = /export\s*\{([^}]+)\}/g;


### PR DESCRIPTION
… exports

`getNamedExportsViaRegex` only matched function/const/let/var/class declarations, so `export enum`/`export namespace` and destructuring exports (e.g. `export const { addItem: createActionAddItem } = slice.actions`) reached via `export *` were dropped from the shared `loadShare` proxy. Importing those names across the share boundary failed at runtime with `does not provide an export named '<name>'`.

Add `enum`/`namespace` to the declaration regex and a dedicated pass for object/array destructuring exports (handling renames, defaults and rest).

Closes #780.