### PR TITLE
fix: Correct the HMR plugin name for @vitejs/plugin-react-swc

### DIFF
--- a/src/plugins/__tests__/hmrAdapterRegistry.test.ts
+++ b/src/plugins/__tests__/hmrAdapterRegistry.test.ts
@@ -8,9 +8,7 @@ describe('HMR adapter registry', () => {
 
   it('resolves the matching adapter by plugin name', () => {
     expect(resolveAdapters([{ name: 'vite:react-refresh' }]).map((a) => a.name)).toEqual(['react']);
-    expect(resolveAdapters([{ name: 'vite:react-swc:refresh' }]).map((a) => a.name)).toEqual([
-      'react',
-    ]);
+    expect(resolveAdapters([{ name: 'vite:react-swc' }]).map((a) => a.name)).toEqual(['react']);
     expect(resolveAdapters([{ name: 'vite:vue' }]).map((a) => a.name)).toEqual(['vue']);
     expect(resolveAdapters([{ name: 'vite:vue-jsx' }]).map((a) => a.name)).toEqual(['vue']);
   });

--- a/src/plugins/hmr/__tests__/react.test.ts
+++ b/src/plugins/hmr/__tests__/react.test.ts
@@ -34,7 +34,7 @@ function createCtx(): { ctx: AdapterContext; middlewares: Middleware[] } {
 describe('reactAdapter', () => {
   it('declares the React-specific plugin names', () => {
     expect(reactAdapter.pluginNames).toEqual(
-      expect.arrayContaining(['vite:react-refresh', 'vite:react-swc:refresh'])
+      expect.arrayContaining(['vite:react-refresh', 'vite:react-swc'])
     );
   });
 

--- a/src/plugins/hmr/react.ts
+++ b/src/plugins/hmr/react.ts
@@ -57,7 +57,7 @@ export const reactAdapter: HmrAdapter = {
   name: 'react',
   pluginNames: [
     'vite:react-refresh', // @vitejs/plugin-react
-    'vite:react-swc:refresh', // @vitejs/plugin-react-swc
+    'vite:react-swc', // @vitejs/plugin-react-swc
   ],
   remote: {
     configureServer({ server }) {


### PR DESCRIPTION
## Summary

Projects using `@vitejs/plugin-react-swc` currently fall back to full-page reload HMR because the plugin name used to detect native HMR support is incorrect.

The actual plugin name exposed by `@vitejs/plugin-react-swc` is `vite:react-swc`, as defined in the plugin implementation:
https://github.com/vitejs/vite-plugin-react/blob/013588199583c4ea8bbcc17ec39cb3ed1fea4e19/packages/plugin-react-swc/src/index.ts#L121

This PR updates the detection logic to use the correct plugin name, allowing projects that use `@vitejs/plugin-react-swc` to leverage native HMR instead of falling back to full-page reloads.

## Testing

* Applied the change locally using a patched version.
* Verified that native HMR works correctly in a project using `@vitejs/plugin-react-swc`.
* Confirmed that changes are updated without triggering a full-page reload.
