### PR TITLE
fix: improve hostInit browsers support

### DIFF
--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -58,8 +58,10 @@ describe('host build', () => {
     const bootstrapAsset = output.output.find(
       (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
     );
-    expect(bootstrapAsset?.source).toContain('const runtime = await __mfImport(');
-    expect(bootstrapAsset?.source).toContain('.then(({ initHost }) => initHost());');
+    expect(bootstrapAsset?.source).toContain('const __mfHostInit = await __mfImport(');
+    expect(bootstrapAsset?.source).toContain('await __mfHostInit.__tla;');
+    expect(bootstrapAsset?.source).toContain('const { initHost } = __mfHostInit;');
+    expect(bootstrapAsset?.source).toContain('const runtime = await initHost();');
     expect(bootstrapAsset?.source).toContain('__mfPreloadRemote("remote1/Module")');
     expect(bootstrapAsset?.source).toContain('runtime.loadRemote(remote)');
     expect(bootstrapAsset?.source).toContain('})().then(() => __mfImport(');

--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -58,10 +58,8 @@ describe('host build', () => {
     const bootstrapAsset = output.output.find(
       (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
     );
-    expect(bootstrapAsset?.source).toContain('const __mfHostInit = await __mfImport(');
-    expect(bootstrapAsset?.source).toContain('await __mfHostInit.__tla;');
-    expect(bootstrapAsset?.source).toContain('const { initHost } = __mfHostInit;');
-    expect(bootstrapAsset?.source).toContain('const runtime = await initHost();');
+    expect(bootstrapAsset?.source).toContain('const runtime = await __mfImport(');
+    expect(bootstrapAsset?.source).toContain('.then(({ initHost }) => initHost());');
     expect(bootstrapAsset?.source).toContain('__mfPreloadRemote("remote1/Module")');
     expect(bootstrapAsset?.source).toContain('runtime.loadRemote(remote)');
     expect(bootstrapAsset?.source).toContain('})().then(() => __mfImport(');

--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -58,7 +58,9 @@ describe('host build', () => {
     const bootstrapAsset = output.output.find(
       (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
     );
-    expect(bootstrapAsset?.source).toContain('const { initHost } = await __mfImport(');
+    expect(bootstrapAsset?.source).toContain('const __mfHostInit = await __mfImport(');
+    expect(bootstrapAsset?.source).toContain('await __mfHostInit.__tla;');
+    expect(bootstrapAsset?.source).toContain('const { initHost } = __mfHostInit;');
     expect(bootstrapAsset?.source).toContain('const runtime = await initHost();');
     expect(bootstrapAsset?.source).toContain('__mfPreloadRemote("remote1/Module")');
     expect(bootstrapAsset?.source).toContain('runtime.loadRemote(remote)');

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -218,15 +218,8 @@ describe('pluginAddEntry', () => {
       '/src/main.tsx'
     )) as { code: string } | undefined;
 
-    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
-    expect(result?.code).toContain('await __mfHostInit.__tla;');
-    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
-    expect(result?.code).toContain('await initHost();');
-    // Regression (Safari TLA-lowering race): the emulated `__tla` promise must
-    // be awaited BEFORE initHost() runs, or `initHost` reads undefined.
-    const bootstrap = result?.code ?? '';
-    expect(bootstrap.indexOf('await __mfHostInit.__tla;')).toBeLessThan(
-      bootstrap.indexOf('await initHost();')
+    expect(result?.code).toContain(
+      'await import("/virtual/hostInit.js").then(({ initHost }) => initHost());'
     );
     expect(result?.code).toContain('})().then(() => import("/src/main.tsx?mf-entry-bootstrap"));');
     expect(result?.code).not.toContain('globalThis.System.import(src)');
@@ -260,10 +253,9 @@ describe('pluginAddEntry', () => {
       '/virtual/client-entry.tsx'
     )) as { code: string } | undefined;
 
-    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
-    expect(result?.code).toContain('await __mfHostInit.__tla;');
-    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
-    expect(result?.code).toContain('await initHost();');
+    expect(result?.code).toContain(
+      'await import("/virtual/hostInit.js").then(({ initHost }) => initHost());'
+    );
     expect(result?.code).toContain(
       '})().then(() => import("/virtual/client-entry.tsx?mf-entry-bootstrap"));'
     );
@@ -524,7 +516,9 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('__mfPreloadRemote');
     expect(result?.code).not.toContain('loadRemote');
     expect(result?.code).not.toContain('__mfRemotePreloads');
-    expect(result?.code).toContain('await initHost();');
+    expect(result?.code).toContain(
+      'await import("/virtual/hostInit.js").then(({ initHost }) => initHost());'
+    );
     expect(result?.code).toContain('})().then(() => import("/src/main.ts?mf-entry-bootstrap"));');
   });
 
@@ -651,11 +645,8 @@ describe('pluginAddEntry', () => {
     // The proxy module must import both init and entry as resolvable paths
     // (no base prefix — Vite's server-side resolver handles base itself)
     expect(code).toContain(
-      `const __mfHostInit = await import("${VITE_ID_PREFIX}virtual:mf-host-init");`
+      `await import("${VITE_ID_PREFIX}virtual:mf-host-init").then(({ initHost }) => initHost());`
     );
-    expect(code).toContain('await __mfHostInit.__tla;');
-    expect(code).toContain('const { initHost } = __mfHostInit;');
-    expect(code).toContain('await initHost();');
     expect(code).toContain('})().then(() => import("/src/main.tsx"));');
     expect(code).not.toContain('globalThis.System.import(src)');
     expect(code).not.toContain('/foo/');

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -218,8 +218,15 @@ describe('pluginAddEntry', () => {
       '/src/main.tsx'
     )) as { code: string } | undefined;
 
-    expect(result?.code).toContain(
-      'await import("/virtual/hostInit.js").then(({ initHost }) => initHost());'
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('await __mfHostInit.__tla;');
+    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
+    expect(result?.code).toContain('await initHost();');
+    // Regression (Safari TLA-lowering race): the emulated `__tla` promise must
+    // be awaited BEFORE initHost() runs, or `initHost` reads undefined.
+    const bootstrap = result?.code ?? '';
+    expect(bootstrap.indexOf('await __mfHostInit.__tla;')).toBeLessThan(
+      bootstrap.indexOf('await initHost();')
     );
     expect(result?.code).toContain('})().then(() => import("/src/main.tsx?mf-entry-bootstrap"));');
     expect(result?.code).not.toContain('globalThis.System.import(src)');
@@ -253,9 +260,10 @@ describe('pluginAddEntry', () => {
       '/virtual/client-entry.tsx'
     )) as { code: string } | undefined;
 
-    expect(result?.code).toContain(
-      'await import("/virtual/hostInit.js").then(({ initHost }) => initHost());'
-    );
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('await __mfHostInit.__tla;');
+    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
+    expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain(
       '})().then(() => import("/virtual/client-entry.tsx?mf-entry-bootstrap"));'
     );
@@ -516,9 +524,7 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('__mfPreloadRemote');
     expect(result?.code).not.toContain('loadRemote');
     expect(result?.code).not.toContain('__mfRemotePreloads');
-    expect(result?.code).toContain(
-      'await import("/virtual/hostInit.js").then(({ initHost }) => initHost());'
-    );
+    expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain('})().then(() => import("/src/main.ts?mf-entry-bootstrap"));');
   });
 
@@ -645,8 +651,11 @@ describe('pluginAddEntry', () => {
     // The proxy module must import both init and entry as resolvable paths
     // (no base prefix — Vite's server-side resolver handles base itself)
     expect(code).toContain(
-      `await import("${VITE_ID_PREFIX}virtual:mf-host-init").then(({ initHost }) => initHost());`
+      `const __mfHostInit = await import("${VITE_ID_PREFIX}virtual:mf-host-init");`
     );
+    expect(code).toContain('await __mfHostInit.__tla;');
+    expect(code).toContain('const { initHost } = __mfHostInit;');
+    expect(code).toContain('await initHost();');
     expect(code).toContain('})().then(() => import("/src/main.tsx"));');
     expect(code).not.toContain('globalThis.System.import(src)');
     expect(code).not.toContain('/foo/');

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -218,8 +218,16 @@ describe('pluginAddEntry', () => {
       '/src/main.tsx'
     )) as { code: string } | undefined;
 
-    expect(result?.code).toContain('const { initHost } = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('await __mfHostInit.__tla;');
+    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
     expect(result?.code).toContain('await initHost();');
+    // Regression (Safari TLA-lowering race): the emulated `__tla` promise must
+    // be awaited BEFORE initHost() runs, or `initHost` reads undefined.
+    const bootstrap = result?.code ?? '';
+    expect(bootstrap.indexOf('await __mfHostInit.__tla;')).toBeLessThan(
+      bootstrap.indexOf('await initHost();')
+    );
     expect(result?.code).toContain('})().then(() => import("/src/main.tsx?mf-entry-bootstrap"));');
     expect(result?.code).not.toContain('globalThis.System.import(src)');
   });
@@ -252,7 +260,9 @@ describe('pluginAddEntry', () => {
       '/virtual/client-entry.tsx'
     )) as { code: string } | undefined;
 
-    expect(result?.code).toContain('const { initHost } = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('await __mfHostInit.__tla;');
+    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
     expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain(
       '})().then(() => import("/virtual/client-entry.tsx?mf-entry-bootstrap"));'
@@ -641,8 +651,10 @@ describe('pluginAddEntry', () => {
     // The proxy module must import both init and entry as resolvable paths
     // (no base prefix — Vite's server-side resolver handles base itself)
     expect(code).toContain(
-      `const { initHost } = await import("${VITE_ID_PREFIX}virtual:mf-host-init");`
+      `const __mfHostInit = await import("${VITE_ID_PREFIX}virtual:mf-host-init");`
     );
+    expect(code).toContain('await __mfHostInit.__tla;');
+    expect(code).toContain('const { initHost } = __mfHostInit;');
     expect(code).toContain('await initHost();');
     expect(code).toContain('})().then(() => import("/src/main.tsx"));');
     expect(code).not.toContain('globalThis.System.import(src)');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -271,9 +271,10 @@ const addEntry = ({
           .join(',')
       : '';
 
+    const hostInitCall = `${importExpression(initSrc)}.then(({ initHost }) => initHost())`;
     const preloadBlock = remotePreloads
       ? `
-  const runtime = await initHost();
+  const runtime = await ${hostInitCall};
   const __mfPreloadRemote = (remote) => {
     const pendingKey = "__mf_pending__" + remote;
     if (!__mfModuleCache.remote[pendingKey]) {
@@ -292,22 +293,10 @@ const addEntry = ({
   };
   const __mfRemotePreloads = [${remotePreloads}];
   await Promise.allSettled(__mfRemotePreloads);`
-      : `await initHost();`;
+      : `await ${hostInitCall};`;
 
-    // The hostInit chunk's top-level await may be lowered to an emulated
-    // `__tla` promise (e.g. by vite-plugin-top-level-await, or any build target
-    // below es2022). Under that lowering the dynamic import resolves after the
-    // module's *synchronous* evaluation — before its async init assigns
-    // `initHost` — so destructuring `initHost` immediately races the init and
-    // reads `undefined` in engines that settle the import microtask first
-    // (notably Safari/JavaScriptCore; V8 happens to win the race). Await the
-    // module's exported `__tla` promise before reading `initHost`. No-op under
-    // native TLA, where `__tla` is undefined.
     const importCode = `
 (async () => {
-  const __mfHostInit = await ${importExpression(initSrc)};
-  await __mfHostInit.__tla;
-  const { initHost } = __mfHostInit;
   ${preloadBlock}
 })().then(() => ${importExpression(entrySrc)});
 `;

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -294,9 +294,20 @@ const addEntry = ({
   await Promise.allSettled(__mfRemotePreloads);`
       : `await initHost();`;
 
+    // The hostInit chunk's top-level await may be lowered to an emulated
+    // `__tla` promise (e.g. by vite-plugin-top-level-await, or any build target
+    // below es2022). Under that lowering the dynamic import resolves after the
+    // module's *synchronous* evaluation — before its async init assigns
+    // `initHost` — so destructuring `initHost` immediately races the init and
+    // reads `undefined` in engines that settle the import microtask first
+    // (notably Safari/JavaScriptCore; V8 happens to win the race). Await the
+    // module's exported `__tla` promise before reading `initHost`. No-op under
+    // native TLA, where `__tla` is undefined.
     const importCode = `
 (async () => {
-  const { initHost } = await ${importExpression(initSrc)};
+  const __mfHostInit = await ${importExpression(initSrc)};
+  await __mfHostInit.__tla;
+  const { initHost } = __mfHostInit;
   ${preloadBlock}
 })().then(() => ${importExpression(entrySrc)});
 `;

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -271,10 +271,9 @@ const addEntry = ({
           .join(',')
       : '';
 
-    const hostInitCall = `${importExpression(initSrc)}.then(({ initHost }) => initHost())`;
     const preloadBlock = remotePreloads
       ? `
-  const runtime = await ${hostInitCall};
+  const runtime = await initHost();
   const __mfPreloadRemote = (remote) => {
     const pendingKey = "__mf_pending__" + remote;
     if (!__mfModuleCache.remote[pendingKey]) {
@@ -293,10 +292,22 @@ const addEntry = ({
   };
   const __mfRemotePreloads = [${remotePreloads}];
   await Promise.allSettled(__mfRemotePreloads);`
-      : `await ${hostInitCall};`;
+      : `await initHost();`;
 
+    // The hostInit chunk's top-level await may be lowered to an emulated
+    // `__tla` promise (e.g. by vite-plugin-top-level-await, or any build target
+    // below es2022). Under that lowering the dynamic import resolves after the
+    // module's *synchronous* evaluation — before its async init assigns
+    // `initHost` — so destructuring `initHost` immediately races the init and
+    // reads `undefined` in engines that settle the import microtask first
+    // (notably Safari/JavaScriptCore; V8 happens to win the race). Await the
+    // module's exported `__tla` promise before reading `initHost`. No-op under
+    // native TLA, where `__tla` is undefined.
     const importCode = `
 (async () => {
+  const __mfHostInit = await ${importExpression(initSrc)};
+  await __mfHostInit.__tla;
+  const { initHost } = __mfHostInit;
   ${preloadBlock}
 })().then(() => ${importExpression(entrySrc)});
 `;


### PR DESCRIPTION
Fixes #813.

## Problem

`getBootstrapSource` (`src/plugins/pluginAddEntry.ts`) emits a host bootstrap that destructures `initHost` from the hostInit chunk and calls it without awaiting that module's `__tla` promise:

```js
const { initHost } = await import("./hostInit-<hash>.js");
await initHost();
```

This assumes **native** top-level await. When the hostInit chunk's TLA is lowered to an emulation (`vite-plugin-top-level-await`, or any `build.target` below `es2022`), `initHost` is assigned asynchronously inside the `__tla` chain and is `undefined` until it settles. The `await import()` resolves after the module's *synchronous* evaluation, so reading `initHost` is a microtask race — V8 wins it, **JavaScriptCore (Safari) loses** → `TypeError: initHost is not a function` on host bootstrap.

Full details + minimal repro in #813.

## Change

Await the hostInit module's exported `__tla` promise before reading `initHost`:

```diff
     const importCode = `
 (async () => {
-  const { initHost } = await ${importExpression(initSrc)};
+  const __mfHostInit = await ${importExpression(initSrc)};
+  await __mfHostInit.__tla;
+  const { initHost } = __mfHostInit;
   ${preloadBlock}
 })().then(() => ${importExpression(entrySrc)});
 `;
```

- No-op under native TLA (`__tla` is `undefined` → `await undefined`)
- Mirrors the existing remoteEntry loader, which already does `await r.__tla`
- Covers both the standard and `useSystemImportFallback` bootstraps (the latter delegates to the same template)

## Test

Updated the three bootstrap assertions in `src/plugins/__tests__/pluginAddEntry.test.ts` to the new shape, and added a regression assertion that `__tla` is awaited **before** `initHost()` is called (a plain `toContain` would still pass if the ordering regressed).

Verified locally:

- Full suite: 507/507 pass
- `pnpm build` (tsdown) clean

## Not included

The SvelteKit inline-start (`rewriteSvelteKitInlineStart`) and Nuxt dev-mount injections use the same `…then(({ initHost }) => initHost())` shape and share this defect, but I can't repro those framework paths — happy to fold them in here or as a follow-up if you'd prefer.
