### PR TITLE
fix: serve default remoteEntry in dev

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -7,6 +7,7 @@ import type {
   ResolvedConfig,
   Rollup,
   UserConfig,
+  ViteDevServer,
 } from 'vite';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
@@ -81,6 +82,11 @@ async function runTransformIndexHtml(
 async function runLoad(plugin: AddEntryPlugin, id: string) {
   if (!plugin.load) throw new Error(`${plugin.name} load hook not found`);
   return await callHook(plugin.load, {} as Rollup.PluginContext, id);
+}
+
+function runConfigureServer(plugin: AddEntryPlugin, server: ViteDevServer): void {
+  if (!plugin.configureServer) throw new Error(`${plugin.name} configureServer hook not found`);
+  callHook(plugin.configureServer, {} as MinimalPluginContextWithoutEnvironment, server);
 }
 
 function runBuildStart(
@@ -168,6 +174,37 @@ describe('pluginAddEntry', () => {
     );
 
     expect(result).toBeUndefined();
+  });
+
+  it('serves stable remoteEntry.js for hash-pattern dev entries', () => {
+    const plugins = addEntry({
+      entryName: 'remoteEntry',
+      entryPath: 'virtual:mf-remote-entry',
+      fileName: 'remoteEntry-[hash]',
+    });
+    const servePlugin = plugins[0];
+    const handlers: Function[] = [];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(servePlugin, {
+      root: '/',
+      base: '/',
+    } as unknown as ResolvedConfig);
+    runConfigureServer(servePlugin, {
+      middlewares: { use: (handler: Function) => handlers.push(handler) },
+    } as unknown as ViteDevServer);
+
+    const req = { url: '/remoteEntry.js?cache=1' };
+    const next = vi.fn();
+    handlers[0](req, {}, next);
+
+    expect(req.url).toBe('/@id/virtual:mf-remote-entry');
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it('injects host init into html-script entry during serve when inject is entry', async () => {

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -359,6 +359,54 @@ describe('pluginMFManifest', () => {
     expect(manifest.exposes[0].assets.js.sync).toEqual(['remoteEntry.js']);
   });
 
+  it('serves hash-pattern dev remoteEntry through stable filename without manifest', () => {
+    getNormalizeModuleFederationOptions.mockReturnValue({
+      name: 'basicRemote',
+      filename: 'remoteEntry-[hash]',
+      getPublicPath: undefined,
+      varFilename: undefined,
+      manifest: undefined,
+      exposes: { './exposed': { import: './src/exposed.js' } },
+      remotes: {},
+      shared: {},
+      publicPath: 'auto',
+      bundleAllCSS: false,
+      shareStrategy: 'version-first',
+      implementation: 'module-federation-runtime',
+      runtimePlugins: [],
+      virtualModuleDir: '__mf__virtual',
+      hostInitInjectLocation: 'html',
+      moduleParseTimeout: 10,
+      ignoreOrigin: false,
+    });
+
+    const [servePlugin, buildPlugin] = manifestPlugin();
+    const handlers: Function[] = [];
+
+    callHook(buildPlugin.config, {} as ConfigPluginContext, {}, { command: 'serve', mode: 'test' });
+    callHook(
+      servePlugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        base: '/',
+      } as unknown as ResolvedConfig
+    );
+    callHook(
+      servePlugin.configureServer,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        middlewares: { use: (handler: Function) => handlers.push(handler) },
+      } as any
+    );
+
+    const remoteEntryReq = { url: '/remoteEntry.js?cache=1' };
+    const next = vi.fn();
+    handlers[0](remoteEntryReq, {}, next);
+
+    expect(remoteEntryReq.url).toBe('/remoteEntry-[hash]?cache=1');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
   it('keeps build manifest remoteEntry resolved from emitted bundle', async () => {
     const bundle = makeBundle();
     const remoteEntry = bundle['remoteEntry.js'] as OutputChunk;

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -79,6 +79,15 @@ function stripQueryAndHash(file: string) {
   return file.split(/[?#]/)[0];
 }
 
+function resolveDevHashEntryFileName(fileName: string) {
+  if (!fileName.includes('[hash')) return fileName;
+
+  const normalized = fileName.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
+  const baseName = path.basename(normalized);
+
+  return path.extname(baseName) ? normalized : `${normalized}.js`;
+}
+
 function getBuildInput(config: any) {
   return config.build?.rollupOptions?.input ?? config.build?.rolldownOptions?.input;
 }
@@ -421,6 +430,13 @@ const addEntry = ({
           if (!fileName) {
             next();
             return;
+          }
+          const devFileName = resolveDevHashEntryFileName(fileName);
+          if (
+            devFileName !== fileName &&
+            req.url?.startsWith((viteConfig.base + devFileName).replace(/^\/?/, '/'))
+          ) {
+            req.url = req.url.replace(devFileName, fileName);
           }
           if (req.url && req.url.startsWith((viteConfig.base + fileName).replace(/^\/?/, '/'))) {
             req.url = devEntryPath;

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -141,16 +141,17 @@ const Manifest = (): Plugin[] => {
        */
       configureServer(server) {
         server.middlewares.use((req, res, next) => {
-          if (!mfManifestName) {
-            next();
-            return;
-          }
           const devRemoteEntryFile = resolveDevRemoteEntryFileName(filename);
           if (
             devRemoteEntryFile !== filename &&
+            Object.keys(mfOptions.exposes).length > 0 &&
             req.url?.startsWith((viteConfig.base + devRemoteEntryFile).replace(/^\/?/, '/'))
           ) {
             req.url = req.url.replace(devRemoteEntryFile, filename);
+            next();
+            return;
+          }
+          if (!mfManifestName) {
             next();
             return;
           }


### PR DESCRIPTION
Close #847

Fixes dev serving when the filename prop is omitted.
The plugin defaults to a hashed remote entry, but hosts commonly request /remoteEntry.js; this now maps that stable path before Vite falls back to index.html.