### PR TITLE
fix: bind acyclic workspace shared singletons eagerly when consumed by a peer (#823)

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -85,6 +85,12 @@ vi.mock('../../utils/packageUtils', () => ({
     if (pkg === 'workspace-cycle-b') {
       return '/repo/packages/workspace-cycle-b/src/index.ts';
     }
+    if (pkg === 'workspace-producer' || pkg.startsWith('workspace-producer/')) {
+      return '/repo/packages/workspace-producer/src/index.ts';
+    }
+    if (pkg === 'workspace-consumer') {
+      return '/repo/packages/workspace-consumer/src/index.ts';
+    }
   }),
   getInstalledPackageJson: vi.fn((pkg: string, opts?: { fromResolvedEntry?: string }) => {
     if (opts?.fromResolvedEntry?.includes('/repo/packages/workspace-shared-lib/')) {
@@ -120,6 +126,23 @@ vi.mock('../../utils/packageUtils', () => ({
         packageJson: {
           name: 'workspace-cycle-b',
           dependencies: { 'workspace-cycle-a': 'workspace:*' },
+        },
+      };
+    }
+    if (opts?.fromResolvedEntry?.includes('/repo/packages/workspace-producer/')) {
+      return {
+        path: '/repo/packages/workspace-producer/package.json',
+        dir: '/repo/packages/workspace-producer',
+        packageJson: { name: 'workspace-producer' },
+      };
+    }
+    if (opts?.fromResolvedEntry?.includes('/repo/packages/workspace-consumer/')) {
+      return {
+        path: '/repo/packages/workspace-consumer/package.json',
+        dir: '/repo/packages/workspace-consumer',
+        packageJson: {
+          name: 'workspace-consumer',
+          dependencies: { 'workspace-producer': 'workspace:*' },
         },
       };
     }
@@ -192,6 +215,8 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/workspace-name-mismatch/package.json') ||
       filePath.endsWith('/repo/packages/workspace-cycle-a/package.json') ||
       filePath.endsWith('/repo/packages/workspace-cycle-b/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-producer/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-consumer/package.json') ||
       filePath.endsWith('/repo/packages/custom-shared-source/index.ts')
   ),
   readFileSync: vi.fn((filePath: string) => {
@@ -531,6 +556,12 @@ vi.mock('module', async (importOriginal) => {
           }
           if (pkg === 'workspace-cycle-b') {
             return '/repo/packages/workspace-cycle-b/src/index.ts';
+          }
+          if (pkg === 'workspace-producer' || pkg.startsWith('workspace-producer/')) {
+            return '/repo/packages/workspace-producer/src/index.ts';
+          }
+          if (pkg === 'workspace-consumer') {
+            return '/repo/packages/workspace-consumer/src/index.ts';
           }
           if (
             pkg === 'mock-package-reexport-type' ||
@@ -1380,6 +1411,47 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('export { __mf_default as default };');
     expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).not.toContain('await ');
+    expect(generatedCode).toContain('Promise.resolve().then');
+  });
+
+  it('emits eager local re-exports for acyclic workspace singletons consumed by a peer', () => {
+    // Reproduces issue #823: an acyclic (DAG) shared-singleton graph where
+    // `workspace-producer` is shared together with one of its subpath exports and
+    // is depended on by a peer shared singleton (`workspace-consumer`). The peer
+    // reads the producer's bindings at module-evaluation time, so the producer must
+    // assign its exports synchronously. Before the fix only cyclic graphs triggered
+    // the eager path, leaving this case lazy and crashing at startup with
+    // "Cannot read properties of undefined".
+    normalizeModuleFederationOptions({
+      name: 'host',
+      shared: {
+        'workspace-producer': { singleton: true },
+        'workspace-producer/extra': { singleton: true },
+        'workspace-consumer': { singleton: true },
+      },
+    });
+    const pkg = 'workspace-producer';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'import * as __mfLocalShare from "/repo/packages/workspace-producer/src/index.ts";'
+    );
+    expect(generatedCode).toContain('export { __mf_default as default };');
+    expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).toContain('Promise.resolve().then');
   });
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -350,7 +350,7 @@ function getDependencyNames(packageJson: Record<string, unknown> | undefined) {
   return Array.from(names);
 }
 
-function hasCyclicWorkspaceSingletonDependency(pkg: string) {
+function isWorkspaceSingletonConsumedByPeer(pkg: string) {
   const options = getNormalizeModuleFederationOptions();
   const shared = options?.shared || {};
   const sharedKeyByPackageName = new Map<string, string>();
@@ -364,7 +364,14 @@ function hasCyclicWorkspaceSingletonDependency(pkg: string) {
       }
     });
 
-  const visit = (current: string, seen: Set<string>): boolean => {
+  // A workspace singleton must assign its exports synchronously (eager) when a
+  // peer shared singleton can read them at module-evaluation time. That happens
+  // whenever another shared singleton depends on `pkg`: the bundler may evaluate
+  // the consumer before `pkg`'s lazy `loadShare` wrapper has populated the share
+  // cache, leaving the consumer's top-level read of `pkg`'s bindings undefined.
+  // This covers both cyclic graphs and acyclic ones where a package is shared
+  // together with one of its subpath exports (see issue #823).
+  const reachesPkg = (current: string, seen: Set<string>): boolean => {
     const packageJson = getWorkspacePackageJson(current);
     for (const dependency of getDependencyNames(packageJson)) {
       const sharedDependency = sharedKeyByPackageName.get(dependency);
@@ -372,12 +379,14 @@ function hasCyclicWorkspaceSingletonDependency(pkg: string) {
       if (sharedDependency === pkg) return true;
       if (seen.has(sharedDependency)) continue;
       seen.add(sharedDependency);
-      if (visit(sharedDependency, seen)) return true;
+      if (reachesPkg(sharedDependency, seen)) return true;
     }
     return false;
   };
 
-  return visit(pkg, new Set([pkg]));
+  return Array.from(sharedKeyByPackageName.values()).some(
+    (sharedPkg) => sharedPkg !== pkg && reachesPkg(sharedPkg, new Set([sharedPkg]))
+  );
 }
 
 function tryResolveImportFromPackageRoot(pkg: string, root: string): string | undefined {
@@ -778,7 +787,7 @@ export function writeLoadShareModule(
   const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
   const isWorkspaceSingleton = isWorkspacePackage && shareItem.shareConfig.singleton === true;
   const usesEagerWorkspaceFallback =
-    isWorkspaceSingleton && hasCyclicWorkspaceSingletonDependency(pkg);
+    isWorkspaceSingleton && isWorkspaceSingletonConsumedByPeer(pkg);
   const namedExports = getSharedNamedExports(pkg, shareItem);
   let exportLine: string;
   let initBlock = '';


### PR DESCRIPTION
## Summary

- Fixes #823: a Module Federation host crashes at startup with `Cannot read properties of undefined (reading 'getLogger')` on an **acyclic** shared-singleton graph where a workspace package is shared together with one of its subpath exports (`pkg` + `pkg/sub`) and is consumed by a peer shared singleton.
- A workspace singleton's `loadShare` wrapper binds its exports either eagerly (synchronously, safe at module-evaluation time) or lazily (deferred via `initPromise.then`). The eager path was only taken when `pkg` had a *cyclic* workspace-singleton dependency, so acyclic graphs where a consumer reads the producer's bindings at evaluation time still raced and read `undefined`.

## Changes

- `src/virtualModules/virtualShared_preBuild.ts`: generalize the gating predicate `hasCyclicWorkspaceSingletonDependency` → `isWorkspaceSingletonConsumedByPeer`. A workspace singleton now binds eagerly whenever *any peer shared singleton* transitively depends on it. This subsumes the existing cyclic behaviour (each node in a cycle is reached from its peer) and additionally covers the acyclic root + subpath scenario. Leaf / top-level-only singletons remain lazy.
- `src/virtualModules/__tests__/virtualShared_preBuild.test.ts`: add a regression test (`emits eager local re-exports for acyclic workspace singletons consumed by a peer`) reproducing #823, plus mock wiring for the `workspace-producer` / `workspace-consumer` packages. Verified the test fails without the source change and passes with it.

Fixes #823
