### PR TITLE
fix: fix dev manifest hashed remote entry

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -127,13 +127,15 @@ async function runGenerateBundleWithManifest(
       | undefined
     >;
     dts?: unknown;
+    filename?: string;
+    bundle?: OutputBundle;
   } = {},
   command: 'serve' | 'build' = 'build',
   base = '/'
 ): Promise<Record<string, string>> {
   getNormalizeModuleFederationOptions.mockReturnValue({
     name: 'basicRemote',
-    filename: 'remoteEntry.js',
+    filename: runtime.filename || 'remoteEntry.js',
     getPublicPath: undefined,
     varFilename: undefined,
     dts: runtime.dts,
@@ -199,7 +201,7 @@ async function runGenerateBundleWithManifest(
       }) as ResolvedId,
   };
 
-  await runGenerateBundle(buildPlugin, ctx, makeBundle());
+  await runGenerateBundle(buildPlugin, ctx, runtime.bundle || makeBundle());
   return emitted;
 }
 
@@ -246,6 +248,128 @@ describe('pluginMFManifest', () => {
       path: '/__mf_ssr__/',
       type: 'module',
     });
+  });
+
+  it('uses a served remoteEntry filename for hash patterns in serve manifest', async () => {
+    const emitted = await runGenerateBundleWithManifest(
+      true,
+      {
+        filename: 'remoteEntry-[hash]',
+        exposePaths: {
+          './exposed': { import: './src/exposed.js' },
+        },
+        usedShares: new Set(['react']),
+        shareItems: {
+          react: {
+            version: '18.0.0',
+            shareConfig: { requiredVersion: '^18.0.0', singleton: true },
+          },
+        },
+      },
+      'serve'
+    );
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+    expect(manifest.metaData.remoteEntry).toMatchObject({
+      name: 'remoteEntry.js',
+      type: 'module',
+    });
+    expect(manifest.metaData.ssrRemoteEntry).toMatchObject({
+      name: 'remoteEntry.ssr.js',
+      path: '/__mf_ssr__/',
+      type: 'module',
+    });
+    expect(manifest.shared[0].assets.js.sync).toEqual(['remoteEntry.js']);
+  });
+
+  it('serves hash-pattern dev remoteEntry through stable manifest filename', async () => {
+    getNormalizeModuleFederationOptions.mockReturnValue({
+      name: 'basicRemote',
+      filename: 'remoteEntry-[hash]',
+      getPublicPath: undefined,
+      varFilename: undefined,
+      manifest: true,
+      exposes: { './exposed': { import: './src/exposed.js' } },
+      remotes: {},
+      shared: {},
+      publicPath: 'auto',
+      bundleAllCSS: false,
+      shareStrategy: 'version-first',
+      implementation: 'module-federation-runtime',
+      runtimePlugins: [],
+      virtualModuleDir: '__mf__virtual',
+      hostInitInjectLocation: 'html',
+      moduleParseTimeout: 10,
+      ignoreOrigin: false,
+    });
+    getUsedRemotesMap.mockReturnValue(new Map());
+    getUsedShares.mockReturnValue(new Set());
+
+    const [servePlugin, buildPlugin] = manifestPlugin();
+    const handlers: Function[] = [];
+
+    callHook(buildPlugin.config, {} as ConfigPluginContext, {}, { command: 'serve', mode: 'test' });
+    callHook(
+      buildPlugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        root: '/',
+        base: '/',
+        build: {},
+        server: { origin: 'http://localhost' },
+      } as unknown as ResolvedConfig
+    );
+    callHook(
+      servePlugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        base: '/',
+      } as unknown as ResolvedConfig
+    );
+    callHook(
+      servePlugin.configureServer,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        middlewares: { use: (handler: Function) => handlers.push(handler) },
+      } as any
+    );
+
+    const remoteEntryReq = { url: '/remoteEntry.js?cache=1' };
+    const next = vi.fn();
+    handlers[0](remoteEntryReq, {}, next);
+    expect(remoteEntryReq.url).toBe('/remoteEntry-[hash]?cache=1');
+    expect(next).toHaveBeenCalledOnce();
+
+    const source = await new Promise<string>((resolve, reject) => {
+      handlers[0](
+        { url: '/mf-manifest.json' },
+        {
+          setHeader: vi.fn(),
+          end: resolve,
+        },
+        reject
+      );
+    });
+    const manifest = JSON.parse(source);
+
+    expect(manifest.metaData.remoteEntry.name).toBe('remoteEntry.js');
+    expect(manifest.metaData.ssrRemoteEntry.name).toBe('remoteEntry.ssr.js');
+  });
+
+  it('keeps build manifest remoteEntry resolved from emitted bundle', async () => {
+    const bundle = makeBundle();
+    const remoteEntry = bundle['remoteEntry.js'] as OutputChunk;
+    remoteEntry.fileName = 'remoteEntry-a1b2c3d4.js';
+    const emitted = await runGenerateBundleWithManifest(true, {
+      filename: 'remoteEntry-[hash]',
+      bundle,
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+    expect(manifest.metaData.remoteEntry.name).toBe('remoteEntry-a1b2c3d4.js');
+    expect(manifest.metaData.ssrRemoteEntry.name).toBe('remoteEntry-a1b2c3d4.ssr.js');
   });
 
   it('emits companion stats file using manifest fileName suffix', async () => {

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -281,6 +281,7 @@ describe('pluginMFManifest', () => {
       type: 'module',
     });
     expect(manifest.shared[0].assets.js.sync).toEqual(['remoteEntry.js']);
+    expect(manifest.exposes[0].assets.js.sync).toEqual(['remoteEntry.js']);
   });
 
   it('serves hash-pattern dev remoteEntry through stable manifest filename', async () => {
@@ -355,6 +356,7 @@ describe('pluginMFManifest', () => {
 
     expect(manifest.metaData.remoteEntry.name).toBe('remoteEntry.js');
     expect(manifest.metaData.ssrRemoteEntry.name).toBe('remoteEntry.ssr.js');
+    expect(manifest.exposes[0].assets.js.sync).toEqual(['remoteEntry.js']);
   });
 
   it('keeps build manifest remoteEntry resolved from emitted bundle', async () => {

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -64,6 +64,15 @@ function resolveTypesMeta(dts: ReturnType<typeof getNormalizeModuleFederationOpt
   };
 }
 
+function resolveDevRemoteEntryFileName(fileName: string): string {
+  if (!fileName.includes('[hash')) return fileName;
+
+  const normalized = fileName.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
+  const baseName = path.basename(normalized);
+
+  return path.extname(baseName) ? normalized : `${normalized}.js`;
+}
+
 const Manifest = (): Plugin[] => {
   const mfOptions = getNormalizeModuleFederationOptions();
   const { name, filename, getPublicPath, manifest: manifestOptions, varFilename } = mfOptions;
@@ -129,6 +138,15 @@ const Manifest = (): Plugin[] => {
             next();
             return;
           }
+          const devRemoteEntryFile = resolveDevRemoteEntryFileName(filename);
+          if (
+            devRemoteEntryFile !== filename &&
+            req.url?.startsWith((viteConfig.base + devRemoteEntryFile).replace(/^\/?/, '/'))
+          ) {
+            req.url = req.url.replace(devRemoteEntryFile, filename);
+            next();
+            return;
+          }
           if (
             req.url?.replace(/\?.*/, '') === (viteConfig.base + mfManifestName).replace(/^\/?/, '/')
           ) {
@@ -144,12 +162,12 @@ const Manifest = (): Plugin[] => {
                   type: 'app',
                   buildInfo: { buildVersion: getBuildVersion(), buildName: name },
                   remoteEntry: {
-                    name: filename,
+                    name: devRemoteEntryFile,
                     path: '',
                     type: 'module',
                   },
                   ssrRemoteEntry: {
-                    name: getSsrRemoteEntryFileName(filename),
+                    name: getSsrRemoteEntryFileName(devRemoteEntryFile),
                     path: '/__mf_ssr__/',
                     type: 'module',
                   },
@@ -218,7 +236,9 @@ const Manifest = (): Plugin[] => {
         let filesMap: PreloadMap = {};
 
         const foundRemoteEntryFile = findRemoteEntryFile(mfOptions.filename, bundle);
-        const expectedSsrRemoteEntryFile = getSsrRemoteEntryFileName(mfOptions.filename);
+        const expectedSsrRemoteEntryFile = getSsrRemoteEntryFileName(
+          foundRemoteEntryFile || mfOptions.filename
+        );
         const foundSsrRemoteEntryFile = Object.values(bundle).find(
           (file) => file.fileName === expectedSsrRemoteEntryFile
         )?.fileName;
@@ -227,7 +247,11 @@ const Manifest = (): Plugin[] => {
         if (foundRemoteEntryFile) {
           remoteEntryFile = foundRemoteEntryFile;
         }
-        ssrRemoteEntryFile = foundSsrRemoteEntryFile || expectedSsrRemoteEntryFile;
+        ssrRemoteEntryFile =
+          foundSsrRemoteEntryFile ||
+          (_command === 'serve'
+            ? getSsrRemoteEntryFileName(resolveDevRemoteEntryFileName(mfOptions.filename))
+            : expectedSsrRemoteEntryFile);
 
         // Second pass: Collect all CSS assets
         const allCssAssets =
@@ -304,13 +328,21 @@ const Manifest = (): Plugin[] => {
   function generateMFManifest(preloadMap: PreloadMap, disableAssetsAnalyze = false) {
     const options = getNormalizeModuleFederationOptions();
     const { name, varFilename } = options;
+    const resolvedRemoteEntryFile =
+      _command === 'serve'
+        ? remoteEntryFile || resolveDevRemoteEntryFileName(filename)
+        : remoteEntryFile;
     const remoteEntry = {
-      name: remoteEntryFile,
+      name: resolvedRemoteEntryFile,
       path: '',
       type: 'module',
     };
     const ssrRemoteEntry = {
-      name: ssrRemoteEntryFile || getSsrRemoteEntryFileName(filename),
+      name:
+        ssrRemoteEntryFile ||
+        getSsrRemoteEntryFileName(
+          _command === 'serve' ? resolveDevRemoteEntryFileName(filename) : filename
+        ),
       path: _command === 'serve' ? '/__mf_ssr__/' : '',
       type: 'module',
     };
@@ -340,7 +372,14 @@ const Manifest = (): Plugin[] => {
       // shareItem can be undefined when a key was added to usedShares before
       // excludeSharedSubDependencies removed it from options.shared in dev mode.
       if (!shareItem) return [];
-      const assets = preloadMap[shareKey] || createEmptyAssetMap();
+      const assets =
+        preloadMap[shareKey] ||
+        (_command === 'serve' && resolvedRemoteEntryFile
+          ? {
+              js: { async: [], sync: [resolvedRemoteEntryFile] },
+              css: { async: [], sync: [] },
+            }
+          : createEmptyAssetMap());
 
       return [
         {

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -73,6 +73,13 @@ function resolveDevRemoteEntryFileName(fileName: string): string {
   return path.extname(baseName) ? normalized : `${normalized}.js`;
 }
 
+function createRemoteEntryAssetMap(fileName: string) {
+  return {
+    js: { async: [], sync: [fileName] },
+    css: { async: [], sync: [] },
+  };
+}
+
 const Manifest = (): Plugin[] => {
   const mfOptions = getNormalizeModuleFederationOptions();
   const { name, filename, getPublicPath, manifest: manifestOptions, varFilename } = mfOptions;
@@ -375,10 +382,7 @@ const Manifest = (): Plugin[] => {
       const assets =
         preloadMap[shareKey] ||
         (_command === 'serve' && resolvedRemoteEntryFile
-          ? {
-              js: { async: [], sync: [resolvedRemoteEntryFile] },
-              css: { async: [], sync: [] },
-            }
+          ? createRemoteEntryAssetMap(resolvedRemoteEntryFile)
           : createEmptyAssetMap());
 
       return [
@@ -406,7 +410,11 @@ const Manifest = (): Plugin[] => {
     const exposes = Object.entries(options.exposes).map(([key, value]) => {
       const formatKey = key.replace('./', '');
       const sourceFile = value.import;
-      const assets = preloadMap[sourceFile] || createEmptyAssetMap();
+      const assets =
+        preloadMap[sourceFile] ||
+        (_command === 'serve' && resolvedRemoteEntryFile
+          ? createRemoteEntryAssetMap(resolvedRemoteEntryFile)
+          : createEmptyAssetMap());
 
       return {
         id: `${name}:${formatKey}`,


### PR DESCRIPTION
Close #833

- Fix dev mf-manifest.json remote entry when filename contains [hash].
- Serve stable dev remoteEntry.js while preserving existing virtual entry handling.
- Add dev shared asset fallback to remoteEntry.js.
- Fix prod SSR fallback to derive from emitted hashed remote entry.
- Add regression tests for dev and build manifest filenames.