### PR TITLE
fix: await nested remote static imports

### DIFF
--- a/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
+++ b/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
@@ -98,6 +98,11 @@ describe('pluginRemoteNamedExports', () => {
     it('rewrites named import', async () => {
       const result = await transform('import { foo } from "remoteApp/utils";');
       expect(result).toContain('import { __moduleExports as');
+      expect(result).toContain('__mf_remote_pending as __mf_ns_0_pending');
+      expect(result).toContain(
+        'export const __mf_remote_dependency_pending = Promise.all([__mf_ns_0_pending]);'
+      );
+      expect(result).not.toContain('await ');
       expect(result).toContain('__mfCreateNamedRemoteProxy');
       expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
       expect(result).not.toContain('import { foo }');
@@ -188,7 +193,13 @@ describe('pluginRemoteNamedExports', () => {
   describe('namespace imports', () => {
     it('rewrites namespace import', async () => {
       const result = await transform('import * as utils from "remoteApp/utils";');
-      expect(result).toContain('import { __moduleExports as utils }');
+      expect(result).toContain(
+        'import { __moduleExports as utils, __mf_remote_pending as utils__mf_pending }'
+      );
+      expect(result).toContain(
+        'export const __mf_remote_dependency_pending = Promise.all([utils__mf_pending]);'
+      );
+      expect(result).not.toContain('await ');
       expect(result).not.toContain('import *');
     });
   });
@@ -235,6 +246,11 @@ describe('pluginRemoteNamedExports', () => {
     it('rewrites named re-export', async () => {
       const result = await transform('export { foo } from "remoteApp/utils";');
       expect(result).toContain('import { __moduleExports as');
+      expect(result).toContain('__mf_remote_pending as __mf_ns_0_pending');
+      expect(result).toContain(
+        'export const __mf_remote_dependency_pending = Promise.all([__mf_ns_0_pending]);'
+      );
+      expect(result).not.toContain('await ');
       expect(result).toContain('__mf_re_');
       expect(result).toContain('as foo');
     });
@@ -274,7 +290,13 @@ describe('pluginRemoteNamedExports', () => {
         '/src/app.tsx',
         true
       );
-      expect(result).toContain('import { __moduleExports as utils }');
+      expect(result).toContain(
+        'import { __moduleExports as utils, __mf_remote_pending as utils__mf_pending }'
+      );
+      expect(result).toContain(
+        'export const __mf_remote_dependency_pending = Promise.all([utils__mf_pending]);'
+      );
+      expect(result).not.toContain('await ');
     });
 
     it('rewrites default + named import via fallback', async () => {
@@ -399,7 +421,13 @@ describe('pluginRemoteNamedExports', () => {
         '/src/app.jsx',
         true
       );
-      expect(result).toContain('import { __moduleExports as routesRemote }');
+      expect(result).toContain(
+        'import { __moduleExports as routesRemote, __mf_remote_pending as routesRemote__mf_pending }'
+      );
+      expect(result).toContain(
+        'export const __mf_remote_dependency_pending = Promise.all([routesRemote__mf_pending]);'
+      );
+      expect(result).not.toContain('await ');
       expect(result).not.toContain('import * as routesRemote');
     });
   });

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -131,6 +131,7 @@ function applyRewrites(
   // Per-file counter — deterministic regardless of file processing order.
   let counter = 0;
   let namedProxyHelperDeclared = false;
+  const dependencyPendingIds: string[] = [];
   const namedProxyHelper = `function __mfCreateNamedRemoteProxy(ns, key) {
   const target = function (...args) {
     const value = ns[key];
@@ -156,18 +157,23 @@ function applyRewrites(
         const src = JSON.stringify(imp.source);
 
         if (imp.namespaceLocal && !imp.defaultLocal && imp.named.length === 0) {
+          const pendingId = `${imp.namespaceLocal}__mf_pending`;
+          dependencyPendingIds.push(pendingId);
           // import * as ns from "remote/xxx"
           ms.overwrite(
             imp.start,
             imp.end,
-            `import { __moduleExports as ${imp.namespaceLocal} } from ${src};`
+            `import { __moduleExports as ${imp.namespaceLocal}, __mf_remote_pending as ${pendingId} } from ${src};`
           );
         } else {
           const nsId = `__mf_ns_${counter++}`;
+          const pendingId = `${nsId}_pending`;
+          dependencyPendingIds.push(pendingId);
           const importParts: string[] = [];
 
           if (imp.defaultLocal) importParts.push(`default as ${imp.defaultLocal}`);
           importParts.push(`__moduleExports as ${nsId}`);
+          importParts.push(`__mf_remote_pending as ${pendingId}`);
 
           let rewrite = `import { ${importParts.join(', ')} } from ${src};`;
           if (imp.named.length > 0) {
@@ -196,19 +202,25 @@ function applyRewrites(
       case 'reexport': {
         const src = JSON.stringify(imp.source);
         const nsId = `__mf_ns_${counter++}`;
+        const pendingId = `${nsId}_pending`;
+        dependencyPendingIds.push(pendingId);
 
         const vars = imp.specifiers.map((s) => {
           const tmp = `__mf_re_${counter++}`;
           return { ...s, tmp };
         });
 
-        const importLine = `import { __moduleExports as ${nsId} } from ${src};`;
+        const importLine = `import { __moduleExports as ${nsId}, __mf_remote_pending as ${pendingId} } from ${src};`;
         const varLines = vars
-          .map((v) => `const ${v.tmp} = ${nsId}[${JSON.stringify(v.local)}];`)
+          .map((v) => `let ${v.tmp} = ${nsId}[${JSON.stringify(v.local)}];`)
           .join('\n');
+        const assignLines = vars
+          .map((v) => `${v.tmp} = ${nsId}[${JSON.stringify(v.local)}];`)
+          .join('\n');
+        const syncLine = `${pendingId}.then(() => {\n${assignLines}\n});`;
         const exportLine = `export { ${vars.map((v) => `${v.tmp} as ${v.exported}`).join(', ')} };`;
 
-        ms.overwrite(imp.start, imp.end, `${importLine}\n${varLines}\n${exportLine}`);
+        ms.overwrite(imp.start, imp.end, `${importLine}\n${varLines}\n${syncLine}\n${exportLine}`);
         changed = true;
         break;
       }
@@ -230,6 +242,13 @@ function applyRewrites(
   }
 
   if (!changed) return;
+  if (dependencyPendingIds.length > 0) {
+    ms.overwrite(
+      code.length,
+      code.length,
+      `\nexport const __mf_remote_dependency_pending = Promise.all([${dependencyPendingIds.join(', ')}]);`
+    );
+  }
   return {
     code: ms.toString(),
     map: ms.generateMap(id),

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -135,6 +135,9 @@ describe('generateRemotes', () => {
     const code = generateRemotes('remote/Button', 'serve');
 
     expect(code).not.toContain('await __mfRemotePending');
+    expect(code).toContain(
+      '.then((mod) => Promise.resolve(mod?.__mf_remote_dependency_pending).then(() => mod))'
+    );
     expect(code).toContain('export { exportModule as __moduleExports };');
     expect(code).toContain(
       'export const __mf_remote_pending = __mfRemotePending || Promise.resolve(exportModule);'

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -125,6 +125,7 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
             ${registerRemoteCode}
             return runtime.loadRemote(${JSON.stringify(id)});
           })
+          .then((mod) => Promise.resolve(mod?.__mf_remote_dependency_pending).then(() => mod))
           .then((mod) => {
             __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
             delete __mfModuleCache.remote[pendingKey];


### PR DESCRIPTION
Close #785

Fixes a race where a remote module could render before its static federated imports finished resolving. Static named/namespace remote import rewrites now expose a dependency promise, and remote wrappers wait for it before caching/rendering the loaded module. This avoids unresolved named import proxies returning undefined, no use of top-level await.