### PR TITLE
fix: publish SSR federation artifacts in multi-environment builds

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -129,6 +129,7 @@ async function runGenerateBundleWithManifest(
     dts?: unknown;
     filename?: string;
     bundle?: OutputBundle;
+    environmentName?: string;
   } = {},
   command: 'serve' | 'build' = 'build',
   base = '/'
@@ -201,6 +202,10 @@ async function runGenerateBundleWithManifest(
       }) as ResolvedId,
   };
 
+  if (runtime.environmentName) {
+    Object.assign(ctx, { environment: { name: runtime.environmentName } });
+  }
+
   await runGenerateBundle(buildPlugin, ctx, runtime.bundle || makeBundle());
   return emitted;
 }
@@ -208,6 +213,19 @@ async function runGenerateBundleWithManifest(
 describe('pluginMFManifest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('does not emit the browser manifest in the ssr environment', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, { environmentName: 'ssr' });
+
+    expect(emitted['mf-manifest.json']).toBeUndefined();
+    expect(emitted['mf-stats.json']).toBeUndefined();
+  });
+
+  it('emits the browser manifest in the client environment', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, { environmentName: 'client' });
+
+    expect(emitted['mf-manifest.json']).toBeDefined();
   });
 
   it('emits manifest and mf-stats artifacts by default', async () => {

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -668,6 +668,55 @@ describe('pluginSSRRemoteEntry', () => {
   });
 
   describe('main plugin — writeBundle', () => {
+    function prepareSsrPublish(
+      mainPlugin: NonNullable<ReturnType<typeof pluginSSRRemoteEntry>[1]>,
+      root: string,
+      clientDir: string
+    ) {
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        root,
+        environments: { client: { build: { outDir: clientDir } } },
+      } as unknown as ResolvedConfig);
+      callHook(
+        mainPlugin.buildStart,
+        {
+          meta: makePluginMeta(false),
+          emitFile: makeEmitFile(),
+          environment: { name: 'ssr' },
+        } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+
+      const outputBundle = {
+        'remoteEntry.ssr.js': {
+          type: 'chunk',
+          fileName: 'remoteEntry.ssr.js',
+          imports: ['mf-assets/exposes-map.js', 'mf-assets/ssr-only.js', 'mf-assets/shared.js'],
+          dynamicImports: [],
+          implicitlyLoadedBefore: [],
+          referencedFiles: [],
+        },
+        'mf-assets/exposes-map.js': {
+          type: 'asset',
+          fileName: 'mf-assets/exposes-map.js',
+          source: 'export default { Widget: () => import("./Widget.js") };',
+        },
+        'mf-assets/ssr-only.js': { type: 'chunk', fileName: 'mf-assets/ssr-only.js' },
+        'mf-assets/Widget.js': { type: 'chunk', fileName: 'mf-assets/Widget.js' },
+        'mf-assets/shared.js': { type: 'chunk', fileName: 'mf-assets/shared.js' },
+      } as unknown as Rollup.OutputBundle;
+      callHook(
+        mainPlugin.generateBundle,
+        { environment: { name: 'ssr' } } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        outputBundle,
+        true
+      );
+
+      return outputBundle;
+    }
+
     it('publishes the SSR entry graph without exposing unrelated server files', () => {
       const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-vite-'));
       const ssrDir = path.join(root, 'dist', 'ssr');
@@ -685,46 +734,7 @@ describe('pluginSSRRemoteEntry', () => {
       try {
         const plugins = pluginSSRRemoteEntry(makeOptions());
         const mainPlugin = plugins[1];
-        const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
-        configResolved?.({
-          root,
-          environments: { client: { build: { outDir: clientDir } } },
-        } as unknown as ResolvedConfig);
-        callHook(
-          mainPlugin.buildStart,
-          {
-            meta: makePluginMeta(false),
-            emitFile: makeEmitFile(),
-            environment: { name: 'ssr' },
-          } as unknown as Rollup.PluginContext,
-          {} as Rollup.NormalizedInputOptions
-        );
-
-        const outputBundle = {
-          'remoteEntry.ssr.js': {
-            type: 'chunk',
-            fileName: 'remoteEntry.ssr.js',
-            imports: ['mf-assets/exposes-map.js', 'mf-assets/ssr-only.js', 'mf-assets/shared.js'],
-            dynamicImports: [],
-            implicitlyLoadedBefore: [],
-            referencedFiles: [],
-          },
-          'mf-assets/exposes-map.js': {
-            type: 'asset',
-            fileName: 'mf-assets/exposes-map.js',
-            source: 'export default { Widget: () => import("./Widget.js") };',
-          },
-          'mf-assets/ssr-only.js': { type: 'chunk', fileName: 'mf-assets/ssr-only.js' },
-          'mf-assets/Widget.js': { type: 'chunk', fileName: 'mf-assets/Widget.js' },
-          'mf-assets/shared.js': { type: 'chunk', fileName: 'mf-assets/shared.js' },
-        } as unknown as Rollup.OutputBundle;
-        callHook(
-          mainPlugin.generateBundle,
-          { environment: { name: 'ssr' } } as unknown as Rollup.PluginContext,
-          {} as Rollup.NormalizedOutputOptions,
-          outputBundle,
-          true
-        );
+        const outputBundle = prepareSsrPublish(mainPlugin, root, clientDir);
         callHook(
           mainPlugin.writeBundle,
           { environment: { name: 'ssr' } } as unknown as Rollup.PluginContext,
@@ -745,6 +755,48 @@ describe('pluginSSRRemoteEntry', () => {
           'client shared'
         );
         expect(fs.existsSync(path.join(clientDir, 'server-only.js'))).toBe(false);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('defers SSR graph publication until the client output directory is available', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-vite-'));
+      const ssrDir = path.join(root, 'dist', 'ssr');
+      const clientDir = path.join(root, 'dist', 'client');
+      fs.mkdirSync(path.join(ssrDir, 'mf-assets'), { recursive: true });
+      fs.writeFileSync(path.join(ssrDir, 'remoteEntry.ssr.js'), 'ssr entry');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'exposes-map.js'), 'exposes map');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'ssr-only.js'), 'ssr asset');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'Widget.js'), 'exposed widget');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'shared.js'), 'ssr shared');
+
+      try {
+        const plugins = pluginSSRRemoteEntry(makeOptions());
+        const mainPlugin = plugins[1];
+        const outputBundle = prepareSsrPublish(mainPlugin, root, clientDir);
+
+        callHook(
+          mainPlugin.writeBundle,
+          { environment: { name: 'ssr' } } as unknown as Rollup.PluginContext,
+          { dir: ssrDir } as Rollup.NormalizedOutputOptions,
+          outputBundle
+        );
+        fs.rmSync(clientDir, { recursive: true, force: true });
+
+        callHook(
+          mainPlugin.writeBundle,
+          { environment: { name: 'client' } } as unknown as Rollup.PluginContext,
+          { dir: clientDir } as Rollup.NormalizedOutputOptions,
+          outputBundle
+        );
+
+        expect(fs.readFileSync(path.join(clientDir, 'remoteEntry.ssr.js'), 'utf8')).toBe(
+          'ssr entry'
+        );
+        expect(fs.readFileSync(path.join(clientDir, 'mf-assets', 'Widget.js'), 'utf8')).toBe(
+          'exposed widget'
+        );
       } finally {
         fs.rmSync(root, { recursive: true, force: true });
       }

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { Rollup, ResolvedConfig } from 'vite';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
@@ -86,6 +89,7 @@ describe('pluginSSRRemoteEntry', () => {
     // so the Vite dev server can respond to virtual SSR module requests.
     expect(plugins[0].apply).toBeUndefined();
     expect(plugins[1].name).toBe('mf:ssr-remote-entry');
+    expect(plugins[1].sharedDuringBuild).toBe(true);
     expect(plugins[1].apply).toBeUndefined();
   });
 
@@ -660,6 +664,90 @@ describe('pluginSSRRemoteEntry', () => {
       );
 
       expect(asset.source).toBe('const map = import("./_nuxt/virtualExposes-abc.js");');
+    });
+  });
+
+  describe('main plugin — writeBundle', () => {
+    it('publishes the SSR entry graph without exposing unrelated server files', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-vite-'));
+      const ssrDir = path.join(root, 'dist', 'ssr');
+      const clientDir = path.join(root, 'dist', 'client');
+      fs.mkdirSync(path.join(ssrDir, 'mf-assets'), { recursive: true });
+      fs.mkdirSync(path.join(clientDir, 'mf-assets'), { recursive: true });
+      fs.writeFileSync(path.join(ssrDir, 'remoteEntry.ssr.js'), 'ssr entry');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'exposes-map.js'), 'exposes map');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'ssr-only.js'), 'ssr asset');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'Widget.js'), 'exposed widget');
+      fs.writeFileSync(path.join(ssrDir, 'mf-assets', 'shared.js'), 'ssr shared');
+      fs.writeFileSync(path.join(ssrDir, 'server-only.js'), 'private server code');
+      fs.writeFileSync(path.join(clientDir, 'mf-assets', 'shared.js'), 'client shared');
+
+      try {
+        const plugins = pluginSSRRemoteEntry(makeOptions());
+        const mainPlugin = plugins[1];
+        const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+        configResolved?.({
+          root,
+          environments: { client: { build: { outDir: clientDir } } },
+        } as unknown as ResolvedConfig);
+        callHook(
+          mainPlugin.buildStart,
+          {
+            meta: makePluginMeta(false),
+            emitFile: makeEmitFile(),
+            environment: { name: 'ssr' },
+          } as unknown as Rollup.PluginContext,
+          {} as Rollup.NormalizedInputOptions
+        );
+
+        const outputBundle = {
+          'remoteEntry.ssr.js': {
+            type: 'chunk',
+            fileName: 'remoteEntry.ssr.js',
+            imports: ['mf-assets/exposes-map.js', 'mf-assets/ssr-only.js', 'mf-assets/shared.js'],
+            dynamicImports: [],
+            implicitlyLoadedBefore: [],
+            referencedFiles: [],
+          },
+          'mf-assets/exposes-map.js': {
+            type: 'asset',
+            fileName: 'mf-assets/exposes-map.js',
+            source: 'export default { Widget: () => import("./Widget.js") };',
+          },
+          'mf-assets/ssr-only.js': { type: 'chunk', fileName: 'mf-assets/ssr-only.js' },
+          'mf-assets/Widget.js': { type: 'chunk', fileName: 'mf-assets/Widget.js' },
+          'mf-assets/shared.js': { type: 'chunk', fileName: 'mf-assets/shared.js' },
+        } as unknown as Rollup.OutputBundle;
+        callHook(
+          mainPlugin.generateBundle,
+          { environment: { name: 'ssr' } } as unknown as Rollup.PluginContext,
+          {} as Rollup.NormalizedOutputOptions,
+          outputBundle,
+          true
+        );
+        callHook(
+          mainPlugin.writeBundle,
+          { environment: { name: 'ssr' } } as unknown as Rollup.PluginContext,
+          { dir: ssrDir } as Rollup.NormalizedOutputOptions,
+          outputBundle
+        );
+
+        expect(fs.readFileSync(path.join(clientDir, 'remoteEntry.ssr.js'), 'utf8')).toBe(
+          'ssr entry'
+        );
+        expect(fs.readFileSync(path.join(clientDir, 'mf-assets', 'ssr-only.js'), 'utf8')).toBe(
+          'ssr asset'
+        );
+        expect(fs.readFileSync(path.join(clientDir, 'mf-assets', 'Widget.js'), 'utf8')).toBe(
+          'exposed widget'
+        );
+        expect(fs.readFileSync(path.join(clientDir, 'mf-assets', 'shared.js'), 'utf8')).toBe(
+          'client shared'
+        );
+        expect(fs.existsSync(path.join(clientDir, 'server-only.js'))).toBe(false);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -241,6 +241,12 @@ const Manifest = (): Plugin[] => {
       async generateBundle(_options, bundle) {
         if (!mfManifestName) return;
 
+        // A multi-environment build runs generateBundle once per environment.
+        // The SSR manifest references chunks that externalize framework
+        // dependencies, so it must not overwrite the browser-safe manifest
+        // emitted by the client environment into the public output directory.
+        if (this.environment?.name === 'ssr') return;
+
         let filesMap: PreloadMap = {};
 
         const foundRemoteEntryFile = findRemoteEntryFile(mfOptions.filename, bundle);

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Plugin, ResolvedConfig } from 'vite';
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { getIsRolldown, isNuxtProjectRoot } from '../utils/packageUtils';
@@ -27,6 +29,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
   let isRolldown = false;
   let ssrOutputFilename = '';
+  let ssrOutputFiles = new Set<string>();
 
   // MF internal packages must be external for the SSR entry (Node resolves
   // them via its module cache) but must NOT be global externals — they need
@@ -131,6 +134,10 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
     },
     {
       name: 'mf:ssr-remote-entry',
+      // The post-build publisher consumes the SSR environment's generated
+      // bundle graph, so Vite 8 must use this same plugin instance for every
+      // build environment and the top-level buildApp hook.
+      sharedDuringBuild: true,
       // No `apply: 'build'` — resolveId/load must run in serve too.
       // buildStart and generateBundle are guarded internally.
 
@@ -375,6 +382,10 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
           );
         }
 
