### PR TITLE
fix: select import:false shared providers by strategy

### DIFF
--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -100,7 +100,8 @@ describe('shared dependencies', () => {
     expect(loadShare).toBeDefined();
     expect(allCode).toContain('const versions =');
     expect(allCode).toContain('[pkg]');
-    expect(allCode).toContain('const provider = versions && versions[Object.keys(versions)[0]]');
+    expect(allCode).toContain('__mfSelectSharedProvider');
+    expect(allCode).not.toContain('versions[Object.keys(versions)[0]]');
     expect(allCode).toContain('__mfModuleCache.share[cacheKey]');
     expect(allCode).not.toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -187,6 +187,25 @@ function getModuleFederationVitePlugin(): FederationPlugin {
   return plugin;
 }
 
+function getModuleFederationVitePluginWithImportFalse(implementation?: string): FederationPlugin {
+  const plugin = (
+    federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      implementation,
+      shared: {
+        react: {
+          singleton: true,
+          import: false,
+        },
+      },
+    }) as Plugin[]
+  ).find((entry) => entry.name === 'module-federation-vite');
+
+  if (!plugin) throw new Error('module-federation-vite plugin not found');
+  return plugin;
+}
+
 function resolvesQuickly(promise: Promise<unknown>) {
   return Promise.race([
     promise.then(() => true),
@@ -1413,12 +1432,111 @@ describe('vite:module-federation-early-init', () => {
     });
 
     const runtimeAlias = config.resolve.alias.find(
-      (alias: { find: string }) => alias.find === '@module-federation/runtime'
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime')
+    );
+    const runtimeHelpersAlias = config.resolve.alias.find(
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime/helpers')
     );
 
+    expect(runtimeHelpersAlias).toBeUndefined();
+    expect(runtimeAlias.find).toBeInstanceOf(RegExp);
+    expect((runtimeAlias.find as RegExp).test('@module-federation/runtime/helpers')).toBe(false);
     expect(runtimeAlias.replacement).toEqual(
       expect.stringMatching(/@module-federation\/runtime\/dist\/index\.js$/)
     );
+    expect(config.optimizeDeps.include).toContain('@module-federation/runtime');
+    expect(config.optimizeDeps.include).not.toContain('@module-federation/runtime/helpers');
+  });
+
+  it('aliases runtime helpers to the same runtime package for import:false provider selection', () => {
+    const plugin = getModuleFederationVitePluginWithImportFalse();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      resolve: {
+        alias: [],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const runtimeAlias = config.resolve.alias.find(
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime')
+    );
+    const runtimeHelpersAlias = config.resolve.alias.find(
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime/helpers')
+    );
+
+    expect(runtimeHelpersAlias.find).toBeInstanceOf(RegExp);
+    expect(
+      (runtimeHelpersAlias.find as RegExp).test('@module-federation/runtime/helpers/extra')
+    ).toBe(false);
+    expect(runtimeHelpersAlias.replacement).toEqual(
+      expect.stringMatching(/@module-federation\/runtime\/dist\/helpers\.js$/)
+    );
+    expect(runtimeAlias.replacement).toEqual(
+      expect.stringMatching(/@module-federation\/runtime\/dist\/index\.js$/)
+    );
+    expect(config.optimizeDeps.include).toContain('@module-federation/runtime/helpers');
+  });
+
+  it('derives the runtime helpers alias from custom runtime implementations', () => {
+    const plugin = getModuleFederationVitePluginWithImportFalse('/custom/runtime/dist/index.js');
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      resolve: {
+        alias: [],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const runtimeHelpersAlias = config.resolve.alias.find(
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime/helpers')
+    );
+
+    expect(runtimeHelpersAlias.replacement).toBe('/custom/runtime/dist/helpers.js');
+  });
+
+  it('derives the runtime helpers alias from custom runtime package paths', () => {
+    const plugin = getModuleFederationVitePluginWithImportFalse('/custom/runtime');
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      resolve: {
+        alias: [],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const runtimeHelpersAlias = config.resolve.alias.find(
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime/helpers')
+    );
+
+    expect(runtimeHelpersAlias.replacement).toBe('/custom/runtime/helpers');
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,28 @@ function appendResolveAlias(config: UserConfig, alias: ResolveAliasEntry): void 
   ];
 }
 
+function hasImportFalseShared(options: NormalizedModuleFederationOptions): boolean {
+  return Object.values(options.shared ?? {}).some((share) => share?.shareConfig?.import === false);
+}
+
+function getRuntimeHelpersImplementation(runtimeImplementation: string): string {
+  const indexEntryMatch = runtimeImplementation.match(/^(.*[\\/])index(\.[cm]?js)$/);
+  if (indexEntryMatch) {
+    return `${indexEntryMatch[1]}helpers${indexEntryMatch[2]}`;
+  }
+
+  const extension = path.extname(runtimeImplementation);
+  if (extension) {
+    return path.join(path.dirname(runtimeImplementation), `helpers${extension}`);
+  }
+
+  if (path.isAbsolute(runtimeImplementation) || runtimeImplementation.startsWith('.')) {
+    return path.join(runtimeImplementation, 'helpers');
+  }
+
+  return `${runtimeImplementation.replace(/\/$/, '')}/helpers`;
+}
+
 const UNSAFE_JS_SOURCE_CHAR_MAP: Record<string, string> = {
   '<': '\\u003C',
   '>': '\\u003E',
@@ -1051,9 +1073,17 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       config(config: UserConfig, { command: _command }: { command: string }) {
         const isRolldown = getIsRolldown(this);
         isSsrBuild = _command === 'build' && config.build?.ssr === true;
+        const needsSharedProviderSelectionHelper = hasImportFalseShared(options);
+
+        if (needsSharedProviderSelectionHelper) {
+          appendResolveAlias(config, {
+            find: /^@module-federation\/runtime\/helpers$/,
+            replacement: getRuntimeHelpersImplementation(options.implementation),
+          });
+        }
 
         appendResolveAlias(config, {
-          find: '@module-federation/runtime',
+          find: /^@module-federation\/runtime$/,
           replacement: options.implementation,
         });
         config.build ||= {};
@@ -1062,6 +1092,9 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         config.optimizeDeps ||= {};
         config.optimizeDeps.include ||= [];
         config.optimizeDeps.include.push('@module-federation/runtime');
+        if (needsSharedProviderSelectionHelper) {
+          config.optimizeDeps.include.push('@module-federation/runtime/helpers');
+        }
 
         // Add all runtime plugins to optimizeDeps to prevent 504 re-optimization.
         // SSR-only plugins import Node modules — exclude them from browser optimisation.

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -21,6 +21,33 @@ function getLastCallFirstArg<T>(mockFn: { mock: { calls: T[][] } }): T | undefin
   return calls.length > 0 ? calls[calls.length - 1][0] : undefined;
 }
 
+type SharedProviderSelector = (
+  versions: Record<string, unknown> | undefined,
+  pkg: string,
+  share: {
+    scope?: string | string[];
+    from?: string;
+    shareConfig: {
+      singleton?: boolean;
+      requiredVersion?: string | false;
+      strictVersion?: boolean;
+    };
+  },
+  strategy: 'version-first' | 'loaded-first'
+) => unknown;
+
+async function getSharedProviderSelector() {
+  const [mod, { share: runtimeShare }] = await Promise.all([
+    import('../virtualRemoteEntry'),
+    import('@module-federation/runtime/helpers'),
+  ]);
+
+  return new Function(
+    'runtimeShare',
+    `${mod.sharedProviderSelectionHelperCode}; return __mfSelectSharedProvider;`
+  )(runtimeShare) as SharedProviderSelector;
+}
+
 vi.mock('../../utils/VirtualModule', () => {
   return {
     default: class MockVirtualModule {
@@ -770,6 +797,200 @@ describe('virtualRemoteEntry', () => {
     );
     expect(code.indexOf('const singletonCacheKey')).toBeLessThan(
       code.indexOf('if (__mfModuleCache.share["default:react@18.3.1"] === undefined)')
+    );
+  });
+
+  it('selects the runtime provider for import:false singleton shares with version-first', async () => {
+    const selectProvider = await getSharedProviderSelector();
+    const react18 = { from: 'host-react-18', lib: () => ({ marker: 'react-18' }), loaded: true };
+    const react19 = { from: 'host-react-19', lib: () => ({ marker: 'react-19' }) };
+
+    expect(
+      selectProvider(
+        {
+          '18.3.1': react18,
+          '19.2.7': react19,
+        },
+        'react',
+        {
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^19.0.0',
+          },
+        },
+        'version-first'
+      )
+    ).toBe(react19);
+  });
+
+  it('prefers an already loaded provider for import:false shares with loaded-first', async () => {
+    const selectProvider = await getSharedProviderSelector();
+    const loadedReact18 = { from: 'loaded-host-react-18', loaded: true };
+    const react19 = { from: 'host-react-19' };
+
+    expect(
+      selectProvider(
+        {
+          '18.3.1': loadedReact18,
+          '19.2.7': react19,
+        },
+        'react',
+        {
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^18.0.0',
+          },
+        },
+        'loaded-first'
+      )
+    ).toBe(loadedReact18);
+  });
+
+  it('matches tilde major ranges when selecting import:false providers', async () => {
+    const selectProvider = await getSharedProviderSelector();
+    const react100 = { from: 'host-react-1.0.0' };
+    const react130 = { from: 'host-react-1.3.0' };
+    const react200 = { from: 'host-react-2.0.0' };
+
+    expect(
+      selectProvider(
+        {
+          '1.0.0': react100,
+          '1.3.0': react130,
+          '2.0.0': react200,
+        },
+        'react',
+        {
+          shareConfig: {
+            requiredVersion: '~1',
+          },
+        },
+        'version-first'
+      )
+    ).toBe(react100);
+  });
+
+  it('matches hyphen ranges when selecting import:false providers', async () => {
+    const selectProvider = await getSharedProviderSelector();
+    const dep123 = { from: 'host-dep-1.2.3' };
+    const dep234 = { from: 'host-dep-2.3.4' };
+    const dep240 = { from: 'host-dep-2.4.0' };
+
+    expect(
+      selectProvider(
+        {
+          '1.2.3': dep123,
+          '2.3.4': dep234,
+          '2.4.0': dep240,
+        },
+        'dep',
+        {
+          shareConfig: {
+            requiredVersion: '1.2.3 - 2.3.4',
+          },
+        },
+        'version-first'
+      )
+    ).toBe(dep123);
+  });
+
+  it('does not import runtime share helpers when no import:false share is configured', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).not.toContain(
+      'import {share as runtimeShare} from "@module-federation/runtime/helpers";'
+    );
+    expect(code).not.toContain('const __mfSelectSharedProvider');
+  });
+
+  it('uses provider selection helper for import:false remote entry bridging', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: {
+          react: {
+            name: 'react',
+            version: '19.2.0',
+            scope: ['default'],
+            shareConfig: {
+              singleton: true,
+              import: false,
+              requiredVersion: '^19.0.0',
+            },
+          },
+        },
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).toContain(
+      'import {share as runtimeShare} from "@module-federation/runtime/helpers";'
+    );
+    expect(code).toContain("__mfSelectSharedProvider(versions, pkg, share, 'version-first')");
+    expect(code).not.toContain('versions[Object.keys(versions)[0]]');
+  });
+
+  it('uses provider selection helper before seeding import:false shares from the global share scope', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: {
+          react: {
+            name: 'react',
+            version: '19.2.0',
+            scope: ['default'],
+            shareConfig: {
+              singleton: true,
+              import: false,
+              requiredVersion: '^19.0.0',
+            },
+          },
+        },
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).toContain('const usedShare = usedShared?.[pkg];');
+    expect(code).toContain('const providerEntries = usedShare?.shareConfig?.import === false');
+    expect(code).toContain("__mfSelectSharedProvider(versionMap, pkg, usedShare, 'version-first')");
+    expect(code.indexOf('__mfSelectSharedProvider(versionMap')).toBeLessThan(
+      code.indexOf('for (const [version, provider] of providerEntries)')
     );
   });
 });

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -142,6 +142,7 @@ export function generateLocalSharedImportMap() {
             shareConfig: {
               singleton: ${shareItem.shareConfig.singleton},
               requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
+              strictVersion: ${shareItem.shareConfig.strictVersion},
               ${shareItem.shareConfig.import === false ? 'import: false,' : ''}
             }
           }
