### PR TITLE
fix: manage default share key compatibility

### DIFF
--- a/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
+++ b/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
@@ -46,6 +46,40 @@ describe('virtualRuntimeInitStatus', () => {
     expect(cache.remote).toBe(remote);
   });
 
+  it('aliases default-scoped and legacy share cache keys both ways', async () => {
+    const { getRuntimeModuleCacheBootstrapCode } = await import('../virtualRuntimeInitStatus');
+    const legacyReact = { source: 'legacy-react' };
+    const legacyVersioned = { source: 'legacy-versioned' };
+    const defaultVue = { source: 'default-vue' };
+    const defaultVersioned = { source: 'default-versioned' };
+    const customScoped = { source: 'custom-scope' };
+    const existingDefaultReact = { source: 'existing-default-react' };
+    (globalThis as any).__mf_module_cache__ = {
+      share: {
+        react: legacyReact,
+        'default:react': existingDefaultReact,
+        'react@1.2.3': legacyVersioned,
+        'default:vue': defaultVue,
+        'default:vue@2.0.0': defaultVersioned,
+        'react-18:react': customScoped,
+      },
+      remote: {},
+    };
+
+    const share = runCode<Record<string, unknown>>(
+      getRuntimeModuleCacheBootstrapCode(),
+      'return __mfModuleCache.share;'
+    );
+
+    expect(share['default:react']).toBe(existingDefaultReact);
+    expect(share.react).toBe(legacyReact);
+    expect(share['default:react@1.2.3']).toBe(legacyVersioned);
+    expect(share.vue).toBe(defaultVue);
+    expect(share['vue@2.0.0']).toBe(defaultVersioned);
+    expect(share['react-18:react']).toBe(customScoped);
+    expect(share['default:react-18:react']).toBeUndefined();
+  });
+
   it('promise bootstrap with enableSsrInit resolves to SSR no-op runtime', async () => {
     const { getRuntimeInitPromiseBootstrapCode } = await import('../virtualRuntimeInitStatus');
 

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -135,6 +135,19 @@ globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
 globalThis[__mfCacheGlobalKey].share ||= {};
 globalThis[__mfCacheGlobalKey].remote ||= {};
 const __mfModuleCache = globalThis[__mfCacheGlobalKey];
+for (const __mfShareKey of Object.keys(__mfModuleCache.share)) {
+  if (__mfShareKey.startsWith("default:")) {
+    const __mfLegacyShareKey = __mfShareKey.slice("default:".length);
+    if (__mfModuleCache.share[__mfLegacyShareKey] === undefined) {
+      __mfModuleCache.share[__mfLegacyShareKey] = __mfModuleCache.share[__mfShareKey];
+    }
+  } else if (!__mfShareKey.includes(":")) {
+    const __mfDefaultShareKey = "default:" + __mfShareKey;
+    if (__mfModuleCache.share[__mfDefaultShareKey] === undefined) {
+      __mfModuleCache.share[__mfDefaultShareKey] = __mfModuleCache.share[__mfShareKey];
+    }
+  }
+}
 `;
 }
 


### PR DESCRIPTION
Close #842 

- Adds default-scope cache aliases for backward compatibility between old flat keys and new scoped keys.
  - Examples:
      - react also available as default:react
      - default:react also available as react
      - react@1.2.3 also available as default:react@1.2.3
      - default:react@1.2.3 also available as react@1.2.3
- Does not alias custom scopes like react-18:react. (Those are in new versions)
- Existing keys are never overwritten.