### PR TITLE
fix: resolve manifest remoteEntry to the container, not a same-named expose

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -422,6 +422,31 @@ describe('pluginMFManifest', () => {
     expect(manifest.metaData.ssrRemoteEntry.name).toBe('remoteEntry-a1b2c3d4.ssr.js');
   });
 
+  // An expose basenamed like the container gets the same chunk name; even emitted first,
+  // the manifest must point at the container, not the expose. Covers a camelCase
+  // `remoteEntry.js` and a kebab `remote-entry.js` filename.
+  it.each(['remote-entry', 'remoteEntry'])(
+    'resolves the build remoteEntry to the %s container, not a same-named expose',
+    async (base) => {
+      const filename = `${base}.js`;
+      const exposeFile = `assets/${base}-abc123.js`;
+      const container = {
+        ...(makeBundle()['remoteEntry.js'] as OutputChunk),
+        fileName: filename,
+        name: base,
+      };
+      const bundle: OutputBundle = {
+        [exposeFile]: { ...container, fileName: exposeFile, facadeModuleId: '/src/expose.js' },
+        [filename]: container,
+      };
+
+      const emitted = await runGenerateBundleWithManifest(true, { bundle, filename });
+      const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+      expect(manifest.metaData.remoteEntry.name).toBe(filename);
+    }
+  );
+
   it('emits companion stats file using manifest fileName suffix', async () => {
     const emitted = await runGenerateBundleWithManifest({
       fileName: 'path/custom-manifest.json',

--- a/src/plugins/__tests__/pluginVarRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginVarRemoteEntry.test.ts
@@ -1,0 +1,91 @@
+import type {
+  EmitFile,
+  NormalizedOutputOptions,
+  OutputBundle,
+  OutputChunk,
+  PluginContext,
+} from 'rollup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { callHook } from '../../utils/__tests__/viteHookHelpers';
+import pluginVarRemoteEntry from '../pluginVarRemoteEntry';
+
+const { getNormalizeModuleFederationOptions } = vi.hoisted(() => ({
+  getNormalizeModuleFederationOptions: vi.fn(),
+}));
+
+vi.mock('../../utils/normalizeModuleFederationOptions', () => ({
+  getNormalizeModuleFederationOptions,
+}));
+
+type TestPluginContext = Pick<PluginContext, 'emitFile'>;
+type GenerateBundleHook = (
+  this: PluginContext,
+  outputOptions: NormalizedOutputOptions,
+  bundle: OutputBundle,
+  isWrite: boolean
+) => void | Promise<void>;
+
+const chunk = (fileName: string, name: string): OutputChunk => ({
+  type: 'chunk',
+  fileName,
+  name,
+  facadeModuleId: null,
+  code: '',
+  modules: {},
+  dynamicImports: [],
+  implicitlyLoadedBefore: [],
+  importedBindings: {},
+  imports: [],
+  isDynamicEntry: false,
+  isEntry: false,
+  isImplicitEntry: false,
+  moduleIds: [],
+  referencedFiles: [],
+  exports: [],
+  map: null,
+  preliminaryFileName: fileName,
+  sourcemapFileName: null,
+});
+
+describe('pluginVarRemoteEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getNormalizeModuleFederationOptions.mockReturnValue({
+      name: 'basicRemote',
+      filename: 'remoteEntry.js',
+      varFilename: 'remoteEntry.var.js',
+    });
+  });
+
+  it('wraps the container remoteEntry, not a same-named expose chunk', async () => {
+    const [, buildPlugin] = pluginVarRemoteEntry();
+    const emitted: Record<string, string> = {};
+    const emitFile: EmitFile = (asset) => {
+      if ('fileName' in asset && typeof asset.fileName === 'string' && 'source' in asset) {
+        emitted[asset.fileName] =
+          typeof asset.source === 'string'
+            ? asset.source
+            : Buffer.from(asset.source ?? new Uint8Array()).toString('utf8');
+        return `id:${asset.fileName}`;
+      }
+      return 'id:unknown';
+    };
+    const bundle = {
+      'assets/remoteEntry-abc123.js': chunk('assets/remoteEntry-abc123.js', 'remoteEntry'),
+      'remoteEntry.js': chunk('remoteEntry.js', 'remoteEntry'),
+    } as OutputBundle;
+
+    await callHook(
+      buildPlugin.generateBundle as unknown as GenerateBundleHook | { handler: GenerateBundleHook },
+      { emitFile } as TestPluginContext as PluginContext,
+      {} as NormalizedOutputOptions,
+      bundle,
+      false
+    );
+
+    expect(emitted['remoteEntry.var.js']).toContain(
+      "const entry = getScriptUrl() + 'remoteEntry.js'"
+    );
+    expect(emitted['remoteEntry.var.js']).not.toContain('assets/remoteEntry-abc123.js');
+  });
+});

