### PR TITLE
fix: handle boolean Vite watch config

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -760,6 +760,67 @@ describe('vite:module-federation-early-init', () => {
     expect(federationIgnored('/repo/src/App.vue')).toBe(false);
   });
 
+  it('skips dev server watch ignores when watching is disabled', () => {
+    const plugin = getEarlyInitPlugin();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      server: {
+        watch: false,
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.server.watch).toBe(false);
+  });
+
+  it('preserves disabled Vite fs watching', () => {
+    const plugin = getEarlyInitPlugin();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      server: {
+        watch: null,
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.server.watch).toBeNull();
+  });
+
+  it('normalizes enabled dev server watch before adding federation ignores', () => {
+    const plugin = getEarlyInitPlugin();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      server: {
+        watch: true,
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(typeof config.server.watch.ignored).toBe('function');
+    expect(config.server.watch.ignored('/repo/src/__mf__virtual/loadShare.js')).toBe(true);
+  });
+
   it('skips pure virtual optimizeDeps includes in Rolldown serve', () => {
     const plugin = getEarlyInitPlugin();
     const config: any = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,9 @@ type CodeSplittingGroup = {
   priority?: number;
 };
 
+type ViteWatchOptions = NonNullable<NonNullable<UserConfig['server']>['watch']>;
+type ViteWatchConfig = ViteWatchOptions | boolean | null | undefined;
+
 function normalizeVinextRscPreloadHints(code: string): string {
   return code
     .replace(/(:HL\[[^\]\n]*?,)"stylesheet"/g, '$1"style"')
@@ -102,19 +105,26 @@ function ignoreFederationGeneratedFiles(
   options: NormalizedModuleFederationOptions
 ): void {
   config.server ??= {};
-  config.server.watch ??= {};
+  const watch = config.server.watch as ViteWatchConfig;
+
+  if (watch === false || watch === null) {
+    return;
+  }
+
+  const watchOptions = watch === true || watch === undefined ? {} : watch;
+  config.server.watch = watchOptions;
 
   const federationIgnore = (file: string) => shouldIgnoreFile(file, options);
-  const ignored = config.server.watch.ignored;
+  const ignored = watchOptions.ignored;
   if (!ignored) {
-    config.server.watch.ignored = federationIgnore;
+    watchOptions.ignored = federationIgnore;
     return;
   }
   if (Array.isArray(ignored)) {
     ignored.push(federationIgnore);
     return;
   }
-  config.server.watch.ignored = [ignored, federationIgnore];
+  watchOptions.ignored = [ignored, federationIgnore];
 }
 
 function isSharedResolverInternalImporter(importer: string | undefined): boolean {


### PR DESCRIPTION
Close #851

- Fixes crash when server.watch is passed as false by wrappers like Nx.
- Preserves Vite’s null behavior for disabled filesystem watching.
- Normalizes true/undefined watch config to default watch options before adding federation ignores.
- Adds regression tests for boolean and null watch config cases.