### PR TITLE
fix(ssr): initialize host before Vue and remote entries

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1132,6 +1132,43 @@ describe('vite:module-federation-early-init', () => {
     expect(virtualModule?.code).toContain('jsx');
   });
 
+  it('registers zustand shared subpath loadShare modules during early init', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        shared: {
+          zustand: {
+            singleton: true,
+          },
+        },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+        exclude: [],
+      },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const vanillaImportId = getLoadShareModulePath('zustand/vanilla', false);
+    const reactImportId = getLoadShareModulePath('zustand/react', false);
+    const optimizeDeps = [...config.optimizeDeps.include, ...config.optimizeDeps.exclude];
+
+    expect(VirtualModule.findById(vanillaImportId)?.code).toBeTruthy();
+    expect(VirtualModule.findById(reactImportId)?.code).toBeTruthy();
+    expect(optimizeDeps).toContain('zustand/vanilla');
+    expect(optimizeDeps).toContain('zustand/react');
+  });
+
   it('excludes shared react from dev optimizeDeps when react-redux is installed', () => {
     hasPackageDependencyMock.mockImplementation(
       (dependency: string): boolean => dependency === 'react-redux'

--- a/src/index.ts
+++ b/src/index.ts
@@ -619,7 +619,6 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       entryName: 'hostInit',
       entryPath: () => getHostAutoInitPath(),
       inject: hostInitInjectLocation,
-      forceClientInjected: Object.keys(options.exposes).length > 0,
       skipTransformFor: Object.values(options.exposes).map((expose) => expose.import),
     }),
     ...addEntry({

--- a/src/index.ts
+++ b/src/index.ts
@@ -619,6 +619,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       entryName: 'hostInit',
       entryPath: () => getHostAutoInitPath(),
       inject: hostInitInjectLocation,
+      forceClientInjected: Object.keys(options.exposes).length > 0,
       skipTransformFor: Object.values(options.exposes).map((expose) => expose.import),
     }),
     ...addEntry({

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -916,8 +916,40 @@ describe('pluginAddEntry', () => {
       '/repo/remote-app/src/main.ts'
     );
 
-    // With forceClientInjected, the fallback path is skipped
+    // With forceClientInjected, the dev HTML fallback path is skipped
     expect(result).toBeUndefined();
+  });
+
+  it('still wraps hydration entry when forceClientInjected is true and inject is entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-force-client-hydration-'));
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+      forceClientInjected: true,
+    });
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);',
+      '/src/entry-client.tsx'
+    )) as { code: string } | undefined;
+
+    expect(result?.code).toContain('await initHost();');
   });
 
   it('does not replace exposed modules that are also rollup inputs', async () => {

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -316,6 +316,105 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toMatch(/^import "\/virtual\/hostInit\.js";\nimport/m);
   });
 
+  it('wraps the same dev hydration fallback entry on repeated transforms', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-repeat-hydration-'));
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const code = 'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);';
+    const id = '/src/entry-client.tsx';
+    const first = (await runTransform(buildPlugin, code, id)) as { code: string } | undefined;
+    const second = (await runTransform(buildPlugin, code, id)) as { code: string } | undefined;
+    const other = await runTransform(
+      buildPlugin,
+      'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(otherDocument, otherApp);',
+      '/src/other-client.tsx'
+    );
+
+    expect(first?.code).toContain(
+      '})().then(() => import("/src/entry-client.tsx?mf-entry-bootstrap"));'
+    );
+    expect(second?.code).toContain(
+      '})().then(() => import("/src/entry-client.tsx?mf-entry-bootstrap"));'
+    );
+    expect(other).toBeUndefined();
+  });
+
+  it('does not consume hydration fallback on MF internal virtual share modules', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-mf-virtual-'));
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const internalResult = await runTransform(
+      buildPlugin,
+      'export const hydrateRoot = localShare.hydrateRoot;',
+      '\0virtual:mf:__mfe_internal__host__loadShare__react_mf_2_dom_mf_1_client__loadShare__.js'
+    );
+
+    expect(internalResult).toBeUndefined();
+
+    const entryResult = (await runTransform(
+      buildPlugin,
+      'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);',
+      '/src/entry-client.tsx'
+    )) as { code: string } | undefined;
+
+    expect(entryResult?.code).toContain(
+      'const __mfHostInit = await import("/virtual/hostInit.js");'
+    );
+    expect(entryResult?.code).toContain(
+      '})().then(() => import("/src/entry-client.tsx?mf-entry-bootstrap"));'
+    );
+  });
+
   // Custom Vue SSR clients (Nitro, not Nuxt) mount via `app.mount('#root')` with
   // createSSRApp/createApp in a separate module, so the React hydrateRoot match
   // never fires. The selector-string mount must trigger the same host-init
