### PR TITLE
fix: respect entryFileNames directory for bootstrap file output

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -967,7 +967,7 @@ describe('pluginAddEntry', () => {
     expect(bootstrapFile).toBeDefined();
     expect(bootstrapFile!.fileName).toMatch(/^static\/js\/mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
     expect(bootstrapFile!.source as string).toContain('__mfImport("./hostInit-abc.js")');
-    expect(bootstrapFile!.source as string).toContain('__mfImport("../src/main.tsx")');
+    expect(bootstrapFile!.source as string).toContain('__mfImport("../../src/main.tsx")');
   });
 
   it('emits bootstrap file at root when entryFileNames is not set', () => {
@@ -1021,6 +1021,124 @@ describe('pluginAddEntry', () => {
     ) as Rollup.EmittedAsset | undefined;
     expect(bootstrapFile).toBeDefined();
     expect(bootstrapFile!.fileName).toMatch(/^mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
+  });
+
+  it('strips Vite base before rebasing bootstrap imports (base: /app/)', () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+    });
+    const buildPlugin = plugins[1];
+    const emitted: Rollup.EmittedFile[] = [];
+    const bundle: any = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head><script type="module" src="/app/src/main.tsx"></script></head><body></body></html>',
+      },
+    };
+
+    runConfigResolved(buildPlugin, {
+      root: '/repo/host',
+      base: '/app/',
+      command: 'build',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+    runBuildStart(
+      buildPlugin,
+      {
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'host-init-ref';
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedInputOptions
+    );
+    runGenerateBundle(
+      buildPlugin,
+      {
+        getFileName: () => 'static/js/hostInit-abc.js',
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'bootstrap-ref-' + emitted.length;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle,
+      false
+    );
+
+    const bootstrapFile = emitted.find((f) =>
+      (f as Rollup.EmittedAsset).fileName?.includes('mf-entry-bootstrap')
+    ) as Rollup.EmittedAsset | undefined;
+    expect(bootstrapFile).toBeDefined();
+    expect(bootstrapFile!.fileName).toMatch(/^static\/js\/mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
+    expect(bootstrapFile!.source as string).toContain('__mfImport("./hostInit-abc.js")');
+    expect(bootstrapFile!.source as string).toContain('__mfImport("../../src/main.tsx")');
+  });
+
+  it('does not rebase absolute URLs from renderBuiltUrl in bootstrap', () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+    });
+    const buildPlugin = plugins[1];
+    const emitted: Rollup.EmittedFile[] = [];
+    const bundle: any = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head><script type="module" src="/src/main.tsx"></script></head><body></body></html>',
+      },
+    };
+
+    runConfigResolved(buildPlugin, {
+      root: '/repo/host',
+      base: '/',
+      command: 'build',
+      experimental: {
+        renderBuiltUrl(filename: string) {
+          if (filename.includes('hostInit')) {
+            return 'https://cdn.example.com/hostInit-abc.js';
+          }
+          return { relative: true };
+        },
+      },
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+    runBuildStart(
+      buildPlugin,
+      {
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'host-init-ref';
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedInputOptions
+    );
+    runGenerateBundle(
+      buildPlugin,
+      {
+        getFileName: () => 'static/js/hostInit-abc.js',
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'bootstrap-ref-' + emitted.length;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle,
+      false
+    );
+
+    const bootstrapFile = emitted.find((f) =>
+      (f as Rollup.EmittedAsset).fileName?.includes('mf-entry-bootstrap')
+    ) as Rollup.EmittedAsset | undefined;
+    expect(bootstrapFile).toBeDefined();
+    expect(bootstrapFile!.source as string).toContain(
+      '__mfImport("https://cdn.example.com/hostInit-abc.js")'
+    );
   });
 
   it('wraps SvelteKit static inline startup behind host init during build', () => {

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -904,15 +904,123 @@ describe('pluginAddEntry', () => {
       (item) =>
         item.type === 'asset' &&
         typeof item.fileName === 'string' &&
-        item.fileName.startsWith('mf-entry-bootstrap-')
+        item.fileName.includes('mf-entry-bootstrap-')
     ) as Rollup.EmittedAsset | undefined;
-    expect(bootstrapAsset?.fileName).toMatch(/^mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
+    expect(bootstrapAsset?.fileName).toMatch(/^assets\/mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
     expect(emitted).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ type: 'chunk', id: '/virtual/hostInit.js' }),
       ])
     );
     expect(bundle['indexProd.html'].source).toContain(bootstrapAsset!.fileName);
+  });
+
+  it('emits bootstrap file with directory prefix from entryFileNames pattern', () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+    });
+    const buildPlugin = plugins[1];
+    const emitted: Rollup.EmittedFile[] = [];
+    const bundle: any = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head><script type="module" src="./src/main.tsx"></script></head><body></body></html>',
+      },
+    };
+
+    runConfigResolved(buildPlugin, {
+      root: '/repo/host',
+      base: '',
+      command: 'build',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+    runBuildStart(
+      buildPlugin,
+      {
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'host-init-ref';
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedInputOptions
+    );
+    runGenerateBundle(
+      buildPlugin,
+      {
+        getFileName: () => 'static/js/hostInit-abc.js',
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'bootstrap-ref-' + emitted.length;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle,
+      false
+    );
+
+    const bootstrapFile = emitted.find((f) =>
+      (f as Rollup.EmittedAsset).fileName?.includes('mf-entry-bootstrap')
+    ) as Rollup.EmittedAsset | undefined;
+    expect(bootstrapFile).toBeDefined();
+    expect(bootstrapFile!.fileName).toMatch(/^static\/js\/mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
+    expect(bootstrapFile!.source as string).toContain('__mfImport("./hostInit-abc.js")');
+    expect(bootstrapFile!.source as string).toContain('__mfImport("../src/main.tsx")');
+  });
+
+  it('emits bootstrap file at root when entryFileNames is not set', () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+    });
+    const buildPlugin = plugins[1];
+    const emitted: Rollup.EmittedFile[] = [];
+    const bundle: any = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head><script type="module" src="./src/main.tsx"></script></head><body></body></html>',
+      },
+    };
+
+    runConfigResolved(buildPlugin, {
+      root: '/repo/host',
+      base: '',
+      command: 'build',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+    runBuildStart(
+      buildPlugin,
+      {
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'host-init-ref';
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedInputOptions
+    );
+    runGenerateBundle(
+      buildPlugin,
+      {
+        getFileName: () => 'hostInit-abc.js',
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'bootstrap-ref-' + emitted.length;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle,
+      false
+    );
+
+    const bootstrapFile = emitted.find((f) =>
+      (f as Rollup.EmittedAsset).fileName?.includes('mf-entry-bootstrap')
+    ) as Rollup.EmittedAsset | undefined;
+    expect(bootstrapFile).toBeDefined();
+    expect(bootstrapFile!.fileName).toMatch(/^mf-entry-bootstrap-0-[a-f0-9]{8}\.js$/);
   });
 
   it('wraps SvelteKit static inline startup behind host init during build', () => {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -538,6 +538,14 @@ const addEntry = ({
           return viteConfig.base + file;
         };
 
+        // Strip Vite base before rebasing — paths in HTML include the base
+        // prefix (e.g. "/app/static/js/hostInit.js" with base="/app/"),
+        // but rebaseImport works against the output directory structure
+        // (e.g. "static/js/"), which is relative to the build root.
+        const basePrefix = viteConfig.base?.replace(/\/$/, '') ?? '';
+        const stripBase = (p: string) =>
+          basePrefix && p.startsWith(basePrefix + '/') ? p.slice(basePrefix.length) : p;
+
         let bootstrapIndex = 0;
         // Process each HTML file
         for (const fileName of htmlFileNames) {
@@ -551,8 +559,14 @@ const addEntry = ({
           let rewritten = false;
           htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
             rewritten = true;
-            const rebasedInitPath = bootstrapDir ? rebaseImport(initPath, bootstrapDir) : initPath;
-            const rebasedEntrySrc = bootstrapDir ? rebaseImport(entrySrc, bootstrapDir) : entrySrc;
+            const strippedInit = stripBase(initPath);
+            const strippedEntry = stripBase(entrySrc);
+            const rebasedInitPath = bootstrapDir
+              ? rebaseImport(strippedInit, bootstrapDir)
+              : initPath;
+            const rebasedEntrySrc = bootstrapDir
+              ? rebaseImport(strippedEntry, bootstrapDir)
+              : entrySrc;
             const bootstrapSource = getSystemBootstrapSource(rebasedInitPath, rebasedEntrySrc);
             // Content-hash the bootstrap filename so browsers/CDNs invalidate
             // the cache on deploy. Without a hash the file ships as

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import * as fs from 'fs';
 import * as path from 'pathe';
 import type { Plugin } from 'vite';
+import { rebaseImport } from '../utils/buildPaths';
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 
 import {
@@ -92,6 +93,7 @@ const addEntry = ({
   let clientInjected = forceClientInjected ?? false;
   let emittedFileName: string | undefined;
   let skipTransformIds = new Set<string>();
+  let bootstrapDir = '';
 
   function skipSvelteKitSsrBuild() {
     return (
@@ -495,6 +497,11 @@ const addEntry = ({
         if (htmlFileNames.length === 0) return;
         const file = this.getFileName(emitFileId);
         emittedFileName = file;
+        // Derive bootstrapDir from the emitted hostInit file path.
+        // entryFileNames is normalized away by Vite/Rolldown before plugins
+        // can read it, so we extract the directory from the actual output path.
+        const lastSlash = file.lastIndexOf('/');
+        bootstrapDir = lastSlash !== -1 ? file.slice(0, lastSlash + 1) : '';
         // Helper to resolve path with proper renderBuiltUrl handling
         const resolvePath = (htmlFileName: string): string => {
           if (!viteConfig.experimental?.renderBuiltUrl) {
@@ -544,7 +551,9 @@ const addEntry = ({
           let rewritten = false;
           htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
             rewritten = true;
-            const bootstrapSource = getSystemBootstrapSource(initPath, entrySrc);
+            const rebasedInitPath = bootstrapDir ? rebaseImport(initPath, bootstrapDir) : initPath;
+            const rebasedEntrySrc = bootstrapDir ? rebaseImport(entrySrc, bootstrapDir) : entrySrc;
+            const bootstrapSource = getSystemBootstrapSource(rebasedInitPath, rebasedEntrySrc);
             // Content-hash the bootstrap filename so browsers/CDNs invalidate
             // the cache on deploy. Without a hash the file ships as
             // `mf-entry-bootstrap-0.js` and stale caches serve the old
@@ -553,7 +562,7 @@ const addEntry = ({
               .update(bootstrapSource)
               .digest('hex')
               .slice(0, 8);
-            const bootstrapFileName = `mf-entry-bootstrap-${bootstrapIndex++}-${bootstrapHash}.js`;
+            const bootstrapFileName = `${bootstrapDir}mf-entry-bootstrap-${bootstrapIndex++}-${bootstrapHash}.js`;
             const bootstrapRef = this.emitFile({
               type: 'asset',
               fileName: bootstrapFileName,

--- a/src/utils/__tests__/buildPaths.test.ts
+++ b/src/utils/__tests__/buildPaths.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { rebaseImport } from '../buildPaths';
+
+describe('rebaseImport', () => {
+  it('strips dir prefix from absolute path and makes relative', () => {
+    expect(rebaseImport('/static/js/hostInit.js', 'static/js/')).toBe('./hostInit.js');
+  });
+
+  it('strips dir prefix from bare path and makes relative', () => {
+    expect(rebaseImport('static/js/hostInit.js', 'static/js/')).toBe('./hostInit.js');
+  });
+
+  it('climbs up for relative path without dir prefix', () => {
+    expect(rebaseImport('./src/main.tsx', 'assets/')).toBe('../src/main.tsx');
+  });
+
+  it('climbs up for absolute path without dir prefix', () => {
+    expect(rebaseImport('/src/main.tsx', 'assets/')).toBe('../src/main.tsx');
+  });
+
+  it('climbs up for bare path without dir prefix', () => {
+    expect(rebaseImport('src/main.tsx', 'assets/')).toBe('../src/main.tsx');
+  });
+
+  it('returns unchanged path when dir is empty', () => {
+    expect(rebaseImport('./static/js/hostInit.js', '')).toBe('./static/js/hostInit.js');
+  });
+});

--- a/src/utils/__tests__/buildPaths.test.ts
+++ b/src/utils/__tests__/buildPaths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { rebaseImport } from '../buildPaths';
+import { isAbsoluteUrl, rebaseImport } from '../buildPaths';
 
 describe('rebaseImport', () => {
   it('strips dir prefix from absolute path and makes relative', () => {
@@ -24,5 +24,67 @@ describe('rebaseImport', () => {
 
   it('returns unchanged path when dir is empty', () => {
     expect(rebaseImport('./static/js/hostInit.js', '')).toBe('./static/js/hostInit.js');
+  });
+
+  it('does not rebase https:// absolute URLs', () => {
+    expect(rebaseImport('https://cdn.example.com/hostInit.js', 'static/js/')).toBe(
+      'https://cdn.example.com/hostInit.js'
+    );
+  });
+
+  it('does not rebase http:// absolute URLs', () => {
+    expect(rebaseImport('http://localhost:3000/hostInit.js', 'static/js/')).toBe(
+      'http://localhost:3000/hostInit.js'
+    );
+  });
+
+  it('does not rebase protocol-relative URLs', () => {
+    expect(rebaseImport('//cdn.example.com/hostInit.js', 'static/js/')).toBe(
+      '//cdn.example.com/hostInit.js'
+    );
+  });
+
+  it('does not rebase data: URIs', () => {
+    expect(rebaseImport('data:text/javascript;base64,ZnVuY3Rpb24oKXt9', 'static/js/')).toBe(
+      'data:text/javascript;base64,ZnVuY3Rpb24oKXt9'
+    );
+  });
+
+  it('does not rebase blob: URIs', () => {
+    expect(rebaseImport('blob:https://example.com/uuid', 'static/js/')).toBe(
+      'blob:https://example.com/uuid'
+    );
+  });
+
+  it('strips dir prefix when path starts with / + dir', () => {
+    expect(rebaseImport('/static/js/hostInit-abc.js', 'static/js/')).toBe('./hostInit-abc.js');
+  });
+});
+
+describe('isAbsoluteUrl', () => {
+  it('detects https://', () => {
+    expect(isAbsoluteUrl('https://example.com/file.js')).toBe(true);
+  });
+
+  it('detects http://', () => {
+    expect(isAbsoluteUrl('http://localhost/file.js')).toBe(true);
+  });
+
+  it('detects protocol-relative //', () => {
+    expect(isAbsoluteUrl('//cdn.example.com/file.js')).toBe(true);
+  });
+
+  it('detects data: URIs', () => {
+    expect(isAbsoluteUrl('data:text/javascript,export{}')).toBe(true);
+  });
+
+  it('detects blob: URIs', () => {
+    expect(isAbsoluteUrl('blob:https://example.com/uuid')).toBe(true);
+  });
+
+  it('does not match relative paths', () => {
+    expect(isAbsoluteUrl('./hostInit.js')).toBe(false);
+    expect(isAbsoluteUrl('/static/js/hostInit.js')).toBe(false);
+    expect(isAbsoluteUrl('static/js/hostInit.js')).toBe(false);
   });
 });

--- a/src/utils/buildPaths.ts
+++ b/src/utils/buildPaths.ts
@@ -1,0 +1,33 @@
+/**
+ * Rebase an import path for a bootstrap file that moved from root into `dir`.
+ *
+ * When entryFileNames places entries in a subdirectory (e.g. `static/js/`),
+ * the bootstrap file moves there too. Paths that resolved from the HTML root
+ * must resolve from the new directory instead.
+ *
+ * Cases: `/static/js/hostInit.js` → `./hostInit.js` (strip dir prefix)
+ *        `./src/main.tsx`          → `../src/main.tsx` (climb back up)
+ */
+export function rebaseImport(importSrc: string, dir: string): string {
+  if (!dir) return importSrc;
+
+  const absPrefix = '/' + dir;
+  if (importSrc.startsWith(absPrefix)) {
+    const remainder = importSrc.slice(absPrefix.length);
+    return remainder ? './' + remainder : './';
+  }
+
+  if (importSrc.startsWith(dir)) {
+    const remainder = importSrc.slice(dir.length);
+    return remainder ? './' + remainder : './';
+  }
+
+  if (importSrc.startsWith('./')) {
+    return '../' + importSrc.slice('./'.length);
+  }
+  if (importSrc.startsWith('/')) {
+    return '../' + importSrc.slice('/'.length);
+  }
+
+  return '../' + importSrc;
+}

--- a/src/utils/buildPaths.ts
+++ b/src/utils/buildPaths.ts
@@ -6,10 +6,13 @@
  * must resolve from the new directory instead.
  *
  * Cases: `/static/js/hostInit.js` → `./hostInit.js` (strip dir prefix)
- *        `./src/main.tsx`          → `../src/main.tsx` (climb back up)
+ *        `./src/main.tsx`          → `../../src/main.tsx` (climb back up for each dir level)
+ *        `https://cdn.example.com` → unchanged         (absolute URL)
  */
 export function rebaseImport(importSrc: string, dir: string): string {
   if (!dir) return importSrc;
+
+  if (isAbsoluteUrl(importSrc)) return importSrc;
 
   const absPrefix = '/' + dir;
   if (importSrc.startsWith(absPrefix)) {
@@ -22,12 +25,21 @@ export function rebaseImport(importSrc: string, dir: string): string {
     return remainder ? './' + remainder : './';
   }
 
+  const upLevels = dir.split('/').filter(Boolean).length;
+  const prefix = upLevels > 0 ? '../'.repeat(upLevels) : './';
+
   if (importSrc.startsWith('./')) {
-    return '../' + importSrc.slice('./'.length);
+    return prefix + importSrc.slice('./'.length);
   }
   if (importSrc.startsWith('/')) {
-    return '../' + importSrc.slice('/'.length);
+    return prefix + importSrc.slice('/'.length);
   }
 
-  return '../' + importSrc;
+  return prefix + importSrc;
+}
+
+export const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i;
+
+export function isAbsoluteUrl(src: string): boolean {
+  return EXTERNAL_URL_RE.test(src);
 }


### PR DESCRIPTION
The MF bootstrap file was emitted with a hardcoded fileName (mf-entry-bootstrap-N.js) at the build root, bypassing Rollup's entryFileNames pattern. When users configure entryFileNames to place JS in a subdirectory (e.g. static/js/), the bootstrap file still landed at the root while all other entries went to static/js/.

Derive the directory prefix from the emitted hostInit file path at build time (since Vite/Rolldown normalizes entryFileNames before plugins can read it). Rebase the import paths inside the bootstrap to be relative to its new location instead of the HTML root, preventing doubled paths like static/js/static/js/.

Falls back to root-level output when no subdirectory is detected for backward compatibility.

---

The new bootstrap concept broke how I use MF, and so this adds back the needed flexibility for my use case.