### PR TITLE
fix(manifest): advertise types archive url in mf-manifest

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -126,6 +126,7 @@ async function runGenerateBundleWithManifest(
         }
       | undefined
     >;
+    dts?: unknown;
   } = {},
   command: 'serve' | 'build' = 'build',
   base = '/'
@@ -135,6 +136,7 @@ async function runGenerateBundleWithManifest(
     filename: 'remoteEntry.js',
     getPublicPath: undefined,
     varFilename: undefined,
+    dts: runtime.dts,
     manifest: manifestOptions,
     exposes: runtime.exposePaths || {},
     remotes: {},
@@ -383,6 +385,45 @@ describe('pluginMFManifest', () => {
 
     const manifest = JSON.parse(emitted['mf-manifest.json']);
     expect(manifest.metaData.publicPath).toBe('/remote/');
+  });
+
+  it('advertises the types archive url when type generation is enabled', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, { dts: { generateTypes: true } });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    expect(manifest.metaData.types).toMatchObject({
+      zip: '@mf-types.zip',
+      api: '@mf-types.d.ts',
+    });
+  });
+
+  it('honors a custom generateTypes.typesFolder in the advertised url', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, {
+      dts: { generateTypes: { typesFolder: '@types' } },
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    expect(manifest.metaData.types).toMatchObject({
+      zip: '@types.zip',
+      api: '@types.d.ts',
+    });
+  });
+
+  it('omits the types archive url when dts is disabled', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, { dts: false });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    expect(manifest.metaData.types).toEqual({ path: '', name: '' });
+    expect(manifest.metaData.types.zip).toBeUndefined();
+  });
+
+  it('omits the types archive url when generateTypes is disabled', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, {
+      dts: { generateTypes: false },
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    expect(manifest.metaData.types).toEqual({ path: '', name: '' });
   });
 
   it('preserves publicPath "auto" in manifest metaData', async () => {

--- a/src/plugins/pluginDts.ts
+++ b/src/plugins/pluginDts.ts
@@ -34,7 +34,7 @@ const DYNAMIC_HINTS_PLUGIN = '@module-federation/dts-plugin/dynamic-remote-type-
 const getIPv4 = () => process.env['FEDERATION_IPV4'] || '127.0.0.1';
 
 const DEV_TYPES_FOLDER = '.dev-server';
-const DEFAULT_PUBLIC_TYPES_FOLDER = '@mf-types';
+export const DEFAULT_PUBLIC_TYPES_FOLDER = '@mf-types';
 
 type DevWorkerOptions = DTSManagerOptions & {
   name: string;

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -18,6 +18,7 @@ import {
 } from '../utils/cssModuleHelpers';
 import { resolvePublicPath } from '../utils/pathNormalization';
 import { getSsrRemoteEntryFileName } from '../virtualModules/virtualRemoteEntrySSR';
+import { DEFAULT_PUBLIC_TYPES_FOLDER } from './pluginDts';
 
 /**
  * Resolves the build version for the module federation manifest.
@@ -31,6 +32,36 @@ import { getSsrRemoteEntryFileName } from '../virtualModules/virtualRemoteEntryS
  */
 function getBuildVersion(): string {
   return process.env['MF_BUILD_VERSION'] ?? '1.0.0';
+}
+
+/**
+ * Builds the manifest `metaData.types` entry.
+ *
+ * When type generation is enabled, the dts plugin serves the type archive
+ * (`<typesFolder>.zip`) and api file (`<typesFolder>.d.ts`). Consumers using
+ * `@module-federation/dts-plugin` read `metaData.types.zip` to download those
+ * types and throw `Can not get <remote>'s types archive url!` when it is absent.
+ * Advertising the relative paths here (resolved against `publicPath` by the
+ * consumer) mirrors the webpack/rspack (`@module-federation/enhanced`) plugins.
+ */
+function resolveTypesMeta(dts: ReturnType<typeof getNormalizeModuleFederationOptions>['dts']): {
+  path: string;
+  name: string;
+  zip?: string;
+  api?: string;
+} {
+  if (dts === false) return { path: '', name: '' };
+  const generateTypes = typeof dts === 'object' && dts ? dts.generateTypes : undefined;
+  if (generateTypes === false) return { path: '', name: '' };
+  const typesFolder =
+    (typeof generateTypes === 'object' && generateTypes?.typesFolder) ||
+    DEFAULT_PUBLIC_TYPES_FOLDER;
+  return {
+    path: '',
+    name: '',
+    zip: `${typesFolder}.zip`,
+    api: `${typesFolder}.d.ts`,
+  };
 }
 
 const Manifest = (): Plugin[] => {
@@ -129,7 +160,7 @@ const Manifest = (): Plugin[] => {
                         type: 'var',
                       }
                     : undefined,
-                  types: { path: '', name: '' },
+                  types: resolveTypesMeta(mfOptions.dts),
                   globalName: name,
                   pluginVersion: '0.2.5',
                   publicPath,
@@ -368,10 +399,7 @@ const Manifest = (): Plugin[] => {
         remoteEntry,
         ssrRemoteEntry,
         varRemoteEntry,
-        types: {
-          path: '',
-          name: '',
-        },
+        types: resolveTypesMeta(options.dts),
         globalName: name,
         pluginVersion: '0.2.5',
         ...(!!getPublicPath ? { getPublicPath } : { publicPath }),


### PR DESCRIPTION
## Problem

A vite **producer** generates and serves its type archive in dev (`/@mf-types.zip`, `/@mf-types.d.ts`) and emits it on build, but `mf-manifest.json` hardcodes:

```jsonc
"types": { "path": "", "name": "" }
```

in **both** the dev-server middleware and the build manifest. There is no `zip`/`api`.

A **host** consuming that remote via `@module-federation/dts-plugin` reads `metaData.types.zip` to locate the archive (`requestRemoteManifest`), and throws when it's missing:

```
[ERROR] requestRemoteManifest - fetch manifest failed,
Error: Can not get <remote>'s types archive url!, <remote> will be ignored
```

So remote type hints are silently dropped for any host consuming a vite remote — even though the archive is right there and reachable (HTTP 200). Runtime is unaffected; only cross-remote types break.

The webpack/rspack producer (`@module-federation/enhanced`) populates `metaData.types.zip`/`.api` correctly — the vite plugin just never wired it through.

## Fix

Populate `metaData.types.zip` / `.api` with the same relative paths the dts plugin already serves (`<typesFolder>.zip` / `<typesFolder>.d.ts`), resolved against `publicPath` by the consumer. Applied at both manifest sites via a shared `resolveTypesMeta(dts)` helper that:

- returns `{ path: '', name: '' }` (unchanged) when `dts === false` or `generateTypes === false`
- otherwise advertises `zip`/`api`, honoring a custom `generateTypes.typesFolder`

`DEFAULT_PUBLIC_TYPES_FOLDER` is exported from `pluginDts.ts` so both modules share one source of truth.

## Tests

Added 4 cases to `pluginMFManifest.test.ts` (enabled → advertised, custom `typesFolder`, `dts: false` → empty, `generateTypes: false` → empty). Full suite green (505 passed), typecheck + `oxfmt` clean.

## Open question for maintainers

The dts plugin only generates/serves the archive for **TypeScript projects** (`isTSProject`). This PR gates on `dts`/`generateTypes` only, matching the dev middleware's default-on behavior. If you'd prefer to also gate on `isTSProject` to avoid advertising a 404 for non-TS remotes, happy to wire that through.

## Repro

A vite remote exposing any module + any host consuming it through `@module-federation/dts-plugin`'s dynamic remote type hints. Before: host logs the error above and gets no remote types. After: host downloads `@mf-types.zip` and resolves the remote's `.d.ts`.