--- a/src/utils/__tests__/bundleHelpers.test.ts
+++ b/src/utils/__tests__/bundleHelpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { findRemoteEntryFile } from '../bundleHelpers';
+import type { OutputBundleItem } from '../cssModuleHelpers';
+
+const chunk = (fileName: string, name: string): OutputBundleItem => ({
+  type: 'chunk',
+  fileName,
+  name,
+  modules: {},
+  dynamicImports: [],
+});
+
+describe('findRemoteEntryFile', () => {
+  // An expose basenamed like the container gets the same chunk name; even emitted first,
+  // it must not be picked as the remoteEntry — only the container exports `init`/`get`.
+  // Both a camelCase `remoteEntry.js` and a kebab `remote-entry.js` filename collide.
+  it.each(['remote-entry', 'remoteEntry'])(
+    'returns the %s container, not a same-named expose chunk',
+    (base) => {
+      const filename = `${base}.js`;
+      const exposeFile = `assets/${base}-abc123.js`;
+      const bundle: Record<string, OutputBundleItem> = {
+        [exposeFile]: chunk(exposeFile, base),
+        [filename]: chunk(filename, base),
+      };
+      expect(findRemoteEntryFile(filename, bundle)).toBe(filename);
+    }
+  );
+
+  it('returns the container when an unrelated expose is literally named `remoteEntry`', () => {
+    // The matcher also has a hardcoded `name === 'remoteEntry'` branch; guard it for a
+    // custom `filename` so a camelCase expose can't hijack the manifest.
+    const bundle: Record<string, OutputBundleItem> = {
+      'assets/remoteEntry-abc123.js': chunk('assets/remoteEntry-abc123.js', 'remoteEntry'),
+      'mfEntry.js': chunk('mfEntry.js', 'mfEntry'),
+    };
+    expect(findRemoteEntryFile('mfEntry.js', bundle)).toBe('mfEntry.js');
+  });
+
+  it('falls back to the name match when no chunk equals the filename (hashed/dev)', () => {
+    const bundle: Record<string, OutputBundleItem> = {
+      'assets/remoteEntry-abc123.js': chunk('assets/remoteEntry-abc123.js', 'remoteEntry'),
+    };
+    expect(findRemoteEntryFile('remoteEntry.js', bundle)).toBe('assets/remoteEntry-abc123.js');
+  });
+});

--- a/src/utils/bundleHelpers.ts
+++ b/src/utils/bundleHelpers.ts
@@ -303,12 +303,19 @@ export function rewriteSystemProxyConsumers(
 }
 
 export function findRemoteEntryFile(filename: string, bundle: Record<string, OutputBundleItem>) {
-  for (const [_, fileData] of Object.entries(bundle)) {
+  // The container is emitted with this exact `fileName`, so match it directly: matching
+  // by `name` alone can pick a same-named expose chunk, which lacks the container's
+  // `init`/`get`. The name heuristic stays as a fallback for hashed/dev filenames.
+  const strippedName = filename.replace(/[\[\]]/g, '_').replace(/\.[^/.]+$/, '');
+  let fallback: string | undefined;
+  for (const fileData of Object.values(bundle)) {
+    if (fileData.fileName === filename) return fileData.fileName;
     if (
-      filename.replace(/[\[\]]/g, '_').replace(/\.[^/.]+$/, '') === fileData.name ||
-      fileData.name === 'remoteEntry'
+      fallback === undefined &&
+      (strippedName === fileData.name || fileData.name === 'remoteEntry')
     ) {
-      return fileData.fileName; // We can return early since we only need to find remoteEntry once
+      fallback = fileData.fileName;
     }
   }
+  return fallback;
 }


### PR DESCRIPTION
Fixes #853.

### Problem

When an exposed module's output chunk shares a base name with the container `filename`, `mf-manifest.json` advertises `metaData.remoteEntry` as the **expose chunk** instead of the container. A host loading that manifest throws `#RUNTIME-002` ("The remote entry interface does not contain `init`") and never mounts.

`findRemoteEntryFile` resolves the container by stripping the extension off `filename` (`remoteEntry.js` → `remoteEntry`) and returning the first bundle chunk with that name. An exposed module sourced from a file named like `filename` ends up with a chunk of the same name — and on Vite 8 / rolldown it's ordered first, so it wins the lookup. (Vite 7 ordered them the other way, which hid it.)

### Fix

Prefer the chunk whose `fileName` is exactly the configured `filename`. The container is emitted with that exact name (`addEntry({ fileName })`), so it's unambiguous. The existing name match stays as a fallback for the hashed/dev filenames it can't equal.
