### PR TITLE
fix: fix up React federation order edge case

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -161,6 +161,18 @@ function getEarlyInitPluginWithReactShared(): FederationPlugin {
   return plugin;
 }
 
+function getNormalizeOptimizeDepsPlugin(): FederationPlugin {
+  const plugin = (
+    federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+    }) as Plugin[]
+  ).find((entry) => entry.name === 'normalizeOptimizeDeps');
+
+  if (!plugin) throw new Error('normalizeOptimizeDeps plugin not found');
+  return plugin;
+}
+
 function getModuleFederationVitePlugin(): FederationPlugin {
   const plugin = (
     federation({
@@ -770,6 +782,50 @@ describe('vite:module-federation-early-init', () => {
     expect(result.contents).not.toContain(`from ${JSON.stringify(loadSharePath)}`);
   });
 
+  it('does not proxy shared deps when esbuild resolves optimizeDeps entry points', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        shared: {
+          'entry-shared': {
+            singleton: true,
+          },
+        },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const optimizeSharedProxy = config.optimizeDeps.esbuildOptions.plugins.find(
+      (entry: any) => entry.name === 'module-federation:optimize-shared-proxy'
+    );
+    const onResolveHandlers: any[] = [];
+    optimizeSharedProxy.setup({
+      onResolve: (_options: unknown, handler: unknown) => onResolveHandlers.push(handler),
+      onLoad: () => undefined,
+    });
+
+    expect(
+      onResolveHandlers[1]({
+        path: 'entry-shared',
+        importer: '/repo/node_modules/.vite/deps/_metadata.js',
+        kind: 'entry-point',
+      })
+    ).toBeUndefined();
+  });
+
   it('redirects System.register commonjs-proxy consumers to loadShare chunks', () => {
     const plugin = getEsmShimsPlugin();
     const proxyFileName = `assets/host${LOAD_SHARE_TAG}react${LOAD_SHARE_TAG}.js_commonjs-proxy-abc.js`;
@@ -1037,6 +1093,24 @@ describe('vite:module-federation-early-init', () => {
 
     expect(config.optimizeDeps.include).toContain('react');
     expect(config.optimizeDeps.exclude).not.toContain('react');
+  });
+
+  it('removes deps from optimizeDeps exclude when another plugin includes them later', () => {
+    const plugin = getNormalizeOptimizeDepsPlugin();
+    const config: any = {
+      optimizeDeps: {
+        include: ['react'],
+        exclude: ['react', 'remoteApp'],
+      },
+    };
+
+    const hook = plugin.configResolved;
+    if (typeof hook !== 'function') {
+      throw new Error('normalizeOptimizeDeps configResolved hook not found');
+    }
+    hook.call({} as MinimalPluginContextWithoutEnvironment, config);
+
+    expect(config.optimizeDeps.exclude).toEqual(['remoteApp']);
   });
 
   it('leaves ENV_TARGET undefined for Astro mixed builds', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,6 +325,7 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   })
                 );
                 build.onResolve({ filter: /.*/ }, (args: any) => {
+                  if (args.kind === 'entry-point') return;
                   if (!args.importer || args.namespace === 'mf-shared') return;
                   if (isSharedResolverInternalImporter(args.importer)) return;
                   const key = findSharedKey(args.path, shared);

--- a/src/utils/normalizeOptimizeDeps.ts
+++ b/src/utils/normalizeOptimizeDeps.ts
@@ -16,4 +16,11 @@ export default {
     if (!optimizeDeps.exclude) optimizeDeps.exclude = [];
     if (!optimizeDeps.needsInterop) optimizeDeps.needsInterop = [];
   },
+  configResolved: (config: { optimizeDeps?: UserConfig['optimizeDeps'] }) => {
+    const include = config.optimizeDeps?.include;
+    const exclude = config.optimizeDeps?.exclude;
+    if (!include?.length || !exclude?.length) return;
+    const included = new Set(include);
+    config.optimizeDeps!.exclude = exclude.filter((dep) => !included.has(dep));
+  },
 };


### PR DESCRIPTION
Fixes a React federation plugin-order edge case where react could end up in both optimizeDeps.include and exclude, causing esbuild to externalize an entry point and crash. Federation now skips optimizer entry-point proxying, and normalizeOptimizeDeps removes include/exclude conflicts after all plugins mutate config.