@@ -186,6 +187,7 @@ function generateUsedSharedPreloadConfig() {
             shareConfig: {
               singleton: ${shareItem.shareConfig.singleton},
               requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
+              strictVersion: ${shareItem.shareConfig.strictVersion},
               ${shareItem.shareConfig.import === false ? 'import: false,' : ''}
             }
           }`;
@@ -291,6 +293,43 @@ const normalizeRuntimeShareCode = `const __mfNormalizeRuntimeShare = (mod) => {
             return current;
           };`;
 
+// Emitted into remoteEntry for import:false shared provider selection.
+export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey = Symbol("mf.originalSharedProvider");
+          const __mfResolveShareHook = { emit: (params) => params };
+          const __mfCreateProviderSelectionVersions = (versions, strategy) => {
+            if (strategy !== "version-first") return versions;
+            const selectionVersions = {};
+            for (const [version, provider] of Object.entries(versions)) {
+              selectionVersions[version] = Object.assign({}, provider, {
+                loaded: false,
+                loading: undefined,
+                lib: undefined,
+                [__mfOriginalProviderKey]: provider
+              });
+            }
+            return selectionVersions;
+          };
+          const __mfSelectSharedProvider = (versions, pkg, share, strategy) => {
+            if (!versions || !share) return undefined;
+            const scopes = Array.isArray(share.scope) ? share.scope : [share.scope || "default"];
+            const selectionVersions = __mfCreateProviderSelectionVersions(versions, strategy);
+            const shareScopeMap = {};
+            for (const scope of scopes) {
+              shareScopeMap[scope || "default"] = { [pkg]: selectionVersions };
+            }
+            const selected = runtimeShare.getRegisteredShare(
+              shareScopeMap,
+              pkg,
+              { ...share, scope: scopes, strategy },
+              __mfResolveShareHook
+            )?.shared;
+            return selected?.[__mfOriginalProviderKey] || selected;
+          };`;
+
+function hasImportFalseShared(options: NormalizedModuleFederationOptions): boolean {
+  return Object.values(options.shared ?? {}).some((share) => share?.shareConfig?.import === false);
+}
+
 export function generateDirectSharedCacheSeedCode(command = 'build') {
   return getOrderedUsedShares()
     .map((pkg) => {
@@ -368,6 +407,7 @@ export function generateRemoteEntry(
   virtualExposesId = getVirtualExposesId(options),
   command = 'build'
 ): string {
+  const needsSharedProviderSelectionHelper = hasImportFalseShared(options);
   const pluginImportNames = options.runtimePlugins.map((p, i) => {
     if (typeof p === 'string') {
       return [`$runtimePlugin_${i}`, `import $runtimePlugin_${i} from "${p}";`, `undefined`];
@@ -390,6 +430,11 @@ export function generateRemoteEntry(
     globalThis.__VUE_HMR_RUNTIME__ = { createRecord() {}, rerender() {}, reload() {} };
   }
   import {init as runtimeInit, loadRemote} from "@module-federation/runtime";
+  ${
+    needsSharedProviderSelectionHelper
+      ? 'import {share as runtimeShare} from "@module-federation/runtime/helpers";'
+      : ''
+  }
   ${pluginImportNames
     .filter((item) => !isSsrOnlyPlugin(item[1]))
     .map((item) => item[1])
@@ -424,6 +469,7 @@ export function generateRemoteEntry(
       }
     }
   }
+  ${needsSharedProviderSelectionHelper ? sharedProviderSelectionHelperCode : ''}
 
   async function getLocalSharedImportMap() {
     if (!localSharedImportMapPromise) {
@@ -453,7 +499,14 @@ export function generateRemoteEntry(
           const scopeShare = scopes?.['${options.shareScope}'];
           if (!scopeShare) continue;
           for (const [pkg, versionMap] of Object.entries(scopeShare)) {
-            for (const [version, provider] of Object.entries(versionMap)) {
+            const usedShare = usedShared?.[pkg];
+            const selectedProvider = usedShare?.shareConfig?.import === false
+              ? __mfSelectSharedProvider(versionMap, pkg, usedShare, '${options.shareStrategy}')
+              : undefined;
+            const providerEntries = usedShare?.shareConfig?.import === false
+              ? Object.entries(versionMap).filter(([, provider]) => provider === selectedProvider)
+              : Object.entries(versionMap);
+            for (const [version, provider] of providerEntries) {
               if (!provider.lib) continue;
               const cacheKey = __mfGetSharedCacheKey(pkg, provider.shareConfig?.singleton, version, ${JSON.stringify(options.shareScope)});
               if (__mfModuleCache.share[cacheKey] !== undefined) continue;
@@ -461,7 +514,6 @@ export function generateRemoteEntry(
               const resolved = await Promise.resolve(mod);
               const normalized = __mfNormalizeRuntimeShare(resolved);
               __mfModuleCache.share[cacheKey] = normalized;
-              const usedShare = usedShared?.[pkg];
               if (provider.shareConfig?.singleton && usedShare) {
                 const usedCacheKey = __mfGetSharedCacheKey(pkg, usedShare.shareConfig?.singleton, usedShare.version, usedShare.scope);
                 if (__mfModuleCache.share[usedCacheKey] === undefined) {
@@ -529,7 +581,7 @@ export function generateRemoteEntry(
       if (share.shareConfig?.import !== false || __mfModuleCache.share[cacheKey] !== undefined) continue;
       ${normalizeRuntimeShareCode}
       const versions = shared?.[pkg];
-      const provider = versions && versions[Object.keys(versions)[0]];
+      const provider = __mfSelectSharedProvider(versions, pkg, share, '${options.shareStrategy}');
       if (!provider) continue;
       const factory = provider.lib || (provider.loading ? await provider.loading : await provider.get?.());
       const mod = typeof factory === "function" ? factory() : factory;


### PR DESCRIPTION
## Summary

This fixes provider selection for `import: false` shared modules when the shared scope contains multiple providers for the same package.

Previously, the remote entry bridge picked the first provider from the shared scope object. That made the selected shared module depend on object key order rather than the configured share strategy, provider load state, version ordering, and strict version behavior.

When `import: false` shared modules are configured, the generated remote entry imports the public runtime share helper and emits a small bridge for selecting providers before seeding the `__mf_module_cache__` entry.

This aligns the `import: false` bridge with the documented [`shareStrategy`](https://module-federation.io/configure/sharestrategy#sharestrategy) behavior for `version-first` and `loaded-first`.

## Problem

The `import: false` bridge selected a provider like this:

```ts
const provider = versions && versions[Object.keys(versions)[0]];
```

When multiple providers existed for the same shared package, this could select whichever version appeared first in the object.

Example failure before this change:

```ts
const versions = {
  '18.3.1': react18Provider,
  '19.2.0': react19Provider,
};
```

If `18.3.1` was inserted first, `Object.keys(versions)[0]` selected the React 18 provider. A remote configured with `react` as `singleton`, `import: false`, and `requiredVersion: '^19.0.0'` could then seed `__mf_module_cache__.share['default:react']` with React 18 before the exposed module imported React. Since singleton cache entries are reused, later shared imports could keep reading the wrong provider instead of the React 19 provider expected by `version-first`.

The generated share config also did not include `strictVersion`, so strict version mismatch handling was not preserved when the bridge delegated selection to the runtime helper.

## Changes

- Added `strictVersion` to generated local and used shared configs in [`virtualRemoteEntry.ts`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L142) and [`generateUsedSharedPreloadConfig`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L187).
- Added a small provider selection bridge emitted into `remoteEntry` only when `import: false` shared modules are configured: [`sharedProviderSelectionHelperCode`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L296) and [`needsSharedProviderSelectionHelper`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L407).
- Imported `share` from `@module-federation/runtime/helpers` for that bridge so strategy, range, singleton, and strict-version decisions are delegated to the runtime `getRegisteredShare` path: [`runtimeShare` import](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L432).
- Changed the base `@module-federation/runtime` alias to an exact match and added an `import: false`-only exact alias for `@module-federation/runtime/helpers` derived from the same runtime implementation: [`getRuntimeHelpersImplementation`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/index.ts#L180) and [`config` alias setup](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/index.ts#L1073). This keeps custom `implementation` consumers and strict pnpm installs on one runtime package.
- For `version-first`, the bridge uses a selection-only provider map with `loaded`, `loading`, and `lib` neutralized before delegating to the runtime helper: [`__mfCreateProviderSelectionVersions`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L299). This prevents an already materialized lower version from winning over a higher compatible provider during `import: false` cache seeding.
- Updated the `import: false` bridge to use the helper instead of the first object key for both [`global share pre-seeding`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L501) and [`shared init argument bridging`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/virtualRemoteEntry.ts#L579).
- Added focused tests for provider selection, first-key removal, conditional helper imports, helper aliasing, custom runtime implementations, and global share scope pre-seeding in [`virtualRemoteEntry.test.ts`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/virtualModules/__tests__/virtualRemoteEntry.test.ts#L799) and [`index.test.ts`](https://github.com/dmchoi77/vite/blob/d314f63f1ece83466d2cdca0206d8829d2874593/src/__tests__/index.test.ts#L1434).
