### PR TITLE
fix: rethrow failed dev remote loads

### DIFF
--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -190,6 +190,17 @@ describe('generateRemotes', () => {
     expect(exports.__moduleExports).toBe(remoteModule);
   });
 
+  it('rejects remote pending when dev loadRemote fails', async () => {
+    const loadError = new Error('remote failed');
+    const runtime = {
+      loadRemote: vi.fn(() => Promise.reject(loadError)),
+    };
+    const exports = runGeneratedRemoteModule(generateRemotes('remote/Button', 'serve'), runtime);
+
+    await expect(Promise.resolve(exports.__mf_remote_pending)).rejects.toBe(loadError);
+    expect(runtime.loadRemote).toHaveBeenCalledWith('remote/Button');
+  });
+
   it('defers browser remote loading until use for loaded-first (non-React)', () => {
     mockOptions.shareStrategy = 'loaded-first';
     const code = generateRemotes('remote/Button', 'serve');

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -228,7 +228,7 @@ function getRemoteExportBlock(command: string, deferRemoteLoad: boolean, consume
 export { __mfDefaultExport as default };`;
   }
   return `__mfSyncDefaultExport();
-__mfRemotePending?.then(__mfSyncDefaultExport);
+__mfRemotePending?.then(__mfSyncDefaultExport, () => {});
 export { exportModule as __moduleExports };
 ${deferRemoteLoad ? getLazyRemotePendingExport() : getEagerRemotePendingExport()}
 ${command === 'serve' && consumer === 'server' ? getServerThenExport() : ''}
@@ -275,8 +275,9 @@ export function generateRemotes(
             delete __mfModuleCache.remote[pendingKey];
             throw error;
           })`
-      : `.catch(() => {
+      : `.catch((error) => {
             delete __mfModuleCache.remote[pendingKey];
+            throw error;
           })`;
   const startRemoteLoadCode = `
       const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};


### PR DESCRIPTION
Close #824

Fixes loaded-first dev remote failures being swallowed, which left Suspense stuck on its fallback instead of letting React Router show the error route.
  - Clear pending remote cache on loadRemote() failure
  - Rethrow the error for React lazy/Suspense consumers
  - Prevent internal sync listener unhandled rejection noise