### PR TITLE
fix: defer loadShare export reads until ESM import resolves

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -269,6 +269,65 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('globalThis.System.import(src)');
   });
 
+  it('awaits pendingShareLoads after initHost before importing entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-pending-'));
+    const htmlFile = path.join(tempDir, 'index.html');
+    fs.writeFileSync(
+      htmlFile,
+      [
+        '<!doctype html>',
+        '<html>',
+        '  <body>',
+        '    <script type="module" src="/src/main.tsx"></script>',
+        '  </body>',
+        '</html>',
+      ].join('\n')
+    );
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      'export const browserEntry = true;',
+      '/src/main.tsx'
+    )) as { code: string } | undefined;
+
+    expect(result?.code).toContain('__mfModuleCache.pendingShareLoads');
+    expect(result?.code).toContain('await Promise.all(__mfModuleCache.pendingShareLoads)');
+
+    const bootstrap = result?.code ?? '';
+    expect(bootstrap.indexOf('await initHost();')).toBeLessThan(
+      bootstrap.indexOf('__mfModuleCache.pendingShareLoads')
+    );
+    expect(bootstrap.indexOf('__mfModuleCache.pendingShareLoads')).toBeLessThan(
+      bootstrap.indexOf('.then(() => import(')
+    );
+  });
+
   it('wraps hydration entry fallback behind host init during build', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-build-hydration-'));
     const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -317,12 +317,24 @@ const addEntry = ({
     // (notably Safari/JavaScriptCore; V8 happens to win the race). Await the
     // module's exported `__tla` promise before reading `initHost`. No-op under
     // native TLA, where `__tla` is undefined.
+    // After initHost, also await any pending share loads queued by loadShare
+    // modules during init(). When init() seeds the cache with the loadShare
+    // module's _exports (getters returning undefined), the loadShare module
+    // defers real value assignment to an initPromise.then() + ESM import
+    // callback. Those promises are tracked in __mfModuleCache.pendingShareLoads
+    // so the bootstrap can await them before importing the entry, preventing
+    // a race where the entry renders before the ESM import resolves.
+    const pendingShareLoadsAwait = `
+  if (__mfModuleCache.pendingShareLoads) {
+    await Promise.all(__mfModuleCache.pendingShareLoads);
+  }`;
+
     const importCode = `
 (async () => {
   const __mfHostInit = await ${importExpression(initSrc)};
   await __mfHostInit.__tla;
   const { initHost } = __mfHostInit;
-  ${preloadBlock}
+  ${preloadBlock}${pendingShareLoadsAwait}
 })().then(() => ${importExpression(entrySrc)});
 `;
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1647,4 +1647,125 @@ describe('writePreBuildLibPath', () => {
       'export default __mfPrebuildExports.default ?? __mfPrebuildExports;'
     );
   });
+
+  // ── pendingShareLoads: deferred export assignment ──────────────────────────
+  //
+  // Race condition: init() seeds __mfModuleCache.share with the loadShare
+  // module's _exports object (getters returning undefined until initPromise
+  // resolves + ESM import completes). When a cached exportModule exists at
+  // loadShare evaluation time (seeded by initHost → runtime.loadShare), the
+  // else branch must NOT synchronously call __mfApplyLazyShareExports /
+  // __mfApplyHostProvidedExports — that would read the stale undefined getters.
+  // Instead, both branches push their async load promise into
+  // __mfModuleCache.pendingShareLoads so the bootstrap can await them.
+
+  it('pushes lazy share load to pendingShareLoads in else branch (build mode)', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // The else branch (cached exportModule) must defer to pendingShareLoads
+    // instead of synchronously calling __mfApplyLazyShareExports.
+    // The asyncLoadCode (initPromise.then → import → __mfApplyLazyShareExports)
+    // must be pushed to pendingShareLoads, not called directly.
+    expect(generatedCode).toContain('__mfModuleCache.pendingShareLoads');
+    // The push must appear in the else branch — verify by checking that
+    // the else block contains pendingShareLoads, not a bare apply.
+    const elseIndex = generatedCode.indexOf('} else {');
+    if (elseIndex !== -1) {
+      const afterElse = generatedCode.slice(elseIndex);
+      expect(afterElse).toContain('pendingShareLoads');
+    }
+  });
+
+  it('pushes lazy share load to pendingShareLoads in client-side undefined branch (build mode)', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // The non-SSR undefined branch must also use pendingShareLoads
+    // instead of a bare initPromise.then()
+    expect(generatedCode).toContain('pendingShareLoads');
+    expect(generatedCode).toContain('initPromise.then');
+
+    // Must use the ||= pattern for lazy initialization
+    expect(generatedCode).toContain('||= []');
+  });
+
+  it('does not use bare initPromise.then without pendingShareLoads in build mode', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // Every initPromise.then() must be wrapped in a pendingShareLoads push.
+    const pushCount = (generatedCode.match(/pendingShareLoads/g) || []).length;
+    const thenCount = (generatedCode.match(/initPromise\.then/g) || []).length;
+    expect(pushCount).toBeGreaterThanOrEqual(thenCount);
+  });
+
+  it('pushes host-provided share load to pendingShareLoads in else branch (import: false)', () => {
+    const pkg = 'host-only-dep';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // For import:false shares using generateDeferredHostProvidedExports,
+    // the else branch must also defer to pendingShareLoads
+    expect(generatedCode).toContain('pendingShareLoads');
+    expect(generatedCode).toContain('__mfModuleCache.share');
+    expect(generatedCode).toContain('initPromise.then');
+    expect(generatedCode).toContain('||= []');
+  });
 });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -635,6 +635,14 @@ function generateLazyWorkspaceSingletonExports(
       __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;
       __mfApplyLazyShareExports(exportModule);`;
 
+  const asyncLoadCode = `initPromise.then(() =>
+        import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
+          exportModule = __mfNormalizeShareModule(mod);
+          __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;
+          __mfApplyLazyShareExports(exportModule);
+        })
+      )`;
+
   const body = `${declarations}
     const __mfApplyLazyShareExports = (mod) => {
       ${assignments}
@@ -647,17 +655,11 @@ function generateLazyWorkspaceSingletonExports(
           : `if (import.meta.env.SSR) {
         ${applyLocalFallback}
       } else {
-        initPromise.then(() =>
-          import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
-            exportModule = __mfNormalizeShareModule(mod);
-            __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;
-            __mfApplyLazyShareExports(exportModule);
-          })
-        );
+        (__mfModuleCache.pendingShareLoads ||= []).push(${asyncLoadCode});
       }`
       }
     } else {
-      __mfApplyLazyShareExports(exportModule);
+      (__mfModuleCache.pendingShareLoads ||= []).push(${asyncLoadCode});
     }
     export { __mf_default as default };${namedExportLine}`;
 
@@ -721,7 +723,12 @@ function generateDeferredHostProvidedExports(
         __mfApplyHostProvidedExports(exportModule);
       });
     } else {
-      __mfApplyHostProvidedExports(exportModule);
+      (__mfModuleCache.pendingShareLoads ||= []).push(
+        initPromise.then(() => {
+          exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}];
+          __mfApplyHostProvidedExports(exportModule);
+        })
+      );
     }
     export { __mf_default as default };${namedExportLine}`;
 }


