### PR TITLE
fix: avoid duplicate react with redux in dev mode

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -995,6 +995,28 @@ describe('vite:module-federation-early-init', () => {
     expect(virtualModule?.code).toContain('jsx');
   });
 
+  it('excludes shared react from dev optimizeDeps when react-redux is installed', () => {
+    hasPackageDependencyMock.mockImplementation(
+      (dependency: string): boolean => dependency === 'react-redux'
+    );
+    const plugin = getEarlyInitPluginWithReactShared();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+        exclude: [],
+      },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps.exclude).toContain('react');
+    expect(config.optimizeDeps.include).not.toContain('react');
+  });
+
   it('leaves ENV_TARGET undefined for Astro mixed builds', () => {
     hasPackageDependencyMock.mockImplementation(
       (dependency: string): boolean => dependency === 'astro'

--- a/src/index.ts
+++ b/src/index.ts
@@ -391,7 +391,8 @@ export default __mfShared.default ?? __mfShared;`,
             // their submodules rely on parent initialization order. Other
             // shared deps should remain optimizable so Vite can apply CJS
             // interop for transitive dependencies used by prebuild fallbacks.
-            const shouldBypassOptimizeDep = isLitShare(key);
+            const shouldBypassOptimizeDep =
+              isLitShare(key) || (key === 'react' && hasPackageDependency('react-redux', root));
             if (shouldBypassOptimizeDep) {
               optimizeDeps.exclude.push(key);
             } else {


### PR DESCRIPTION
Close #792

In dev only, if react-redux is present, we skip Vite pre-bundling for shared react.
This keeps React resolved through Module Federation sharing.

Result: 
host, remote, and react-redux all use the same React instance.