### PR TITLE
chore: drop CJS build preserving compatibility

### DIFF
--- a/.github/publish-ci/node-esm/package.json
+++ b/.github/publish-ci/node-esm/package.json
@@ -9,8 +9,5 @@
   },
   "dependencies": {
     "@module-federation/vite": "workspace:*"
-  },
-  "devDependencies": {
-    "resolve-esm": "2.0.3"
   }
 }

--- a/.github/publish-ci/node-esm/test-cjs.cjs
+++ b/.github/publish-ci/node-esm/test-cjs.cjs
@@ -20,7 +20,7 @@ for (let [fn, name] of entries) {
   }
 }
 
-const moduleNames = [['@module-federation/vite', 'lib/index.cjs']];
+const moduleNames = [['@module-federation/vite', 'lib/index.js']];
 
 for (let [moduleName, expectedFilename] of moduleNames) {
   const modulePath = require.resolve(moduleName);

--- a/.github/publish-ci/node-esm/test-esm.js
+++ b/.github/publish-ci/node-esm/test-esm.js
@@ -2,7 +2,6 @@
 
 import assert from 'node:assert';
 import path from 'path';
-import { importMetaResolve } from 'resolve-esm';
 
 import { federation } from '@module-federation/vite';
 
@@ -23,11 +22,11 @@ for (let [fn, name] of entries) {
   }
 }
 
-const moduleNames = [['@module-federation/vite', 'lib/index.mjs']];
+const moduleNames = [['@module-federation/vite', 'lib/index.js']];
 
 (async () => {
   for (let [moduleName, expectedFilename] of moduleNames) {
-    const modulePath = await importMetaResolve(moduleName);
+    const modulePath = import.meta.resolve(moduleName);
     const posixPath = modulePath.split(path.sep).join(path.posix.sep);
     console.log(`Module: ${moduleName}, path: ${posixPath}`);
     assert(posixPath.endsWith(expectedFilename));

--- a/.github/publish-ci/node-standard/package.json
+++ b/.github/publish-ci/node-standard/package.json
@@ -8,8 +8,5 @@
   },
   "dependencies": {
     "@module-federation/vite": "workspace:*"
-  },
-  "devDependencies": {
-    "resolve-esm": "2.0.3"
   }
 }

--- a/.github/publish-ci/node-standard/test-cjs.js
+++ b/.github/publish-ci/node-standard/test-cjs.js
@@ -20,7 +20,7 @@ for (let [fn, name] of entries) {
   }
 }
 
-const moduleNames = [['@module-federation/vite', 'lib/index.cjs']];
+const moduleNames = [['@module-federation/vite', 'lib/index.js']];
 
 for (let [moduleName, expectedFilename] of moduleNames) {
   const modulePath = require.resolve(moduleName);

--- a/.github/publish-ci/node-standard/test-esm.mjs
+++ b/.github/publish-ci/node-standard/test-esm.mjs
@@ -2,7 +2,6 @@
 
 import assert from 'node:assert';
 import path from 'path';
-import { importMetaResolve } from 'resolve-esm';
 
 import { federation } from '@module-federation/vite';
 
@@ -23,11 +22,11 @@ for (let [fn, name] of entries) {
   }
 }
 
