### PR TITLE
fix: reuse singleton share cache aliases

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -686,4 +686,90 @@ describe('virtualRemoteEntry', () => {
       'const cacheKey = __mfGetSharedCacheKey(pkg, share.shareConfig?.singleton, share.version, share.scope);'
     );
   });
+
+  it('aliases external singleton providers to the remote share cache key', async () => {
+    normalizedSharedMock.mockReturnValue({
+      react: {
+        name: 'react',
+        from: '',
+        version: '18.3.1',
+        scope: 'default',
+        shareConfig: {
+          singleton: false,
+          requiredVersion: '^18.3.1',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).toContain('const usedShare = usedShared?.[pkg];');
+    expect(code).toContain('if (provider.shareConfig?.singleton && usedShare) {');
+    expect(code).toContain('__mfModuleCache.share[usedCacheKey] = normalized;');
+  });
+
+  it('reuses an already cached singleton for a versioned remote share key', async () => {
+    normalizedSharedMock.mockReturnValue({
+      react: {
+        name: 'react',
+        from: '',
+        version: '18.3.1',
+        scope: 'default',
+        shareConfig: {
+          singleton: false,
+          requiredVersion: '^18.3.1',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).toContain(
+      'const singletonCacheKey = __mfGetSharedCacheKey(pkg, true, share.version, share.scope);'
+    );
+    expect(code).toContain(
+      '__mfModuleCache.share[cacheKey] = __mfModuleCache.share[singletonCacheKey];'
+    );
+    expect(code.indexOf('const singletonCacheKey')).toBeLessThan(
+      code.indexOf('if (__mfModuleCache.share["default:react@18.3.1"] === undefined)')
+    );
+  });
 });

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -459,13 +459,29 @@ export function generateRemoteEntry(
               if (__mfModuleCache.share[cacheKey] !== undefined) continue;
               const mod = typeof provider.lib === "function" ? provider.lib() : provider.lib;
               const resolved = await Promise.resolve(mod);
-              __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
+              const normalized = __mfNormalizeRuntimeShare(resolved);
+              __mfModuleCache.share[cacheKey] = normalized;
+              const usedShare = usedShared?.[pkg];
+              if (provider.shareConfig?.singleton && usedShare) {
+                const usedCacheKey = __mfGetSharedCacheKey(pkg, usedShare.shareConfig?.singleton, usedShare.version, usedShare.scope);
+                if (__mfModuleCache.share[usedCacheKey] === undefined) {
+                  __mfModuleCache.share[usedCacheKey] = normalized;
+                }
+              }
             }
           }
         }
       }
     } catch (e) {
       console.error('[Module Federation] Failed to bridge external shared modules', e)
+    }
+    for (const [pkg, share] of Object.entries(usedShared)) {
+      const cacheKey = __mfGetSharedCacheKey(pkg, share.shareConfig?.singleton, share.version, share.scope);
+      if (__mfModuleCache.share[cacheKey] !== undefined) continue;
+      const singletonCacheKey = __mfGetSharedCacheKey(pkg, true, share.version, share.scope);
+      if (__mfModuleCache.share[singletonCacheKey] !== undefined) {
+        __mfModuleCache.share[cacheKey] = __mfModuleCache.share[singletonCacheKey];
+      }
     }
     ${generateDirectSharedCacheSeedCode(command)}
     const __browserPlugins = [${pluginImportNames


### PR DESCRIPTION
Close #826

Fixes remote shared modules with empty config loading local React instead of host singleton.

  - Alias host singleton cache entries to the remote’s expected versioned key.
  - Prevents duplicate React instances and invalid hook calls.
  - Covers both newly bridged runtime providers and already cached singleton shares.
  - Adds regression test for versioned remote share lookup.