### PR DESCRIPTION
## Problem

Race condition in `@module-federation/vite` build mode: when `init()` seeds `__mfModuleCache.share` with the loadShare module's `_exports` object, those exports are getters that return `undefined` until `initPromise` resolves and the ESM dynamic import completes.

When `initHost()` calls `runtime.loadShare()`, the cache gets populated with real module references. On the next loadShare evaluation (entry import), the `else` branch finds cached `exportModule` and synchronously calls `__mfApplyLazyShareExports` / `__mfApplyHostProvidedExports` — reading stale `undefined` getters before the ESM import has resolved.

This causes runtime crashes (`TypeError: x is not a function` / `undefined` component errors) when the entry renders before shared module ESM imports have completed.

## Fix

**`virtualShared_preBuild.ts`** — Both `generateLazyWorkspaceSingletonExports` and `generateDeferredHostProvidedExports`:
- The `else` branch (cached `exportModule`) now pushes `initPromise.then(...)` to `__mfModuleCache.pendingShareLoads` instead of synchronously applying exports
- The `undefined` branch already used `initPromise.then()` — now also pushes to `pendingShareLoads`

**`pluginAddEntry.ts`** — Bootstrap:
- Added `await Promise.all(__mfModuleCache.pendingShareLoads)` after `await initHost()` and before `import(entrySrc)`, ensuring all shared module ESM imports have resolved before the entry renders

## Tests

5 new tests (604/604 pass):
- `virtualShared_preBuild.test.ts`: 4 tests verifying `pendingShareLoads` is pushed in both branches, `||= []` lazy init pattern, and `import: false` (host-provided) shares
- `pluginAddEntry.test.ts`: 1 test verifying bootstrap awaits `pendingShareLoads` after `initHost()` and before entry import