-const moduleNames = [['@module-federation/vite', 'lib/index.mjs']];
+const moduleNames = [['@module-federation/vite', 'lib/index.js']];
 
 (async () => {
   for (let [moduleName, expectedFilename] of moduleNames) {
-    const modulePath = await importMetaResolve(moduleName);
+    const modulePath = import.meta.resolve(moduleName);
     const posixPath = modulePath.split(path.sep).join(path.posix.sep);
     console.log(`Module: ${moduleName}, path: ${posixPath}`);
     assert(posixPath.endsWith(expectedFilename));

--- a/package.json
+++ b/package.json
@@ -3,27 +3,22 @@
   "version": "1.16.4",
   "description": "Vite plugin for Module Federation",
   "type": "module",
-  "main": "./lib/index.cjs",
-  "module": "./lib/index.mjs",
-  "types": "./lib/index.d.mts",
+  "main": "./lib/index.js",
+  "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "types": {
-        "import": "./lib/index.d.mts",
-        "require": "./lib/index.d.cts"
-      },
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     },
     "./ssrEntryLoader": {
-      "types": {
-        "import": "./lib/utils/ssrEntryLoader.d.mts",
-        "require": "./lib/utils/ssrEntryLoader.d.cts"
-      },
-      "import": "./lib/utils/ssrEntryLoader.mjs",
-      "require": "./lib/utils/ssrEntryLoader.cjs"
+      "types": "./lib/utils/ssrEntryLoader.d.ts",
+      "default": "./lib/utils/ssrEntryLoader.js"
     },
     "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
   },
   "files": [
     "lib/**/*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,20 +60,12 @@ importers:
       '@module-federation/vite':
         specifier: workspace:*
         version: link:../../..
-    devDependencies:
-      resolve-esm:
-        specifier: 2.0.3
-        version: 2.0.3
 
   .github/publish-ci/node-standard:
     dependencies:
       '@module-federation/vite':
         specifier: workspace:*
         version: link:../../..
-    devDependencies:
-      resolve-esm:
-        specifier: 2.0.3
-        version: 2.0.3
 
   examples/rust-vite/rust-host:
     dependencies:
@@ -3986,10 +3978,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  callsites@4.1.0:
-    resolution: {integrity: sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==}
-    engines: {node: '>=12.20'}
-
   camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
 
@@ -5952,10 +5940,6 @@ packages:
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
     engines: {node: '>=0.10.0'}
-
-  resolve-esm@2.0.3:
-    resolution: {integrity: sha512-M1Bqazc53Xy3Sdken2UmlSouyiKaeugDYORcw3khZ4/+wFHCQDEE1clPMeSMd0y9JSUCpUazca5ALXewxZdIbg==}
-    engines: {node: '>=16'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -10600,8 +10584,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  callsites@4.1.0: {}
-
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
@@ -12567,10 +12549,6 @@ snapshots:
     dependencies:
       expand-tilde: 2.0.2
       global-modules: 1.0.0
-
-  resolve-esm@2.0.3:
-    dependencies:
-      callsites: 4.1.0
 
   resolve-from@4.0.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,12 @@ import type {
 } from './utils/normalizeModuleFederationOptions';
 import { normalizeModuleFederationOptions } from './utils/normalizeModuleFederationOptions';
 import normalizeOptimizeDepsPlugin from './utils/normalizeOptimizeDeps';
-import { getIsRolldown, hasPackageDependency, setPackageDetectionCwd } from './utils/packageUtils';
+import {
+  getIsRolldown,
+  hasPackageDependency,
+  resolveImportPath,
+  setPackageDetectionCwd,
+} from './utils/packageUtils';
 import { getCommonSharedSubpaths } from './utils/pathNormalization';
 import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualModule';
 import {
@@ -427,7 +432,6 @@ export default __mfShared.default ?? __mfShared;`,
       });
       if (alreadyInjected) return;
 
-      const pluginRequire = createRequire(import.meta.url);
       const projectRequire = createRequire(new URL(`file://${config.root}/package.json`));
       const sharedKeys = Object.keys(options.shared ?? {});
       const commonSharedPkgs = [
@@ -446,7 +450,7 @@ export default __mfShared.default ?? __mfShared;`,
           resolvedShared[pkg] = projectRequire.resolve(pkg);
         } catch {
           try {
-            resolvedShared[pkg] = pluginRequire.resolve(pkg);
+            resolvedShared[pkg] = resolveImportPath(pkg);
           } catch {
             // Not installed at either location — ssrEntryLoader falls back to
             // runtime resolution from the host app.
@@ -459,7 +463,7 @@ export default __mfShared.default ?? __mfShared;`,
       // Users can still inject manually via runtimePlugins in that case.
       const ssrEntryLoaderSpecifier = '@module-federation/vite/ssrEntryLoader';
       try {
-        pluginRequire.resolve(ssrEntryLoaderSpecifier);
+        resolveImportPath(ssrEntryLoaderSpecifier);
         options.runtimePlugins.push([ssrEntryLoaderSpecifier, { resolvedShared }]);
       } catch {
         // lib/ not built yet — skip silently
@@ -1020,16 +1024,9 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       config(config: UserConfig, { command: _command }: { command: string }) {
         const isRolldown = getIsRolldown(this);
 
-        // For Vite 8+, resolve to ESM entry
-        // because Vite 8's internal bundler cannot parse dynamic import() in .cjs files
-        let implementation = options.implementation;
-        if (isRolldown) {
-          implementation = implementation.replace(/\.cjs(\.js)?$/, '.js');
-        }
-
         appendResolveAlias(config, {
           find: '@module-federation/runtime',
-          replacement: implementation,
+          replacement: options.implementation,
         });
         config.build ||= {};
         config.build.commonjsOptions ||= {};

--- a/src/plugins/__tests__/pluginProxyRemotes.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemotes.test.ts
@@ -18,6 +18,7 @@ const {
 vi.mock('../../utils/packageUtils', () => ({
   getInstalledPackageEntry: getInstalledPackageEntryMock,
   getPackageDetectionCwd: vi.fn(() => '/repo'),
+  resolveImportPath: vi.fn((specifier: string) => `/repo/node_modules/${specifier}/index.js`),
 }));
 
 vi.mock('../../virtualModules', () => ({

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -60,6 +60,9 @@ vi.mock('../../utils/packageUtils', () => ({
   }),
   setPackageDetectionCwd: vi.fn(),
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
+  resolveImportPath: vi.fn(
+    (specifier: string) => `/repo/apps/remote/node_modules/${specifier}/index.js`
+  ),
   getIsRolldown: () => false,
   packageNameEncode: (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_'),
   getPackageName: (pkg: string) => {

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../utils/packageUtils', () => ({
   isNuxtProjectRoot: isNuxtProjectRootMock,
   getPackageDetectionCwd: vi.fn(() => '/mock/cwd'),
   setPackageDetectionCwd: vi.fn(),
+  resolveImportPath: vi.fn((specifier: string) => `/mock/cwd/node_modules/${specifier}/index.js`),
   getPackageName: vi.fn((s: string) => s.split('/')[0]),
   getPackageNameFromNodeModulePath: vi.fn(),
   packageNameEncode: vi.fn((s: string) => s),

--- a/src/plugins/pluginDts.ts
+++ b/src/plugins/pluginDts.ts
@@ -13,7 +13,7 @@ import { rpc, type DTSManagerOptions } from '@module-federation/dts-plugin/core'
 import * as path from 'pathe';
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
-import { hasPackageDependency } from '../utils/packageUtils';
+import { hasPackageDependency, resolveImportPath } from '../utils/packageUtils';
 import { createModuleFederationError, mfError } from '../utils/logger';
 
 type DevOptions = {
@@ -42,8 +42,7 @@ type DevWorkerOptions = DTSManagerOptions & {
 };
 
 const forkDevWorkerPath = (() => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  return require.resolve('@module-federation/dts-plugin/dist/fork-dev-worker.js');
+  return resolveImportPath('@module-federation/dts-plugin/dist/fork-dev-worker.js');
 })();
 
 class DevWorker {

--- a/src/utils/__tests__/controlChunkSanitizer.test.ts
+++ b/src/utils/__tests__/controlChunkSanitizer.test.ts
@@ -9,7 +9,7 @@ describe('controlChunkSanitizer', () => {
   it('strips minified preload helpers and loadShare side-effect imports', () => {
     const code =
       'import{_ as or}from"./assets/TreeLoader-KqsPzsXB.js";' +
-      'import"./assets/reproApp__loadShare__react__loadShare__.mjs-DOStu9DH.js";' +
+      'import"./assets/reproApp__loadShare__react__loadShare__.js-DOStu9DH.js";' +
       'async function load(){return or(()=>import("./assets/localSharedImportMap.js"),[],import.meta.url)}';
 
     expect(stripEmptyPreloadCalls(code)).toBe(

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -1,11 +1,13 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import path from 'pathe';
 import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   getInstalledPackageEntry,
   getInstalledPackageJson,
   getPackageNameFromNodeModulePath,
+  resolveImportPath,
 } from '../packageUtils';
 
 describe('getInstalledPackageJson', () => {
@@ -81,6 +83,17 @@ describe('getInstalledPackageJson', () => {
     const entry = getInstalledPackageEntry(packageName, { cwd: hostDir });
 
     expect(entry).toBe(path.join(packageDir, 'dist/browser.js'));
+  });
+});
+
+describe('resolveImportPath', () => {
+  it('returns an existing package export path', () => {
+    expect(resolveImportPath('@module-federation/runtime')).toContain('@module-federation');
+  });
+
+  it('throws for exported paths that do not exist on disk', () => {
+    const missing = path.join(tmpdir(), `mf-vite-missing-${Date.now()}.js`);
+    expect(() => resolveImportPath(pathToFileURL(missing).href)).toThrow(/Cannot find module/);
   });
 });
 

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -25,7 +25,12 @@ export type RemoteEntryType =
 import * as fs from 'fs';
 import * as path from 'pathe';
 import { createModuleFederationError, mfWarn } from './logger';
-import { getInstalledPackageJson, getPackageDetectionCwd, getPackageName } from './packageUtils';
+import {
+  getInstalledPackageJson,
+  getPackageDetectionCwd,
+  getPackageName,
+  resolveImportPath,
+} from './packageUtils';
 
 interface ExposesItem {
   import: string;
@@ -570,10 +575,10 @@ let config: NormalizedModuleFederationOptions;
 let explicitSharedKeys: Set<string> = new Set();
 
 function resolveRuntimeImplementation(): string {
-  const fallback = require.resolve('@module-federation/runtime');
+  const fallback = resolveImportPath('@module-federation/runtime');
 
   try {
-    const packageJsonPath = require.resolve('@module-federation/runtime/package.json');
+    const packageJsonPath = resolveImportPath('@module-federation/runtime/package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
       module?: string;
       exports?: {

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
 import path from 'pathe';
 import { createModuleFederationError } from './logger';
 import type { ShareItem } from './normalizeModuleFederationOptions';
@@ -24,6 +25,19 @@ export function setPackageDetectionCwd(cwd: string) {
 
 export function getPackageDetectionCwd() {
   return packageDetectionCwd || process.cwd();
+}
+
+export function resolveImportPath(specifier: string): string {
+  const resolved = import.meta.resolve(specifier);
+  if (!resolved.startsWith('file:')) return resolved;
+
+  const filePath = fileURLToPath(resolved);
+  if (!existsSync(filePath)) {
+    const error = new Error(`Cannot find module '${specifier}'`) as NodeJS.ErrnoException;
+    error.code = 'MODULE_NOT_FOUND';
+    throw error;
+  }
+  return filePath;
 }
 
 export type InstalledPackageJson = {

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -345,9 +345,9 @@ function transformSsrCode(code: string, base: string, sharedPkgMap?: Map<string,
 }
 
 /**
- * Fetch an HTTP ESM module, transform it, write it to a temp .mjs file and
+ * Fetch an HTTP ESM module, transform it, write it to a temp .js file and
  * return the file path. Recursively does the same for HTTP transitive imports
- * so that `import('file:///...temp.mjs')` can resolve them.
+ * so that `import('file:///...temp.js')` can resolve them.
  */
 async function fetchEsmToTempFile(
   url: string,
@@ -396,7 +396,7 @@ async function fetchEsmToTempFile(
     const { join } = await _path();
     const { writeFileSync } = await _fs();
     const hash = createHash('sha1').update(url).digest('hex').slice(0, 12);
-    const tmpFile = join(tmpDir, `${hash}.mjs`);
+    const tmpFile = join(tmpDir, `${hash}.js`);
     writeFileSync(tmpFile, code, 'utf8');
     visited.set(url, tmpFile);
     return tmpFile;

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -178,7 +178,7 @@ describe('generateRemotes', () => {
   it('uses ESM remote wrappers in Rollup build mode', () => {
     const virtual = getRemoteVirtualModule('remote/Card', 'build');
 
-    expect(virtual.getImportId()).toContain('.mjs');
+    expect(virtual.getImportId()).toContain('.js');
   });
 
   describe('proxy invariants', () => {

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -17,7 +17,7 @@ export const LOAD_REMOTE_TAG = '__loadRemote__';
 export function getRemoteVirtualModule(remote: string, command: string, enableSsrInit = false) {
   const cacheKey = `${remote}__${command}__${enableSsrInit ? 'ssr' : 'no-ssr'}`;
   if (!cacheRemoteMap[cacheKey]) {
-    cacheRemoteMap[cacheKey] = new VirtualModule(remote, LOAD_REMOTE_TAG, '.mjs');
+    cacheRemoteMap[cacheKey] = new VirtualModule(remote, LOAD_REMOTE_TAG, '.js');
     cacheRemoteMap[cacheKey].writeSync(generateRemotes(remote, command, enableSsrInit));
   }
   const virtual = cacheRemoteMap[cacheKey];

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -477,7 +477,7 @@ export const LOAD_SHARE_TAG = '__loadShare__';
 const loadShareCacheMap: Record<string, VirtualModule> = {};
 export function getLoadShareImportId(pkg: string, _isRolldown: boolean): string {
   if (!loadShareCacheMap[pkg]) {
-    loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, '.mjs');
+    loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, '.js');
   }
   return loadShareCacheMap[pkg].getImportId();
 }
@@ -600,7 +600,7 @@ export function writeLoadShareModule(
   _isRolldown: boolean
 ) {
   if (!loadShareCacheMap[pkg]) {
-    loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, '.mjs');
+    loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, '.js');
   }
   const importLine = getRuntimeModuleCacheBootstrapCode();
   const cacheKey = getSharedCacheKey(pkg, shareItem);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/utils/ssrEntryLoader.ts'],
-  format: ['esm', 'cjs'],
-  outDir: 'lib',
+  entry: ["src/index.ts", "src/utils/ssrEntryLoader.ts"],
+  format: ["esm"],
+  outDir: "lib",
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
   dts: true,
   clean: true,
   deps: {


### PR DESCRIPTION
This is `not` a breaking change because:
 - It drops the CommonJS build and publishes the package as ESM-only, while keeping CommonJS consumers working on Node versions that support require(esm): Node ^20.19.0 or >=22.12.0.
 - It aligns package exports and build output to .js/.d.ts, removes stale CJS output paths, and centralizes ESM-native module resolution through import.meta.resolve.
- It also keeps user project compatibility for .cjs/.mjs/.mts inputs, meaning consumers can still use CJS config/files, ESM .mjs/.mts sources, and CJS/ESM remote/shared dependencies; only this package’s published build output drops CJS.