### PR TITLE
fix: normalize trailing slash shares

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -275,6 +275,7 @@ describe('pluginProxySharedModule_preBuild', () => {
       expect(findSharedKey('@scope/ui/button', shared)).toBe('@scope/ui/');
       expect(findSharedKey('vue/dist/vue.esm-bundler.js', shared)).toBe('vue');
       expect(findSharedKey('react/jsx-runtime', shared)).toBe('react');
+      expect(findSharedKey('react-dom/client', shared)).toBe('react-dom');
     });
 
     it('caches per source without changing misses', () => {

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -288,6 +288,43 @@ describe('normalizeModuleFederationOption', () => {
       });
     });
 
+    it('normalizes docs-style trailing slash keys for common subpath shares', () => {
+      const shared = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          'react/': {
+            singleton: true,
+            requiredVersion: '^19.0.0',
+          },
+          'react-dom/': {
+            singleton: true,
+            import: false,
+          },
+          '@scope/ui/': {
+            singleton: true,
+          },
+        },
+      }).shared;
+
+      expect(shared.react).toMatchObject({
+        name: 'react',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+      });
+      expect(shared['react-dom']).toMatchObject({
+        name: 'react-dom',
+        shareConfig: {
+          import: false,
+          singleton: true,
+        },
+      });
+      expect(shared['react/']).toBeUndefined();
+      expect(shared['react-dom/']).toBeUndefined();
+      expect(shared['@scope/ui/']).toBeDefined();
+    });
+
     it('prefers the installed package version over an inferred requiredVersion', () => {
       const path = require('node:path');
       const fs = require('node:fs');

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -31,6 +31,7 @@ import {
   getPackageName,
   resolveImportPath,
 } from './packageUtils';
+import { getCommonSharedSubpaths } from './pathNormalization';
 
 interface ExposesItem {
   import: string;
@@ -247,6 +248,12 @@ function normalizeShareItem(
   };
 }
 
+function normalizeSharedKey(key: string): string {
+  if (!key.endsWith('/')) return key;
+  const baseKey = key.slice(0, -1);
+  return getCommonSharedSubpaths(baseKey).length > 0 ? baseKey : key;
+}
+
 function normalizeShared(
   shared:
     | string[]
@@ -297,17 +304,19 @@ function normalizeShared(
   if (Array.isArray(shared)) {
     shared.forEach((key) => {
       if (isModuleFederationRuntimePackage(key)) return;
-      result[key] = normalizeShareItem(key, key);
-      explicitSharedKeys.add(key);
-      sourceEntries.push([key, key]);
+      const normalizedKey = normalizeSharedKey(key);
+      result[normalizedKey] = normalizeShareItem(normalizedKey, normalizedKey);
+      explicitSharedKeys.add(normalizedKey);
+      sourceEntries.push([normalizedKey, normalizedKey]);
     });
   } else if (typeof shared === 'object') {
     Object.keys(shared).forEach((key) => {
       if (isModuleFederationRuntimePackage(key)) return;
+      const normalizedKey = normalizeSharedKey(key);
       const value = shared[key] as any;
-      result[key] = normalizeShareItem(key, value);
-      explicitSharedKeys.add(key);
-      sourceEntries.push([key, value]);
+      result[normalizedKey] = normalizeShareItem(normalizedKey, value);
+      explicitSharedKeys.add(normalizedKey);
+      sourceEntries.push([normalizedKey, value]);
     });
   }
 


### PR DESCRIPTION
Close #836

Align Vite shared normalization with Module Federation docs by treating known trailing-slash shares like react/ and react-dom/ as their package roots while preserving common subpath sharing.
This prevents Vite/Rolldown from resolving invalid package imports such as react-dom/.