### PR TITLE
fix: surface SSR entry HTTP errors

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -13,6 +13,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 type FetchEntry = {
   ok: boolean;
+  status?: number;
+  statusText?: string;
   text?: string;
   json?: unknown;
   headers?: Record<string, string>;
@@ -23,7 +25,8 @@ function makeFetchMock(responses: Record<string, FetchEntry>) {
     const entry = responses[url] ?? { ok: false };
     return {
       ok: entry.ok,
-      status: entry.ok ? 200 : 404,
+      status: entry.status ?? (entry.ok ? 200 : 404),
+      statusText: entry.statusText ?? (entry.ok ? 'OK' : 'Not Found'),
       text: async () => entry.text ?? '',
       json: async () => entry.json ?? {},
       headers: { get: (h: string) => entry.headers?.[h] ?? null },
@@ -656,6 +659,72 @@ describe('ssrEntryLoaderPlugin — manifest SSR entry resolution', () => {
 // ---------------------------------------------------------------------------
 
 describe('ssrEntryLoaderPlugin — code transformation', () => {
+  it('throws HTTP status details instead of importing a non-ok SSR entry response', async () => {
+    const fsMock = await import('fs');
+    (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    const fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': {
+        ok: true,
+        json: {
+          metaData: {
+            ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '', type: 'module' },
+          },
+        },
+      },
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: { 'content-type': 'application/javascript' },
+        text: 'export async function init() { return "loaded-from-404"; }',
+      },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+
+    await expect(
+      factory().loadEntry!({
+        remoteInfo: { name: 'r', entry: 'http://localhost:5001/mf-manifest.json' },
+      })
+    ).rejects.toThrow(
+      'Failed to fetch SSR module "http://localhost:5001/remoteEntry.ssr.js": 404 Not Found'
+    );
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws the missing transitive HTTP module URL when a nested import response is non-ok', async () => {
+    const fsMock = await import('fs');
+    (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    const fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': { ok: false },
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+        text: 'import { t } from "./assets/missing.js";export async function init() {}',
+      },
+      'http://localhost:5001/assets/missing.js': {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'content-type': 'text/plain' },
+        text: 'missing chunk',
+      },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+
+    await expect(
+      factory().loadEntry!({
+        remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
+      })
+    ).rejects.toThrow(
+      'Failed to fetch SSR module "http://localhost:5001/assets/missing.js": 500 Internal Server Error'
+    );
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
   it('fetches transitive relative imports', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -164,6 +164,29 @@ interface SsrEntryCandidate {
   type: string;
 }
 
+class SsrEntryHttpError extends Error {
+  constructor(
+    readonly url: string,
+    readonly status: number,
+    readonly statusText: string,
+    readonly bodyPreview: string
+  ) {
+    super(
+      `Failed to fetch SSR module "${url}": ${status} ${statusText}` +
+        (bodyPreview ? `\npreview: ${bodyPreview}` : '')
+    );
+    this.name = 'SsrEntryHttpError';
+  }
+}
+
+function getBodyPreview(body: string): string {
+  return body.slice(0, 240).replace(/\s+/g, ' ').trim();
+}
+
+function isSsrEntryHttpError(error: unknown): error is SsrEntryHttpError {
+  return error instanceof SsrEntryHttpError;
+}
+
 async function fetchManifest(manifestUrl: string): Promise<Manifest | null> {
   try {
     const res = await fetch(manifestUrl);
@@ -420,6 +443,10 @@ function transformSsrCode(code: string, base: string, sharedPkgMap?: Map<string,
   return code;
 }
 
+function isVitePreloadHelperSpecifier(specifier: string): boolean {
+  return specifier.includes('preload-helper');
+}
+
 /**
  * Fetch an HTTP ESM module, transform it, write it to a temp .js file and
  * return the file path. Recursively does the same for HTTP transitive imports
@@ -437,6 +464,10 @@ async function fetchEsmToTempFile(
   const promise = (async () => {
     const res = await fetch(url);
     let code = await res.text();
+    if (!res.ok) {
+      throw new SsrEntryHttpError(url, res.status, res.statusText, getBodyPreview(code));
+    }
+
     const base = url.replace(/\/[^/]*$/, '/');
 
     // Collect relative HTTP imports before transforming. Keep this pattern
@@ -445,7 +476,10 @@ async function fetchEsmToTempFile(
     const relRegex = /(?:from|export\s*\*\s*from|import\s*(?:\(|\s))\s*["'`]([^"'`\s]+)["'`]/g;
     let m: RegExpExecArray | null;
     while ((m = relRegex.exec(code)) !== null) {
-      if (m[1].startsWith('./') || m[1].startsWith('../')) {
+      if (
+        (m[1].startsWith('./') || m[1].startsWith('../')) &&
+        !isVitePreloadHelperSpecifier(m[1])
+      ) {
         relImports.push(new URL(m[1], base).href);
       }
     }
@@ -554,7 +588,8 @@ async function loadSSRRemoteEntry(
     try {
       const tmpFile = await fetchEsmToTempFile(url, cacheDir, new Map(), sharedPkgMap);
       return await importTempModule(tmpFile);
-    } catch {
+    } catch (error) {
+      if (isSsrEntryHttpError(error)) throw error;
       return null;
     }
   }


### PR DESCRIPTION
## Summary

This surfaces HTTP fetch failures when loading SSR remote entries and their transitive ESM imports.

Previously, non-ok HTTP responses could still be treated as module source and written to a temporary file. This made SSR entry failures harder to diagnose, especially when the actual response was a `404`, `500`, or an error page.

SSR module fetches now throw a dedicated error with the failed URL and HTTP status details.

## Problem

`fetchEsmToTempFile()` read the response body before checking whether the HTTP response was successful:

```ts
const res = await fetch(url);
let code = await res.text();
```

Because `res.ok` was not checked, a failed response could continue through the normal SSR module transformation path.

For example, if `remoteEntry.ssr.js` returned `404 Not Found`, the loader could attempt to transform and import that response instead of reporting the actual fetch failure.

This also affected transitive relative imports, where a missing nested chunk did not clearly report which URL failed.

## Changes

- Added `SsrEntryHttpError` for SSR module HTTP failures.
- Included the failed module URL, status code, status text, and a short body preview in the error.
- Updated `fetchEsmToTempFile()` to throw when `fetch()` returns a non-ok response.
- Preserved the existing fallback behavior for non-HTTP SSR loading errors.
- Skipped Vite preload helper specifiers while collecting relative transitive imports.
- Added regression tests for a non-ok SSR entry response and a non-ok transitive HTTP module response.

## Validation

```bash
pnpm exec vitest run src/utils/__tests__/ssrEntryLoader.test.ts
```

Results:

- `src/utils/__tests__/ssrEntryLoader.test.ts`: added coverage for SSR entry HTTP failures and nested import HTTP failures.