+        if ((this as { environment?: { name?: string } }).environment?.name === 'ssr') {
+          ssrOutputFiles = collectEntryOutputFiles(bundle, ssrOutputFilename);
+        }
+
         // Vite 8+ (Rolldown) only — the chunk was emitted via the chunk path in buildStart.
         // No post-processing needed; Rolldown emits ESM natively.
         // On Vite 5–7 the SSR entry was emitted as a pre-generated asset, so nothing to do here.
@@ -383,6 +394,91 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         if (!chunk || chunk.type !== 'chunk') return;
         // Verify the chunk exists and was emitted correctly — no transform needed for Rolldown.
       },
+
+      writeBundle(outputOptions) {
+        const environmentName = (this as { environment?: { name?: string } }).environment?.name;
+        if (environmentName !== 'ssr' || ssrOutputFiles.size === 0) return;
+
+        const ssrOutDir = outputOptions.dir;
+        const clientOutDir = viteConfig?.environments?.client?.build?.outDir;
+        if (!ssrOutDir || !clientOutDir) return;
+
+        const root = viteConfig?.root ?? process.cwd();
+        const ssrDir = path.resolve(root, ssrOutDir);
+        const clientDir = path.resolve(root, clientOutDir);
+        if (ssrDir === clientDir || !fs.existsSync(ssrDir) || !fs.existsSync(clientDir)) return;
+
+        // This runs for each environment build, including framework-managed
+        // builds that do not invoke Vite's buildApp orchestration. Publish only
+        // the SSR entry's reachable output graph; existing client files win.
+        for (const fileName of ssrOutputFiles) {
+          const source = path.resolve(ssrDir, fileName);
+          const destination = path.resolve(clientDir, fileName);
+          if (!isWithinDirectory(source, ssrDir) || !isWithinDirectory(destination, clientDir)) {
+            continue;
+          }
+          if (!fs.existsSync(source) || fs.existsSync(destination)) continue;
+          fs.mkdirSync(path.dirname(destination), { recursive: true });
+          fs.copyFileSync(source, destination);
+        }
+      },
     },
   ];