@@ -361,6 +460,48 @@ describe('pluginAddEntry', () => {
     expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain(
       '})().then(() => import("/src/entry-client.ts?mf-entry-bootstrap"));'
+    );
+  });
+
+  it('wraps relative string rollup input during dev serve', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-relative-input-'));
+    const entryFile = path.join(tempDir, 'app/entry-client.ts');
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: { input: './app/entry-client.ts' } } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: { input: './app/entry-client.ts' } },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      "import { bootstrapApp } from './appBootstrap';\nconst { app } = bootstrapApp();\napp.mount('#root', true);",
+      entryFile
+    )) as { code: string } | undefined;
+
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain(
+      `})().then(() => import(${JSON.stringify(`${entryFile}?mf-entry-bootstrap`)}));`
     );
   });
 

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -316,6 +316,54 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toMatch(/^import "\/virtual\/hostInit\.js";\nimport/m);
   });
 
+  // Custom Vue SSR clients (Nitro, not Nuxt) mount via `app.mount('#root')` with
+  // createSSRApp/createApp in a separate module, so the React hydrateRoot match
+  // never fires. The selector-string mount must trigger the same host-init
+  // bootstrap so bridge-vue remotes find an initialized runtime on first render.
+  it('wraps Vue mount entry fallback behind host init during dev serve', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-serve-vue-mount-'));
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      "import { bootstrapApp } from './appBootstrap';\nconst { app } = bootstrapApp();\napp.mount('#root', true);",
+      '/src/entry-client.ts'
+    )) as { code: string } | undefined;
+
+    expect(result?.code).toContain('const __mfHostInit = await import("/virtual/hostInit.js");');
+    expect(result?.code).toContain('await __mfHostInit.__tla;');
+    expect(result?.code).toContain('const { initHost } = __mfHostInit;');
+    expect(result?.code).toContain('await initHost();');
+    expect(result?.code).toContain(
+      '})().then(() => import("/src/entry-client.ts?mf-entry-bootstrap"));'
+    );
+  });
+
   it('does not wrap Nuxt dev entry.async (mount hook handles host init)', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-nuxt-dev-'));
     const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -747,9 +747,13 @@ const addEntry = ({
 
         // SSR hosts without index.html (Nitro, TanStack Start) and
         // hostInitInjectLocation:'entry' have no rollup input in dev. Match the
-        // client module that hydrates/mounts React so host init runs before
-        // hydrateRoot — required for @module-federation/bridge-react remotes that
-        // call getInstance() on first render.
+        // client module that hydrates/mounts the app so host init runs before
+        // hydrateRoot / app.mount — required for @module-federation/bridge-*
+        // remotes that call getInstance() on first render. Covers React
+        // (hydrateRoot / createRoot / ReactDOM.render) and Vue clients. Vue
+        // entries frequently mount via `app.mount('#app')` while the
+        // createApp/createSSRApp call lives in a separate module, so match a
+        // selector-string mount on its own as well as a co-located createApp.
         const isHydrationEntryFallback =
           inject === 'entry' &&
           entryFiles.length === 0 &&
@@ -757,7 +761,9 @@ const addEntry = ({
           !clientInjected &&
           !id.includes('node_modules') &&
           (id.startsWith('\0') || /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) &&
-          /hydrateRoot|createRoot|ReactDOM\.render/.test(code);
+          (/hydrateRoot|createRoot|ReactDOM\.render/.test(code) ||
+            /\.mount\s*\(\s*['"#]/.test(code) ||
+            (/\.mount\s*\(/.test(code) && /createSSRApp|createApp/.test(code)));
 
         const isNuxtEntryAsyncModule =
           /(?:^|\/)nuxt\/dist\/app\/entry\.async\.js(?:\?|$)/.test(id) && code.includes('entry();');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -23,7 +23,7 @@ interface AddEntryOptions {
   entryPath: string | (() => string);
   fileName?: string;
   inject?: NormalizedModuleFederationOptions['hostInitInjectLocation'];
-  /** When true, skip the SSR fallback bootstrap wrapper (used for MF remotes whose HTML is never browser-requested). */
+  /** When true, skip the dev HTML-entry fallback (used for MF remotes whose index.html is never browser-requested). */
   forceClientInjected?: boolean;
   skipTransformFor?: string[];
 }
@@ -133,7 +133,11 @@ const addEntry = ({
   let _command: string;
   let emitFileId: string;
   let viteConfig: any;
-  let clientInjected = forceClientInjected ?? false;
+  // Producer remotes are consumed via federation entry URLs, not their index.html.
+  // Skip only the broad dev HTML fallback — not isHydrationEntryFallback, which
+  // SSR producer apps without index.html still need when hostInitInjectLocation is 'entry'.
+  let skipHtmlDevFallback = forceClientInjected ?? false;
+  let clientInjected = false;
   let emittedFileName: string | undefined;
   let skipTransformIds = new Set<string>();
   let bootstrapDir = '';
@@ -790,6 +794,7 @@ const addEntry = ({
               inject === 'html' &&
               !isVinext &&
               !clientInjected &&
+              !skipHtmlDevFallback &&
               !id.startsWith('\0') &&
               !id.includes('node_modules') &&
               /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) ||

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -140,6 +140,7 @@ const addEntry = ({
   let clientInjected = false;
   let emittedFileName: string | undefined;
   let skipTransformIds = new Set<string>();
+  let injectedTransformIds = new Set<string>();
   let bootstrapDir = '';
 
   function skipSvelteKitSsrBuild() {
@@ -345,6 +346,13 @@ const addEntry = ({
     return normalizeModuleId(path.isAbsolute(id) ? id : path.resolve(viteConfig.root, id));
   }
 
+  function isFederationInternalVirtualId(id: string) {
+    const normalized = decodeViteId(id).replace(/^\0+/, '');
+    return (
+      normalized.includes('virtual:mf:') || /__(?:loadShare|prebuild|loadRemote)__/.test(normalized)
+    );
+  }
+
   function addEntryFile(file: string) {
     const normalized = normalizeModuleId(file);
     if (!entryFiles.includes(normalized)) entryFiles.push(normalized);
@@ -517,11 +525,11 @@ const addEntry = ({
         if (!inputOptions) {
           htmlFilePath = path.resolve(config.root, 'index.html');
         } else if (typeof inputOptions === 'string') {
-          entryFiles = [normalizeModuleId(inputOptions)];
+          entryFiles = [resolveProjectId(inputOptions)];
         } else if (Array.isArray(inputOptions)) {
-          entryFiles = inputOptions.map(normalizeModuleId);
+          entryFiles = inputOptions.map(resolveProjectId);
         } else if (typeof inputOptions === 'object') {
-          entryFiles = Object.values(inputOptions).map((input) => normalizeModuleId(String(input)));
+          entryFiles = Object.values(inputOptions).map((input) => resolveProjectId(String(input)));
         }
 
         if (entryFiles.length > 0) {
@@ -690,7 +698,8 @@ const addEntry = ({
         if (isSvelteKitServerModule(id)) return;
         if (hasEntryBootstrapParam(id)) return;
         if (normalizeModuleId(id).endsWith('.html')) return;
-        if (skipTransformIds.has(resolveProjectId(id))) return;
+        const projectId = resolveProjectId(id);
+        if (skipTransformIds.has(projectId)) return;
         // Only inject into client-side modules. In Vite 8 multi-environment mode
         // this transform also runs for ssr/server environments — injecting there
         // would set clientInjected=true and prevent the real client injection.
@@ -763,6 +772,7 @@ const addEntry = ({
           entryFiles.length === 0 &&
           (!htmlFilePath || !fs.existsSync(htmlFilePath)) &&
           !clientInjected &&
+          !isFederationInternalVirtualId(id) &&
           !id.includes('node_modules') &&
           (id.startsWith('\0') || /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) &&
           (/hydrateRoot|createRoot|ReactDOM\.render/.test(code) ||
@@ -779,7 +789,7 @@ const addEntry = ({
           !hasEntryBootstrapParam(id) &&
           !id.includes('node_modules/.vite') &&
           isNuxtEntryAsyncModule &&
-          !entryFiles.some((file) => resolveProjectId(id) === file);
+          !entryFiles.some((file) => projectId === file);
 
         // Nuxt dev loads entry.async.js as the HTML module script; wrapping it in
         // the async host-init bootstrap sets clientInjected before entry.js is
@@ -788,7 +798,8 @@ const addEntry = ({
 
         const shouldInject =
           !skipNuxtDevEntryAsyncInject &&
-          ((injectEntry() && entryFiles.some((file) => resolveProjectId(id) === file)) ||
+          (injectedTransformIds.has(projectId) ||
+            (injectEntry() && entryFiles.some((file) => projectId === file)) ||
             // Fallback for SSR frameworks (e.g. Nuxt) that bypass transformIndexHtml.
             (_command === 'serve' &&
               inject === 'html' &&
@@ -809,6 +820,7 @@ const addEntry = ({
             isNuxtClientEntryFallback);
         if (shouldInject) {
           clientInjected = true;
+          injectedTransformIds.add(projectId);
           // Non-hostInit injections only need a side-effect import. Host-init
           // bootstrap must await initHost() before the app entry runs — in both
           // build and serve — so bridge-react remotes do not hit

--- a/src/utils/pathNormalization.ts
+++ b/src/utils/pathNormalization.ts
@@ -4,6 +4,7 @@ export const COMMON_SHARED_SUBPATHS: Record<string, string[]> = {
   react: ['react/jsx-runtime', 'react/jsx-dev-runtime', 'react/compiler-runtime'],
   'react-dom': ['react-dom/client', 'react-dom/server', 'react-dom/server.browser'],
   'solid-js': ['solid-js/web', 'solid-js/store', 'solid-js/html', 'solid-js/h'],
+  zustand: ['zustand/vanilla', 'zustand/react'],
 };
 
 export function removeTrailingSlash(value: string): string {


### PR DESCRIPTION
## Summary

Fixes dev SSR entry initialization for apps that do not use an `index.html` client entry.

- Wrap Vue client entries that mount with `app.mount(...)` so `hostInit` runs before the first render
- Keep exposes-only remotes eligible for the hydration-entry fallback when `hostInitInjectLocation` is `entry`
- Avoid consuming that fallback on Module Federation internal virtual modules or one-off unrelated hydration modules
- Register common Zustand subpaths (`zustand/vanilla` and `zustand/react`) as loadShare modules during early init

## Why

React SSR entries already got a host-init fallback, but custom Vue SSR apps and producer remotes can also render before the Module Federation runtime is initialized. When that happens, bridge remotes can fail on first render because `getInstance()` has no initialized runtime yet. These changes make the fallback apply to the real app entry, keep internal virtual modules out of the way, and add the shared Zustand subpaths that need the same early loadShare setup.