### PR TITLE
fix: use share scope in loadShare cache key to prevent cross-scope collisions

### DIFF
--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -94,7 +94,7 @@ describe('shared dependencies', () => {
     const remoteEntry = findChunk(output, 'remoteEntry');
     const loadShare = output.output
       .filter(isRollupChunk)
-      .find((chunk) => chunk.code.includes('__mfModuleCache.share["mock-shared-dep"]'));
+      .find((chunk) => chunk.code.includes('__mfModuleCache.share["default:mock-shared-dep"]'));
 
     expect(remoteEntry).toBeDefined();
     expect(loadShare).toBeDefined();
@@ -104,7 +104,7 @@ describe('shared dependencies', () => {
     expect(allCode).toContain('__mfModuleCache.share[cacheKey]');
     expect(allCode).not.toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');
-    expect(loadShare!.code).toContain('__mfModuleCache.share["mock-shared-dep"]');
+    expect(loadShare!.code).toContain('__mfModuleCache.share["default:mock-shared-dep"]');
     expect(loadShare!.code).toContain('init');
     expect(loadShare!.code).not.toContain('await initPromise');
     expect(allCode).not.toContain('from"mock-shared-dep"');

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -42,9 +42,13 @@ vi.mock('fs', async (importOriginal) => {
 vi.mock('../../utils/packageUtils', () => ({
   getSharedCacheKey: (
     pkg: string,
-    shareItem: { version?: string; shareConfig: { singleton?: boolean } }
-  ) =>
-    shareItem.shareConfig.singleton || !shareItem.version ? pkg : `${pkg}@${shareItem.version}`,
+    shareItem: { version?: string; scope?: string; shareConfig: { singleton?: boolean } }
+  ) => {
+    const prefix = `${shareItem.scope || 'default'}:`;
+    return shareItem.shareConfig.singleton || !shareItem.version
+      ? `${prefix}${pkg}`
+      : `${prefix}${pkg}@${shareItem.version}`;
+  },
   hasPackageDependency: hasPackageDependencyMock,
   getInstalledPackageEntry: getInstalledPackageEntryMock,
   getInstalledPackageJson: vi.fn((pkg: string) => {

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -7,6 +7,7 @@ import {
   getInstalledPackageEntry,
   getInstalledPackageJson,
   getPackageNameFromNodeModulePath,
+  getSharedCacheKey,
   resolveImportPath,
 } from '../packageUtils';
 
@@ -107,5 +108,36 @@ describe('getPackageNameFromNodeModulePath', () => {
 
   it('returns undefined for non-node_modules paths', () => {
     expect(getPackageNameFromNodeModulePath('/repo/vendor/vue.js')).toBeUndefined();
+  });
+});
+
+describe('getSharedCacheKey', () => {
+  it('prefixes singleton shared cache keys with share scope', () => {
+    expect(
+      getSharedCacheKey('react', {
+        scope: 'react-18',
+        version: '18.3.1',
+        shareConfig: { singleton: true },
+      } as any)
+    ).toBe('react-18:react');
+  });
+
+  it('prefixes versioned shared cache keys with share scope', () => {
+    expect(
+      getSharedCacheKey('react', {
+        scope: 'react-19',
+        version: '19.2.4',
+        shareConfig: { singleton: false },
+      } as any)
+    ).toBe('react-19:react@19.2.4');
+  });
+
+  it('falls back to default scope when scope is missing', () => {
+    expect(
+      getSharedCacheKey('vue', {
+        version: '3.5.0',
+        shareConfig: { singleton: true },
+      } as any)
+    ).toBe('default:vue');
   });
 });

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -155,7 +155,7 @@ export function getPackageNameFromNodeModulePath(source: string): string | undef
 }
 
 export function getSharedCacheKey(pkg: string, shareItem: ShareItem) {
-  const prefix = `${shareItem.scope}:`;
+  const prefix = `${shareItem.scope || 'default'}:`;
   return shareItem.shareConfig.singleton || !shareItem.version
     ? `${prefix}${pkg}`
     : `${prefix}${pkg}@${shareItem.version}`;

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -155,9 +155,10 @@ export function getPackageNameFromNodeModulePath(source: string): string | undef
 }
 
 export function getSharedCacheKey(pkg: string, shareItem: ShareItem) {
+  const prefix = `${shareItem.scope}:`;
   return shareItem.shareConfig.singleton || !shareItem.version
-    ? pkg
-    : `${pkg}@${shareItem.version}`;
+    ? `${prefix}${pkg}`
+    : `${prefix}${pkg}@${shareItem.version}`;
 }
 
 export function getInstalledPackageJson(

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -674,4 +674,16 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('__mfModuleCache.share["default:some-dep"]');
     expect(code).toContain('await import');
   });
+
+  it('emits a scope-aware runtime shared cache key helper', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'serve');
+
+    expect(code).toContain('const normalizedScope = Array.isArray(scope) ? scope[0] : scope;');
+    expect(code).toContain('const prefix = (normalizedScope || "default") + ":";');
+    expect(code).toContain(
+      'const cacheKey = __mfGetSharedCacheKey(pkg, share.shareConfig?.singleton, share.version, share.scope);'
+    );
+  });
 });

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -43,9 +43,13 @@ vi.mock('../../utils/packageUtils', () => {
   return {
     getSharedCacheKey: (
       pkg: string,
-      shareItem: { version?: string; shareConfig: { singleton?: boolean } }
-    ) =>
-      shareItem.shareConfig.singleton || !shareItem.version ? pkg : `${pkg}@${shareItem.version}`,
+      shareItem: { version?: string; scope?: string; shareConfig: { singleton?: boolean } }
+    ) => {
+      const prefix = `${shareItem.scope || 'default'}:`;
+      return shareItem.shareConfig.singleton || !shareItem.version
+        ? `${prefix}${pkg}`
+        : `${prefix}${pkg}@${shareItem.version}`;
+    },
     hasPackageDependency: hasPackageDependencyMock,
     packageNameEncode: (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_'),
     getPackageName: (packageString: string) => {
@@ -538,9 +542,9 @@ describe('virtualRemoteEntry', () => {
 
     const code = mod.generateDirectSharedCacheSeedCode('build');
 
-    expect(code).toContain('__mfModuleCache.share["wildcard-pkg/button"]');
+    expect(code).toContain('__mfModuleCache.share["default:wildcard-pkg/button"]');
     expect(code).toContain('await import("/repo/node_modules/wildcard-pkg/dist/button.js")');
-    expect(code).not.toContain('__mfModuleCache.share["wildcard-pkg"]');
+    expect(code).not.toContain('__mfModuleCache.share["default:wildcard-pkg"]');
   });
 
   it('does not seed import:false shared modules in hostAutoInit during build', async () => {
@@ -580,8 +584,8 @@ describe('virtualRemoteEntry', () => {
 
     // Build mode must NOT generate static imports for import:false modules
     // to avoid bundler resolution failures on transitive dependencies.
-    expect(code).not.toContain('__mfModuleCache.share["some-dep"] === undefined');
-    expect(code).not.toContain('__mfModuleCache.share["vue"] === undefined');
+    expect(code).not.toContain('__mfModuleCache.share["default:some-dep"] === undefined');
+    expect(code).not.toContain('__mfModuleCache.share["default:vue"] === undefined');
     expect(code).not.toContain('some-dep/dist');
     // The runtime.loadShare loop should still be present
     expect(code).toContain('runtime.loadShare(pkg');
@@ -667,7 +671,7 @@ describe('virtualRemoteEntry', () => {
     const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'serve');
 
     // Serve mode should still pre-seed the cache (dev server resolves on-demand)
-    expect(code).toContain('__mfModuleCache.share["some-dep"]');
+    expect(code).toContain('__mfModuleCache.share["default:some-dep"]');
     expect(code).toContain('await import');
   });
 });

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -29,9 +29,13 @@ vi.mock('../../utils/logger', () => ({
 vi.mock('../../utils/packageUtils', () => ({
   getSharedCacheKey: (
     pkg: string,
-    shareItem: { version?: string; shareConfig: { singleton?: boolean } }
-  ) =>
-    shareItem.shareConfig.singleton || !shareItem.version ? pkg : `${pkg}@${shareItem.version}`,
+    shareItem: { version?: string; scope?: string; shareConfig: { singleton?: boolean } }
+  ) => {
+    const prefix = `${shareItem.scope || 'default'}:`;
+    return shareItem.shareConfig.singleton || !shareItem.version
+      ? `${prefix}${pkg}`
+      : `${prefix}${pkg}@${shareItem.version}`;
+  },
   hasPackageDependency: hasPackageDependencyMock,
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
   resolveImportPath: vi.fn(() => '/repo/node_modules/@module-federation/runtime/dist/index.js'),
@@ -712,7 +716,7 @@ describe('writeLoadShareModule', () => {
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
     expect(generatedCode).toContain('const __mfCacheGlobalKey =');
-    expect(generatedCode).toContain('__mfModuleCache.share["mock-package-with-reserved"]');
+    expect(generatedCode).toContain('__mfModuleCache.share["default:mock-package-with-reserved"]');
     expect(generatedCode).not.toContain('await ');
     expect(generatedCode).not.toContain('import { initPromise } from');
     expect(generatedCode).not.toContain('require("mock-import-id")');
@@ -736,8 +740,8 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).not.toContain('__mfModuleCache.share["zustand"]');
-    expect(generatedCode).toContain('__mfModuleCache.share["zustand@4.5.7"]');
+    expect(generatedCode).not.toContain('__mfModuleCache.share["default:zustand"]');
+    expect(generatedCode).toContain('__mfModuleCache.share["default:zustand@4.5.7"]');
   });
 
   it('unwraps default exports for shared ESM modules', () => {
@@ -895,7 +899,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('__mfModuleCache.share["react"]');
+    expect(generatedCode).toContain('__mfModuleCache.share["default:react"]');
     expect(generatedCode).not.toContain('providerModulePromise');
     expect(generatedCode).not.toContain('await ');
   });
@@ -971,7 +975,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toMatch(/import\s+["']host-only-dep["']/);
     // Should not have export * (no local source to re-export from)
     expect(generatedCode).not.toContain('export *');
-    expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
+    expect(generatedCode).toContain('__mfModuleCache.share["default:host-only-dep"]');
     expect(generatedCode).toContain('export { __mf_default as default }');
   });
 
@@ -997,7 +1001,7 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('export *');
-    expect(generatedCode).toContain('__mfModuleCache.share["host-only-dep"]');
+    expect(generatedCode).toContain('__mfModuleCache.share["default:host-only-dep"]');
     expect(generatedCode).not.toContain('await ');
     expect(generatedCode).toContain('initPromise.then');
     expect(generatedCode).toContain('export { __mf_default as default }');
@@ -1026,7 +1030,7 @@ describe('writeLoadShareModule', () => {
 
     // Should NOT reference prebuild modules
     expect(generatedCode).not.toContain('__prebuild__');
-    expect(generatedCode).toContain('__mfModuleCache.share["mock-package-with-reserved"]');
+    expect(generatedCode).toContain('__mfModuleCache.share["default:mock-package-with-reserved"]');
     // Should have named exports destructured from the runtime-provided module
     expect(generatedCode).toContain('__mf_0 as delete');
     expect(generatedCode).toContain('__mf_1 as get');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -274,7 +274,8 @@ function generateSharedCacheSeedItem(pkg: string, shareItem: ShareItem, importPa
 }
 
 const sharedCacheKeyHelperCode = `const __mfGetSharedCacheKey = (pkg, singleton, version, scope) => {
-            const prefix = scope ? (scope + ":") : "";
+            const normalizedScope = Array.isArray(scope) ? scope[0] : scope;
+            const prefix = (normalizedScope || "default") + ":";
             return singleton || !version ? prefix + pkg : prefix + pkg + "@" + version;
           };`;
 

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -181,6 +181,8 @@ function generateUsedSharedPreloadConfig() {
           const shareItem = getShareItemForPreload(pkg);
           if (!shareItem) return null;
           return `${JSON.stringify(pkg)}: {
+            version: ${JSON.stringify(shareItem.version)},
+            scope: ${JSON.stringify(shareItem.scope)},
             shareConfig: {
               singleton: ${shareItem.shareConfig.singleton},
               requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
@@ -270,6 +272,11 @@ function generateSharedCacheSeedItem(pkg: string, shareItem: ShareItem, importPa
         __mfModuleCache.share[${JSON.stringify(cacheKey)}] = exportModule;
       }`;
 }
+
+const sharedCacheKeyHelperCode = `const __mfGetSharedCacheKey = (pkg, singleton, version, scope) => {
+            const prefix = scope ? (scope + ":") : "";
+            return singleton || !version ? prefix + pkg : prefix + pkg + "@" + version;
+          };`;
 
 const normalizeRuntimeShareCode = `const __mfNormalizeRuntimeShare = (mod) => {
             let current = mod;
@@ -435,6 +442,7 @@ export function generateRemoteEntry(
   }
 
   async function init(shared = {}, initScope = []) {
+    ${sharedCacheKeyHelperCode}
     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
     try {
       const allInstances = globalThis.__FEDERATION__?.__SHARE__;
@@ -446,7 +454,7 @@ export function generateRemoteEntry(
           for (const [pkg, versionMap] of Object.entries(scopeShare)) {
             for (const [version, provider] of Object.entries(versionMap)) {
               if (!provider.lib) continue;
-              const cacheKey = provider.shareConfig?.singleton ? pkg : \`\${pkg}@\${version}\`;
+              const cacheKey = __mfGetSharedCacheKey(pkg, provider.shareConfig?.singleton, version, ${JSON.stringify(options.shareScope)});
               if (__mfModuleCache.share[cacheKey] !== undefined) continue;
               const mod = typeof provider.lib === "function" ? provider.lib() : provider.lib;
               const resolved = await Promise.resolve(mod);
@@ -500,7 +508,7 @@ export function generateRemoteEntry(
       console.error('[Module Federation]', e)
     }
     for (const [pkg, share] of Object.entries(usedShared)) {
-      const cacheKey = share.shareConfig?.singleton || !share.version ? pkg : \`\${pkg}@\${share.version}\`;
+      const cacheKey = __mfGetSharedCacheKey(pkg, share.shareConfig?.singleton, share.version, share.scope);
       if (share.shareConfig?.import !== false || __mfModuleCache.share[cacheKey] !== undefined) continue;
       ${normalizeRuntimeShareCode}
       const versions = shared?.[pkg];
@@ -547,12 +555,13 @@ export function generateHostAutoInitCode(remoteEntryImport: string, _command = '
           const remoteEntry = await import(${remoteEntryImport});
           const runtime = await remoteEntry.init();
           const usedShared = ${generateUsedSharedPreloadConfig()};
+          ${sharedCacheKeyHelperCode}
           ${normalizeRuntimeShareCode}
           ${
             shouldPreloadShares
               ? `
           for (const [pkg, share] of Object.entries(usedShared)) {
-            const cacheKey = share.shareConfig?.singleton || !share.version ? pkg : \`\${pkg}@\${share.version}\`;
+            const cacheKey = __mfGetSharedCacheKey(pkg, share.shareConfig?.singleton, share.version, share.scope);
             if (__mfModuleCache.share[cacheKey] !== undefined) {
               continue;
             }


### PR DESCRIPTION
Closes #821 