### PR TITLE
fix: order shared dependency preload

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -48,6 +48,33 @@ vi.mock('../../utils/packageUtils', () => {
       shareItem.shareConfig.singleton || !shareItem.version ? pkg : `${pkg}@${shareItem.version}`,
     hasPackageDependency: hasPackageDependencyMock,
     packageNameEncode: (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_'),
+    getPackageName: (packageString: string) => {
+      const match = packageString.match(/^(?:@[^/]+\/)?[^/]+/);
+      return match ? match[0] : packageString;
+    },
+    getInstalledPackageJson: (pkg: string) => {
+      if (pkg === '@repro/core') {
+        return {
+          path: '/repo/packages/core/package.json',
+          dir: '/repo/packages/core',
+          packageJson: {
+            name: '@repro/core',
+            dependencies: {
+              '@repro/shared-lib': 'workspace:*',
+            },
+          },
+        };
+      }
+      if (pkg === '@repro/shared-lib') {
+        return {
+          path: '/repo/packages/shared-lib/package.json',
+          dir: '/repo/packages/shared-lib',
+          packageJson: {
+            name: '@repro/shared-lib',
+          },
+        };
+      }
+    },
   };
 });
 
@@ -415,6 +442,42 @@ describe('virtualRemoteEntry', () => {
 
     expect(code).toContain('Object.entries(usedShared)');
     expect(code).not.toContain('"lit/decorators.js"');
+  });
+
+  it('preloads shared package dependencies before their consumers', async () => {
+    normalizedSharedMock.mockReturnValue({
+      '@repro/core': {
+        name: '@repro/core',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^1.0.0',
+          strictVersion: false,
+        },
+      },
+      '@repro/shared-lib': {
+        name: '@repro/shared-lib',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^1.0.0',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/core');
+    mod.addUsedShares('@repro/shared-lib');
+
+    const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
+
+    expect(code.indexOf('"@repro/shared-lib"')).toBeLessThan(code.indexOf('"@repro/core"'));
   });
 
   it('does not seed a bare package for trailing slash shared packages', async () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -5,7 +5,13 @@ import {
   NormalizedModuleFederationOptions,
   ShareItem,
 } from '../utils/normalizeModuleFederationOptions';
-import { getSharedCacheKey, hasPackageDependency, packageNameEncode } from '../utils/packageUtils';
+import {
+  getInstalledPackageJson,
+  getPackageName,
+  getSharedCacheKey,
+  hasPackageDependency,
+  packageNameEncode,
+} from '../utils/packageUtils';
 import { serializeRuntimeOptions } from '../utils/serializeRuntimeOptions';
 import VirtualModule from '../utils/VirtualModule';
 import { getVirtualExposesId } from './virtualExposes';
@@ -196,11 +202,39 @@ function getOrderedUsedShares() {
   } catch {
     // Some isolated unit tests call generators before normalized options exist.
   }
-  return Array.from(shares).sort((a, b) => {
+  const sorted = Array.from(shares).sort((a, b) => {
     const priority = (pkg: string) =>
       pkg === 'react' ? 0 : pkg === 'react-dom' ? 1 : pkg.startsWith('react/') ? 2 : 3;
     return priority(a) - priority(b) || a.localeCompare(b);
   });
+  return orderSharedDependenciesFirst(sorted);
+}
+
+function orderSharedDependenciesFirst(sharedPackages: string[]) {
+  const sharedKeyByPackageName = new Map(sharedPackages.map((pkg) => [getPackageName(pkg), pkg]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const ordered: string[] = [];
+  const visit = (pkg: string) => {
+    if (visited.has(pkg)) return;
+    if (visiting.has(pkg)) return;
+    visiting.add(pkg);
+    const packageJson = getInstalledPackageJson(pkg)?.packageJson;
+    const dependencies = {
+      ...((packageJson?.dependencies as Record<string, string> | undefined) || {}),
+      ...((packageJson?.peerDependencies as Record<string, string> | undefined) || {}),
+      ...((packageJson?.optionalDependencies as Record<string, string> | undefined) || {}),
+    };
+    Object.keys(dependencies).forEach((dependency) => {
+      const sharedDependency = sharedKeyByPackageName.get(dependency);
+      if (sharedDependency) visit(sharedDependency);
+    });
+    visiting.delete(pkg);
+    visited.add(pkg);
+    ordered.push(pkg);
+  };
+  sharedPackages.forEach(visit);
+  return ordered;
 }
 
 function getShareItemForPreload(pkg: string) {


### PR DESCRIPTION
Close #805 

Fixes build-mode shared singleton initialization when one shared workspace package depends on another. Shared preload order now respects package dependencies, preventing consumers from evaluating before their shared dependencies are cached, without eager local fallback imports that double-initialize singletons.