### PR TITLE
fix: await host init in dev for bridge SSR hydration entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ export default defineConfig({
       // Optional parameter that controls where the host initialization script is injected.
       // By default, it is injected into the index.html file.
       // You can set this to "entry" to inject it into the entry script instead.
-      // Useful if your application does not load from index.html.
+      // Recommended for SSR hosts without index.html (Nitro, TanStack Start) so
+      // initHost() completes before hydrateRoot and @module-federation/bridge-react
+      // remotes render on first paint.
       hostInitInjectLocation: "html", // or "entry"
       // Controls whether all CSS assets from the bundle should be added to every exposed module.
       // When false (default), the plugin will not process any CSS assets.

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -269,6 +269,53 @@ describe('pluginAddEntry', () => {
     );
   });
 
+  // Nitro/TanStack Start + hostInitInjectLocation:'entry' + bridge-react: dev must
+  // use the same await initHost() bootstrap as build, not a bare side-effect import.
+  it('wraps hydration entry fallback behind host init during dev serve', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-serve-hydration-'));
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);',
+      '/src/entry-client.tsx'
+    )) as { code: string } | undefined;
+
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('await __mfHostInit.__tla;');
+    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
+    expect(result?.code).toContain('await initHost();');
+    expect(result?.code).toContain(
+      '})().then(() => import("/src/entry-client.tsx?mf-entry-bootstrap"));'
+    );
+    expect(result?.code).not.toMatch(/^import "\/virtual\/hostInit\.js";\nimport/m);
+  });
+
   it('does not wrap Nuxt dev entry.async (mount hook handles host init)', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-nuxt-dev-'));
     const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -745,6 +745,11 @@ const addEntry = ({
           );
         }
 
+        // SSR hosts without index.html (Nitro, TanStack Start) and
+        // hostInitInjectLocation:'entry' have no rollup input in dev. Match the
+        // client module that hydrates/mounts React so host init runs before
+        // hydrateRoot — required for @module-federation/bridge-react remotes that
+        // call getInstance() on first render.
         const isHydrationEntryFallback =
           inject === 'entry' &&
           entryFiles.length === 0 &&
@@ -793,13 +798,11 @@ const addEntry = ({
             isNuxtClientEntryFallback);
         if (shouldInject) {
           clientInjected = true;
-          // For the dev-mode entry fallback (inject:'entry' with no known entry
-          // files), always use a simple import injection. The getBootstrapSource
-          // wrapper is incompatible with SSR module evaluation — the async IIFE
-          // it generates prevents the module from exporting synchronously.
-          const usesDevEntryFallback =
-            _command === 'serve' && inject === 'entry' && isHydrationEntryFallback;
-          if (!waitsForInit || usesDevEntryFallback) {
+          // Non-hostInit injections only need a side-effect import. Host-init
+          // bootstrap must await initHost() before the app entry runs — in both
+          // build and serve — so bridge-react remotes do not hit
+          // "Module Federation runtime is not initialized" on first paint.
+          if (!waitsForInit) {
             const injection = `import ${JSON.stringify(getEntryPath())};\n`;
             return mapCodeToCodeWithSourcemap(injection + code);
           }


### PR DESCRIPTION
## Summary

Fixes a dev-only race when `hostInitInjectLocation: "entry"` is used with SSR hosts that have no root `index.html` (Nitro, TanStack Start, etc.).

Production builds already wrap hydration entries with `getBootstrapSource()` (`await initHost()` before the client entry runs). In Vite dev (`serve`), hydration entry fallbacks only received a side-effect `import` of the host-init module, so `hydrateRoot` could run before the Module Federation runtime finished initializing.

This shows up most clearly with **`@module-federation/bridge-react`** (`createLazyComponent` / `loadRemote`): bridge resolves the MF runtime synchronously on first render via `getInstance()`. If `initHost()` has not completed, remotes fail on first paint with: "Module Federation runtime is not initialized" 

Production preview for the same apps works — the gap was dev-only client entry injection.

## Affected setup

- `hostInitInjectLocation: "entry"`
- No `index.html` at dev time (or missing from project root)
- Client entry contains `hydrateRoot`, `createRoot`, or `ReactDOM.render`
- Vite `command: "serve"`

Typical frameworks: Nitro + React (`entry-client.tsx`), TanStack Start (`client.tsx` + `StartClient`).

`React.lazy(() => import('remote/…'))` with a route loader that pre-imports remotes may mask the same race; bridge should not require an app-level `await hostInitPromise` shim.

## Root cause

In `pluginAddEntry.ts`, `isHydrationEntryFallback` matches client hydration modules when rollup has no registered input entry. For `waitsForInit` injections, `usesDevEntryFallback` forced dev serve to prepend only `import hostInit` instead of the full bootstrap wrapper used in `build`.

The old comment about SSR modules needing synchronous exports does not apply here — server entries do not match `isHydrationEntryFallback` (no mount/hydrate calls).

Nuxt dev is unchanged: `entry.async.js` is still skipped (`skipNuxtDevEntryAsyncInject`); host init is injected at mount time in `entry.js`.