+}
+
+type OutputFile = {
+  type: 'asset' | 'chunk';
+  fileName: string;
+  code?: string;
+  source?: string | Uint8Array;
+  imports?: string[];
+  dynamicImports?: string[];
+  implicitlyLoadedBefore?: string[];
+  referencedFiles?: string[];
+};
+
+const RELATIVE_IMPORT_RE =
+  /(?:\bfrom|\bimport\s*(?:\(\s*)?|\bexport\s*\*\s*from)\s*["'`](\.\.?\/[^"'`]+)["'`]/g;
+
+function collectEntryOutputFiles(
+  bundle: Record<string, OutputFile>,
+  entryFileName: string
+): Set<string> {
+  const files = new Set<string>();
+  const visit = (fileName: string) => {
+    if (files.has(fileName)) return;
+    const file = bundle[fileName];
+    if (!file) return;
+    files.add(fileName);
+
+    const dependencies = new Set([
+      ...(file.imports || []),
+      ...(file.dynamicImports || []),
+      ...(file.implicitlyLoadedBefore || []),
+      ...(file.referencedFiles || []),
+    ]);
+    const source =
+      typeof file.code === 'string'
+        ? file.code
+        : typeof file.source === 'string'
+          ? file.source
+          : '';
+    if (source) {
+      const directory = path.posix.dirname(fileName);
+      for (const match of source.matchAll(RELATIVE_IMPORT_RE)) {
+        dependencies.add(path.posix.normalize(path.posix.join(directory, match[1])));
+      }
+    }
+
+    for (const dependency of dependencies) {
+      visit(dependency);
+    }
+  };
+  visit(entryFileName);
+  return files;
+}
+
+function isWithinDirectory(filePath: string, directory: string): boolean {
+  const relative = path.relative(directory, filePath);
+  return relative !== '' && !relative.startsWith(`..${path.sep}`) && relative !== '..';
 }

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -30,6 +30,8 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let isRolldown = false;
   let ssrOutputFilename = '';
   let ssrOutputFiles = new Set<string>();
+  let ssrOutputDir = '';
+  let clientOutputDir = '';
 
   // MF internal packages must be external for the SSR entry (Node resolves
   // them via its module cache) but must NOT be global externals — they need
@@ -397,33 +399,42 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
 
       writeBundle(outputOptions) {
         const environmentName = (this as { environment?: { name?: string } }).environment?.name;
-        if (environmentName !== 'ssr' || ssrOutputFiles.size === 0) return;
-
-        const ssrOutDir = outputOptions.dir;
-        const clientOutDir = viteConfig?.environments?.client?.build?.outDir;
-        if (!ssrOutDir || !clientOutDir) return;
-
-        const root = viteConfig?.root ?? process.cwd();
-        const ssrDir = path.resolve(root, ssrOutDir);
-        const clientDir = path.resolve(root, clientOutDir);
-        if (ssrDir === clientDir || !fs.existsSync(ssrDir) || !fs.existsSync(clientDir)) return;
-
-        // This runs for each environment build, including framework-managed
-        // builds that do not invoke Vite's buildApp orchestration. Publish only
-        // the SSR entry's reachable output graph; existing client files win.
-        for (const fileName of ssrOutputFiles) {
-          const source = path.resolve(ssrDir, fileName);
-          const destination = path.resolve(clientDir, fileName);
-          if (!isWithinDirectory(source, ssrDir) || !isWithinDirectory(destination, clientDir)) {
-            continue;
-          }
-          if (!fs.existsSync(source) || fs.existsSync(destination)) continue;
-          fs.mkdirSync(path.dirname(destination), { recursive: true });
-          fs.copyFileSync(source, destination);
+        if (environmentName === 'ssr' && outputOptions.dir) {
+          ssrOutputDir = outputOptions.dir;
+        } else if (environmentName === 'client' && outputOptions.dir) {
+          clientOutputDir = outputOptions.dir;
         }
+        publishSsrOutputFiles(
+          ssrOutputDir,
+          clientOutputDir || viteConfig?.environments?.client?.build?.outDir
+        );
       },
     },
   ];
+
+  function publishSsrOutputFiles(ssrOutDir?: string, clientOutDir?: string) {
+    if (ssrOutputFiles.size === 0 || !ssrOutDir || !clientOutDir) return;
+
+    const root = viteConfig?.root ?? process.cwd();
+    const ssrDir = path.resolve(root, ssrOutDir);
+    const clientDir = path.resolve(root, clientOutDir);
+    if (ssrDir === clientDir || !fs.existsSync(ssrDir)) return;
+    fs.mkdirSync(clientDir, { recursive: true });
+
+    // This runs for each environment build, including framework-managed
+    // builds that do not invoke Vite's buildApp orchestration. Publish only
+    // the SSR entry's reachable output graph; existing client files win.
+    for (const fileName of ssrOutputFiles) {
+      const source = path.resolve(ssrDir, fileName);
+      const destination = path.resolve(clientDir, fileName);
+      if (!isWithinDirectory(source, ssrDir) || !isWithinDirectory(destination, clientDir)) {
+        continue;
+      }
+      if (!fs.existsSync(source) || fs.existsSync(destination)) continue;
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.copyFileSync(source, destination);
+    }
+  }
 }
 
 type OutputFile = {

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -90,13 +90,17 @@ describe('ssrEntryLoaderPlugin factory', () => {
 // ---------------------------------------------------------------------------
 
 describe('ssrEntryLoaderPlugin — browser guard', () => {
-  it('returns undefined when window is defined', async () => {
+  it('still intercepts on Node when a DOM shim defines window', async () => {
     (globalThis as Record<string, unknown>).window = {};
+    const fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': { ok: false },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
     const factory = await freshLoader();
-    const result = await factory().loadEntry!({
+    await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
     });
-    expect(result).toBeUndefined();
+    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/mf-manifest.json');
     delete (globalThis as Record<string, unknown>).window;
   });
 });

--- a/src/utils/ssrCapabilities.ts
+++ b/src/utils/ssrCapabilities.ts
@@ -1,5 +1,9 @@
 export type MfCommand = 'serve' | 'build';
 
+/** A browser-safe generated expression that is true only in Node.js. */
+export const SERVER_ENV_GUARD =
+  "typeof process !== 'undefined' && !!process.versions && !!process.versions.node";
+
 export interface SsrCapabilities {
   /** Emit server-side MF runtime bootstrap (ssrEntryLoader import) in dev remote wrappers. */
   enableSsrInitBootstrap: boolean;

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -7,7 +7,7 @@
  * `loadScriptNode` — if the hook returns a value, the runtime uses it directly.
  *
  * Strategy:
- *  - In Node (typeof window === 'undefined'), fetch the remote's mf-manifest.json
+ *  - In Node (detected through process.versions.node), fetch the remote's mf-manifest.json
  *    to discover the ssrRemoteEntry URL and its type.
  *  - ESM entry: use a dynamic `import()` — the SSR entry has no browser
  *    globals and all shared packages are external.
@@ -28,12 +28,18 @@
 
 // No static Node.js imports — this module is safe to import in the browser.
 // Node APIs are loaded on demand via dynamic import() which is tree-shaken
-// away when the caller is guarded by typeof window checks.
+// away when the caller is guarded by a Node environment check.
 const importCache = new Map<string, Promise<unknown>>();
 async function nodeImport(id: string): Promise<unknown> {
   if (!importCache.has(id)) importCache.set(id, import(/* @vite-ignore */ id));
   return importCache.get(id);
 }
+
+// DOM shims can define window/document on the server. Node's version marker is
+// not affected by those shims, and is absent in real browser environments.
+const isNodeServer = (): boolean =>
+  typeof (globalThis as { process?: { versions?: { node?: string } } }).process?.versions?.node ===
+  'string';
 
 // ---------------------------------------------------------------------------
 // Vite 8+ ModuleRunner path (dev mode only)
@@ -628,7 +634,7 @@ export default function ssrEntryLoaderPlugin(options: SsrEntryLoaderOptions = {}
     name: 'mf-vite:ssr-entry-loader',
     async loadEntry({ remoteInfo }: { remoteInfo: RemoteInfo }) {
       // Only intercept on the server — browser should use the normal path.
-      if (typeof (globalThis as Record<string, unknown>).window !== 'undefined') return;
+      if (!isNodeServer()) return;
 
       const ssrEntry = await getSSREntry(remoteInfo.entry);
       if (!ssrEntry) return;

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SERVER_ENV_GUARD } from '../../utils/ssrCapabilities';
 import { getRemoteVirtualModule, generateRemotes, resolveRemoteInitMode } from '../virtualRemotes';
 
 const mockOptions = vi.hoisted(() => ({
@@ -128,7 +129,7 @@ describe('generateRemotes', () => {
   it('keeps deferred client proxies on build when SSR init is enabled', () => {
     const code = generateRemotes('remote/Button', 'build', true);
 
-    expect(code).toContain('typeof window === "undefined"');
+    expect(code).toContain(SERVER_ENV_GUARD);
     expect(code).toContain('__mfCreateDeferredRemoteProxy()');
     expect(code).toContain('__mfStartRemoteLoad().then(__mfAssignRemoteModule)');
     expect(code).not.toContain('await ');
@@ -137,7 +138,7 @@ describe('generateRemotes', () => {
   it('split server wrapper with SSR init bootstraps host init on the server only', () => {
     const code = generateRemotes('remote/Button', 'serve', true, 'server');
 
-    expect(code).toContain("typeof window === 'undefined'");
+    expect(code).toContain(SERVER_ENV_GUARD);
     expect(code).toContain('import("/virtual/hostInit.js")');
     expect(code).not.toMatch(
       /import\("\/virtual\/hostInit\.js"\)\s*\n\s*\.then\(\(mod\) => mod\.hostInitPromise\)\s*\n\s*\.then\(initResolve, initReject\)/
@@ -147,7 +148,7 @@ describe('generateRemotes', () => {
   it('starts remote loading during wrapper evaluation for version-first', () => {
     const code = generateRemotes('remote/Button', 'serve');
 
-    expect(code).toContain('typeof window === "undefined"');
+    expect(code).toContain(SERVER_ENV_GUARD);
     expect(code).toContain('__mfCreateDeferredRemoteProxy()');
     expect(code).toContain('runtime.loadRemote("remote/Button")');
     expect(code).toContain('__mfAssignRemoteModule');
@@ -207,11 +208,11 @@ describe('generateRemotes', () => {
 
     expect(code).toContain('__mfCreateDeferredRemoteProxy()');
     expect(code).toContain('runtime.registerRemotes([');
-    expect(code).toContain('typeof window === "undefined"');
+    expect(code).toContain(SERVER_ENV_GUARD);
     expect(code).not.toContain('__mfReact');
     expect(code).not.toContain('__mfCreateRemoteProxy');
     expect(code).not.toMatch(
-      /typeof window === "undefined"[\s\S]*?} else \{\s*__mfRemotePending = __mfStartRemoteLoad\(\)/
+      /process\.versions\.node[\s\S]*?} else \{\s*__mfRemotePending = __mfStartRemoteLoad\(\)/
     );
     expect(code).not.toContain('Promise.resolve(exportModule)');
     expect(code).toContain('export const __mf_remote_pending = __mfRemotePending ?? {');
@@ -224,7 +225,7 @@ describe('generateRemotes', () => {
     mockOptions.shareStrategy = 'loaded-first';
     const code = generateRemotes('remote/Button', 'serve');
 
-    expect(code).toContain('if (typeof window === "undefined")');
+    expect(code).toContain(`if (${SERVER_ENV_GUARD})`);
     expect(code).toContain('__mfAssignRemoteModule');
     expect(code).not.toContain('await ');
   });
@@ -238,7 +239,7 @@ describe('generateRemotes', () => {
       const code = generateRemotes('remote/Button', 'serve', false, 'client');
 
       expect(code).toContain('__mfCreateDeferredRemoteProxy()');
-      expect(code).not.toContain('typeof window === "undefined"');
+      expect(code).not.toContain(SERVER_ENV_GUARD);
       expect(code).toContain('import("/virtual/hostInit.js")');
       expect(code).not.toContain('await ');
       expect(code).not.toContain('Promise.resolve(exportModule)');
@@ -250,7 +251,7 @@ describe('generateRemotes', () => {
 
       expect(code).toContain('__mfAssignRemoteModule');
       expect(code).not.toContain('await ');
-      expect(code).not.toContain('typeof window === "undefined"');
+      expect(code).not.toContain(SERVER_ENV_GUARD);
       expect(code).not.toContain('__mfCreateDeferredRemoteProxy');
       expect(code).not.toContain('import("/virtual/hostInit.js")');
     });
@@ -264,7 +265,7 @@ describe('generateRemotes', () => {
       expect(code).not.toContain('__mfRemotePending = __mfStartRemoteLoad();');
       expect(code).not.toContain('__mfCreateRemoteProxy');
       expect(code).not.toContain('__mfReact');
-      expect(code).not.toContain('typeof window === "undefined"');
+      expect(code).not.toContain(SERVER_ENV_GUARD);
     });
   });
 
@@ -278,7 +279,7 @@ describe('generateRemotes', () => {
     expect(code).toContain('pendingPromise ||= __mfStartRemoteLoad();');
     expect(code).toContain('runtime.registerRemotes([');
     expect(code).not.toMatch(
-      /typeof window === "undefined"[\s\S]*?} else \{\s*__mfRemotePending = __mfStartRemoteLoad\(\)/
+      /process\.versions\.node[\s\S]*?} else \{\s*__mfRemotePending = __mfStartRemoteLoad\(\)/
     );
     expect(code).not.toContain('__mfCreateRemoteProxy');
     expect(code).not.toContain('__mfReact');
@@ -363,7 +364,7 @@ describe('generateRemotes', () => {
   it('uses build remote wrappers with unified remote resolution (version-first)', () => {
     const code = generateRemotes('remote/App', 'build');
 
-    expect(code).toContain('typeof window === "undefined"');
+    expect(code).toContain(SERVER_ENV_GUARD);
     expect(code).toContain('__mfCreateDeferredRemoteProxy()');
     expect(code).toContain('__mfAssignRemoteModule');
     expect(code).not.toContain('await ');
@@ -397,10 +398,10 @@ describe('generateRemotes', () => {
       expect(code).not.toContain('__mfCreateDeferredRemoteProxy');
     });
 
-    it('unified build keeps browser deferral and SSR promise chain via typeof window', () => {
+    it('unified build keeps browser deferral and SSR promise chain via the Node guard', () => {
       const code = generateRemotes('remote/App', 'build');
 
-      expect(code).toContain('typeof window === "undefined"');
+      expect(code).toContain(SERVER_ENV_GUARD);
       expect(code).toContain('__mfCreateDeferredRemoteProxy()');
       expect(code).toContain('__mfAssignRemoteModule');
       expect(code).not.toContain('await ');

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -3,6 +3,7 @@ import {
   type RemoteObjectConfig,
 } from '../utils/normalizeModuleFederationOptions';
 import type { RemoteConsumer } from '../utils/remoteConsumerTarget';
+import { SERVER_ENV_GUARD } from '../utils/ssrCapabilities';
 import VirtualModule from '../utils/VirtualModule';
 import { getHostAutoInitPath } from './virtualRemoteEntry';
 import {
@@ -55,7 +56,7 @@ export function getRemoteFromId(id: string, remotes: Record<string, RemoteObject
  * - `eager`: version-first — start `loadRemote` immediately, resolve via promise chain
  * - `loaded-first-ssr`: SSR/client split — real module (proxies are invalid on the server)
  * - `loaded-first-client`: browser split — defer until an export is read
- * - `loaded-first-unified`: single graph — `typeof window` picks SSR vs browser behavior
+ * - `loaded-first-unified`: single graph — a Node guard picks SSR vs browser behavior
  */
 export type RemoteInitMode =
   | 'eager'
@@ -313,7 +314,7 @@ export function generateRemotes(
       ? clientInit
       : consumer === 'server'
         ? serverInit
-        : `if (typeof window === "undefined") {
+        : `if (${SERVER_ENV_GUARD}) {
       ${serverInit}
     } else {
       ${clientInit}

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -1,4 +1,5 @@
 import VirtualModule from '../utils/VirtualModule';
+import { SERVER_ENV_GUARD } from '../utils/ssrCapabilities';
 
 export const virtualRuntimeInitStatus = new VirtualModule('runtimeInit');
 const MODULE_CACHE_GLOBAL_KEY = '__mf_module_cache__';
@@ -55,7 +56,7 @@ function getSsrNoopResolveCode(
   //
   // Falls back to noops if the runtime is unavailable.
   const remotesJson = JSON.stringify(_ssrRemotes);
-  return `if (typeof window === 'undefined') {
+  return `if (${SERVER_ENV_GUARD}) {
     var _noop = { loadRemote: function() { return Promise.resolve(undefined); }, loadShare: function() { return Promise.resolve(undefined); } };
     ${hostInitResolveCode}.then(function(resolved) {
       if (resolved) return;
@@ -116,7 +117,7 @@ globalThis[globalKey] = {
 ${
   enableSsrInit
     ? `
-if (typeof window === 'undefined' && !globalThis[globalKey].ssrInitStarted) {
+if (${SERVER_ENV_GUARD} && !globalThis[globalKey].ssrInitStarted) {
   globalThis[globalKey].ssrInitStarted = true;
   ${getSsrNoopResolveCode(enableSsrInit, hostInitImportId, 'globalThis[globalKey].initResolve')}
 }`


### PR DESCRIPTION
# Fix SSR federation artifacts in multi-environment builds

## What changed

- Skip browser manifest emission from the `ssr` environment so it cannot overwrite the client manifest.
- From the SSR environment's `writeBundle` hook, publish only the SSR remote entry's reachable chunk graph to the client-served output directory.
- Use a Node-version guard for SSR runtime initialization and entry loading, which remains correct when a DOM shim defines `window` on the server.

## Why

In environment-split SSR builds, the SSR manifest can replace the public manifest even though it references SSR-only chunks. The advertised SSR entry can also be emitted only into an unserved SSR output directory. Both cases can make browser or server remote loading fall back to incompatible code. Publishing from `writeBundle` works when frameworks such as Nitro orchestrate Vite environments themselves, and walking both output metadata and emitted source keeps the publication graph complete without copying unrelated server output.

## Validation

- `pnpm typecheck`
- `pnpm test` (580 tests)
- `pnpm test:integration` (34 tests)
- `pnpm e2e` (19 Playwright tests)
