### PR TITLE
fix: allow additional whitespace in preload-helper regex

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1307,7 +1307,7 @@ describe('module-federation-fix-preload', () => {
     const bundle = {
       'preload-helper-abc.js': createChunk(
         'preload-helper-abc.js',
-        'const u = function(e) { return "/"+e };modulepreload'
+        'const u = function(e) { return "/" + e };modulepreload'
       ),
     };
 
@@ -1328,7 +1328,7 @@ describe('module-federation-fix-preload', () => {
     const bundle = {
       'preload-helper-abc.js': createChunk(
         'preload-helper-abc.js',
-        'const u = e => "/"+e;modulepreload'
+        'const u = e => "/" + e;modulepreload'
       ),
     };
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1301,6 +1301,48 @@ describe('module-federation-fix-preload', () => {
       'new URL(e,import.meta.url).href'
     );
   });
+
+  it('handles spaces in function expression pattern', () => {
+    const plugin = getFixPreloadPlugin();
+    const bundle = {
+      'preload-helper-abc.js': createChunk(
+        'preload-helper-abc.js',
+        'const u = function(e) { return "/"+e };modulepreload'
+      ),
+    };
+
+    runGenerateBundle(
+      plugin,
+      {} as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle
+    );
+
+    expect((bundle['preload-helper-abc.js'] as Rollup.OutputChunk).code).toContain(
+      'new URL(e,import.meta.url).href'
+    );
+  });
+
+  it('handles spaces in arrow function pattern', () => {
+    const plugin = getFixPreloadPlugin();
+    const bundle = {
+      'preload-helper-abc.js': createChunk(
+        'preload-helper-abc.js',
+        'const u = e => "/"+e;modulepreload'
+      ),
+    };
+
+    runGenerateBundle(
+      plugin,
+      {} as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle
+    );
+
+    expect((bundle['preload-helper-abc.js'] as Rollup.OutputChunk).code).toContain(
+      'new URL(e,import.meta.url).href'
+    );
+  });
 });
 
 describe('module-federation-vinext-fix-rsc-preload-as', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1323,6 +1323,32 @@ describe('module-federation-fix-preload', () => {
     );
   });
 
+  it('handles multi-line with semicolon in function expression pattern', () => {
+    const plugin = getFixPreloadPlugin();
+    const bundle = {
+      'preload-helper-abc.js': createChunk(
+        'preload-helper-abc.js',
+        `
+        const scriptRel = "modulepreload";
+        const assetsURL = function(dep) {
+          return "/" + dep;
+        };
+        `
+      ),
+    };
+
+    runGenerateBundle(
+      plugin,
+      {} as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle
+    );
+
+    expect((bundle['preload-helper-abc.js'] as Rollup.OutputChunk).code).toContain(
+      'new URL(dep,import.meta.url).href'
+    );
+  });
+
   it('handles spaces in arrow function pattern', () => {
     const plugin = getFixPreloadPlugin();
     const bundle = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1196,7 +1196,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
                   // The string literal must start with "/" to avoid matching unrelated
                   // functions like Stencil's getScopeId: (e,t)=>"sc-"+e.$tagName$
                   const replaced = chunk.code.replace(
-                  /=\s*\(?(\w+)(?:,\w+)?\)?\s*=>\s*[`"'][./][^`"']*[`"']\s*\+\s*\1/,
+                    /=\s*\(?(\w+)(?:,\w+)?\)?\s*=>\s*[`"'][./][^`"']*[`"']\s*\+\s*\1/,
                     replacement
                   );
                   if (replaced !== chunk.code) {
@@ -1205,7 +1205,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
                   }
                   // Function expression: function(e){return"/"+e} (1 or 2 params)
                   chunk.code = chunk.code.replace(
-                  /=\s*function\((\w+)(?:,\w+)?\)\s*\{\s*return\s*[`"'][./][^`"']*[`"']\s*\+\s*\1\s*\}/,
+                    /=\s*function\((\w+)(?:,\w+)?\)\s*\{\s*return\s*[`"'][./][^`"']*[`"']\s*\+\s*\1\s*\}/,
                     replacement
                   );
                   chunk.code = chunk.code.replace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1205,7 +1205,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
                   }
                   // Function expression: function(e){return"/"+e} (1 or 2 params)
                   chunk.code = chunk.code.replace(
-                    /=\s*function\((\w+)(?:,\w+)?\)\s*\{\s*return\s*[`"'][./][^`"']*[`"']\s*\+\s*\1\s*\}/,
+                    /=\s*function\((\w+)(?:,\w+)?\)\s*\{\s*return\s*[`"'][./][^`"']*[`"']\s*\+\s*\1;?\s*\}/,
                     replacement
                   );
                   chunk.code = chunk.code.replace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1196,7 +1196,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
                   // The string literal must start with "/" to avoid matching unrelated
                   // functions like Stencil's getScopeId: (e,t)=>"sc-"+e.$tagName$
                   const replaced = chunk.code.replace(
-                    /=\(?(\w+)(?:,\w+)?\)?\s*=>\s*[`"'][./][^`"']*[`"']\s*\+\s*\1/,
+                  /=\s*\(?(\w+)(?:,\w+)?\)?\s*=>\s*[`"'][./][^`"']*[`"']\s*\+\s*\1/,
                     replacement
                   );
                   if (replaced !== chunk.code) {
@@ -1205,7 +1205,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
                   }
                   // Function expression: function(e){return"/"+e} (1 or 2 params)
                   chunk.code = chunk.code.replace(
-                    /=function\((\w+)(?:,\w+)?\)\{return\s*[`"'][./][^`"']*[`"']\s*\+\s*\1\s*\}/,
+                  /=\s*function\((\w+)(?:,\w+)?\)\s*\{\s*return\s*[`"'][./][^`"']*[`"']\s*\+\s*\1\s*\}/,
                     replacement
                   );
                   chunk.code = chunk.code.replace(


### PR DESCRIPTION
Closes #802 

I've opted to only extend the regex for the arrow function and function expression, leaving the other two regexes untouched (since they don't have any whitespace tolerance yet anyway).

Related: #629, #699