### PR TITLE
fix: resolve workspace packages with dual ESM/CJS exports to ESM entry

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -95,6 +95,9 @@ vi.mock('../../utils/packageUtils', () => ({
     if (pkg === 'workspace-consumer') {
       return '/repo/packages/workspace-consumer/src/index.ts';
     }
+    if (pkg === 'workspace-dual-format') {
+      return '/repo/packages/workspace-dual-format/dist/index.js';
+    }
   }),
   getInstalledPackageJson: vi.fn((pkg: string, opts?: { fromResolvedEntry?: string }) => {
     if (opts?.fromResolvedEntry?.includes('/repo/packages/workspace-shared-lib/')) {
@@ -147,6 +150,21 @@ vi.mock('../../utils/packageUtils', () => ({
         packageJson: {
           name: 'workspace-consumer',
           dependencies: { 'workspace-producer': 'workspace:*' },
+        },
+      };
+    }
+    if (opts?.fromResolvedEntry?.includes('/repo/packages/workspace-dual-format/')) {
+      return {
+        path: '/repo/packages/workspace-dual-format/package.json',
+        dir: '/repo/packages/workspace-dual-format',
+        packageJson: {
+          name: 'workspace-dual-format',
+          exports: {
+            '.': {
+              import: { default: './dist/index.js' },
+              require: { default: './dist/index.cjs' },
+            },
+          },
         },
       };
     }
@@ -221,6 +239,8 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/workspace-cycle-b/package.json') ||
       filePath.endsWith('/repo/packages/workspace-producer/package.json') ||
       filePath.endsWith('/repo/packages/workspace-consumer/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-dual-format/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-dual-format/dist/index.js') ||
       filePath.endsWith('/repo/packages/custom-shared-source/index.ts')
   ),
   readFileSync: vi.fn((filePath: string) => {
@@ -397,6 +417,20 @@ export const [firstItem, ...restItems] = tuple;`;
         dependencies: { 'workspace-cycle-a': 'workspace:*' },
       });
     }
+    if (filePath.endsWith('/repo/packages/workspace-dual-format/package.json')) {
+      return JSON.stringify({
+        name: 'workspace-dual-format',
+        exports: {
+          '.': {
+            import: { default: './dist/index.js' },
+            require: { default: './dist/index.cjs' },
+          },
+        },
+      });
+    }
+    if (filePath.endsWith('/repo/packages/workspace-dual-format/dist/index.js')) {
+      return 'export const sharedValue = 42; export function increment() { return sharedValue + 1; }';
+    }
     if (filePath.endsWith('/repo/packages/custom-shared-source/index.ts')) {
       return `export const sharedValue = 'shared';
               export function useSharedFeature() {
@@ -566,6 +600,9 @@ vi.mock('module', async (importOriginal) => {
           }
           if (pkg === 'workspace-consumer') {
             return '/repo/packages/workspace-consumer/src/index.ts';
+          }
+          if (pkg === 'workspace-dual-format') {
+            return '/repo/packages/workspace-dual-format/dist/index.cjs';
           }
           if (
             pkg === 'mock-package-reexport-type' ||
@@ -1615,6 +1652,30 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('export * from');
     expect(generatedCode).not.toContain('module.exports = exportModule');
     expect(generatedCode).not.toContain('await ');
+  });
+
+  it('resolves workspace packages with dual ESM/CJS exports to the ESM entry instead of CJS', () => {
+    const pkg = 'workspace-dual-format';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // Should use ESM entry (.js), not CJS entry (.cjs)
+    expect(generatedCode).toContain('/dist/index.js');
+    expect(generatedCode).not.toContain('/dist/index.cjs');
+    expect(generatedCode).not.toContain('module.exports');
   });
 });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -4,6 +4,7 @@ import {
   ShareItem,
 } from '../../utils/normalizeModuleFederationOptions';
 import {
+  getConcreteSharedImportSource,
   getProjectResolvedImportPath,
   writeLoadShareModule,
   writePreBuildLibPath,
@@ -39,7 +40,7 @@ vi.mock('../../utils/packageUtils', () => ({
   hasPackageDependency: hasPackageDependencyMock,
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
   resolveImportPath: vi.fn(() => '/repo/node_modules/@module-federation/runtime/dist/index.js'),
-  getInstalledPackageEntry: vi.fn((pkg: string) => {
+  getInstalledPackageEntry: vi.fn((pkg: string, opts?: { cwd?: string }) => {
     if (pkg === 'mock-package-esm-only/stores' || pkg === 'mock-package-esm-only') {
       return '/repo/apps/remote/node_modules/mock-package-esm-only/dist/stores.js';
     }
@@ -97,6 +98,9 @@ vi.mock('../../utils/packageUtils', () => ({
     }
     if (pkg === 'workspace-dual-format') {
       return '/repo/packages/workspace-dual-format/dist/index.js';
+    }
+    if (pkg === 'workspace-parent-dual-format' && opts?.cwd === '/repo') {
+      return '/repo/packages/workspace-parent-dual-format/dist/index.js';
     }
   }),
   getInstalledPackageJson: vi.fn((pkg: string, opts?: { fromResolvedEntry?: string }) => {
@@ -559,6 +563,12 @@ vi.mock('module', async (importOriginal) => {
               throw new Error('MODULE_NOT_FOUND');
             }
             return '/repo/packages/pkg-b/dist/index.js';
+          }
+          if (pkg === 'workspace-parent-dual-format') {
+            if (!fromPath.includes('/repo/package.json')) {
+              throw new Error('MODULE_NOT_FOUND');
+            }
+            return '/repo/packages/workspace-parent-dual-format/dist/index.cjs';
           }
           if (pkg === 'mock-package-esm-only/stores' || pkg === 'mock-package-esm-only') {
             return '/repo/apps/remote/node_modules/mock-package-esm-only/dist/stores.js';
@@ -1133,6 +1143,12 @@ describe('writeLoadShareModule', () => {
   it('prefers browser conditional exports for project-resolved import paths', () => {
     expect(getProjectResolvedImportPath('mock-package-browser-conditional')).toBe(
       '/repo/apps/remote/node_modules/mock-package-browser-conditional/dist/browser.js'
+    );
+  });
+
+  it('uses parent-root cwd when resolving workspace ESM entries', () => {
+    expect(getConcreteSharedImportSource('workspace-parent-dual-format')).toBe(
+      '/repo/packages/workspace-parent-dual-format/dist/index.js'
     );
   });
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -331,9 +331,14 @@ function isWorkspaceFilePath(resolved: string | undefined): resolved is string {
  * follows Node.js CJS conditions ["node", "require"], which matches exports["."].require.default
  * and returns the .cjs path for packages with dual ESM/CJS exports.
  */
-function resolveWorkspaceEsmEntry(pkg: string, resolved: string): string {
+function resolveWorkspaceEsmEntry(
+  pkg: string,
+  resolved: string,
+  cwd = getPackageDetectionCwd()
+): string {
   if (!isWorkspaceFilePath(resolved)) return resolved;
   const esmEntry = getInstalledPackageEntry(pkg, {
+    cwd,
     conditions: ['browser', 'import', 'module', 'default'],
     resolveSubpathWithRequire: false,
   });
@@ -411,7 +416,7 @@ function isWorkspaceSingletonConsumedByPeer(pkg: string) {
 function tryResolveImportFromPackageRoot(pkg: string, root: string): string | undefined {
   try {
     const projectRequire = createRequire(pathToFileURL(path.join(root, 'package.json')));
-    return resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));
+    return resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg), root);
   } catch {
     return undefined;
   }

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -286,7 +286,7 @@ export function getLocalProviderImportPath(pkg: string): string | undefined {
     const projectRequire = createRequire(
       pathToFileURL(path.join(getPackageDetectionCwd(), 'package.json'))
     );
-    const resolved = projectRequire.resolve(pkg);
+    const resolved = resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));
     return isWorkspaceFilePath(resolved) ? resolved : undefined;
   } catch {
     const resolved = getInstalledPackageEntry(pkg, {
@@ -307,7 +307,7 @@ export function getProjectResolvedImportPath(pkg: string): string | undefined {
     const projectRequire = createRequire(
       pathToFileURL(path.join(getPackageDetectionCwd(), 'package.json'))
     );
-    return projectRequire.resolve(pkg);
+    return resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));
   } catch {
     return undefined;
   }
@@ -320,6 +320,25 @@ function isWorkspaceFilePath(resolved: string | undefined): resolved is string {
     realResolved = realpathSync.native(resolved);
   } catch {}
   return !realResolved.includes('/node_modules/') && !realResolved.includes('\\node_modules\\');
+}
+
+/**
+ * When createRequire resolves a workspace package to a CJS entry (e.g. dist/index.cjs),
+ * re-resolve via getInstalledPackageEntry with ESM-preferring conditions.
+ *
+ * Workspace packages produce browser code, so they must use the ESM build — CJS files
+ * contain `module.exports` which is undefined in the browser. createRequire().resolve()
+ * follows Node.js CJS conditions ["node", "require"], which matches exports["."].require.default
+ * and returns the .cjs path for packages with dual ESM/CJS exports.
+ */
+function resolveWorkspaceEsmEntry(pkg: string, resolved: string): string {
+  if (!isWorkspaceFilePath(resolved)) return resolved;
+  const esmEntry = getInstalledPackageEntry(pkg, {
+    conditions: ['browser', 'import', 'module', 'default'],
+    resolveSubpathWithRequire: false,
+  });
+  if (esmEntry && isWorkspaceFilePath(esmEntry)) return esmEntry;
+  return resolved;
 }
 
 function isWorkspacePackageEntry(pkg: string, resolved: string | undefined): resolved is string {
@@ -392,7 +411,7 @@ function isWorkspaceSingletonConsumedByPeer(pkg: string) {
 function tryResolveImportFromPackageRoot(pkg: string, root: string): string | undefined {
   try {
     const projectRequire = createRequire(pathToFileURL(path.join(root, 'package.json')));
-    return projectRequire.resolve(pkg);
+    return resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## fix: resolve workspace packages with dual ESM/CJS exports to ESM entry in browser context

### Problem

When a workspace package provides dual ESM/CJS exports via the `exports` field in its `package.json`:

```json
{
  "type": "module",
  "main": "dist/index.cjs",
  "module": "dist/index.js",
  "exports": {
    ".": {
      "import": { "default": "./dist/index.js" },
      "require": { "default": "./dist/index.cjs" }
    }
  }
}
```

and this package is shared between a host and a remote via `@module-federation/vite` (e.g. `{ "@whoami.js/what": { singleton: true } }`), the browser throws at runtime:

```
Uncaught (in promise) ReferenceError: module is not defined
    at index.cjs:76:1
```

The offending line in `index.cjs` is the CommonJS export wrapper emitted by the bundler:

```javascript
module.exports = __toCommonJS(index_exports);
```

This is a CommonJS statement executing in the browser, where `module` does not exist.

### Root Cause

The `@module-federation/vite` plugin needs to determine the on-disk file path of each shared package in order to generate the `import` statements in its virtual modules. Three functions in `src/virtualModules/virtualShared_preBuild.ts` use Node.js `createRequire().resolve(pkg)` for this purpose:

1. **`tryResolveImportFromPackageRoot`** -- walks up from the project root to find where a package is installed. Its return value feeds into `getConcreteSharedImportSource` and ultimately into the `import * as __mfLocalShare from "<path>"` statements emitted by `generateEagerWorkspaceSingletonExports` and `generateLazyWorkspaceSingletonExports`.

2. **`getLocalProviderImportPath`** -- determines whether a package is a workspace package (symlinked, not in `node_modules`) and returns its entry path. This path is used as the `lazyLocalFallbackSource` in `writeLoadShareModule`, which generates the static `import` statement for workspace singletons.

3. **`getProjectResolvedImportPath`** -- resolves a package from the project root. Its return value feeds into `getDirectSharedCacheSeedImportPath` (in `virtualRemoteEntry.ts`), which generates dynamic `import()` calls in the `localSharedImportMap` virtual module.

The problem is that `createRequire().resolve(pkg)` is the Node.js CommonJS resolver. It uses the default conditions `["node", "require"]`, which matches the `require` condition in the `exports` field:

```
exports["."].require.default --> "./dist/index.cjs"
```

For packages in `node_modules`, this is harmless because Vite's `optimizeDeps` (dependency pre-bundling) transparently converts CJS to ESM at dev time. But for **workspace packages**, the pre-bundling step is skipped -- their resolved path is written directly into generated `import` statements. The browser then loads the `.cjs` file, encounters `module.exports`, and crashes.

### Fix

Add a `resolveWorkspaceEsmEntry()` helper in `src/virtualModules/virtualShared_preBuild.ts` that intercepts `createRequire`-resolved paths for workspace packages and re-resolves them using ESM-preferring conditions:

```typescript
function resolveWorkspaceEsmEntry(pkg: string, resolved: string): string {
  if (!isWorkspaceFilePath(resolved)) return resolved;
  const esmEntry = getInstalledPackageEntry(pkg, {
    conditions: ["browser", "import", "module", "default"],
    resolveSubpathWithRequire: false,
  });
  if (esmEntry && isWorkspaceFilePath(esmEntry)) return esmEntry;
  return resolved;
}
```

The function works as follows:

1. **Non-workspace packages pass through unchanged.** If the resolved path is inside `node_modules`, the original CJS-resolved path is returned as-is. Vite's dependency pre-bundling handles the CJS-to-ESM conversion for these packages, so no intervention is needed.

2. **Workspace packages are re-resolved with ESM conditions.** The conditions `['browser', 'import', 'module', 'default']` match `exports["."].import.default`, which returns the ESM entry (`dist/index.js`). The `resolveSubpathWithRequire: false` flag prevents the fallback to `createRequire` for subpath exports, ensuring consistent ESM resolution.

3. **Graceful fallback.** If the ESM re-resolution fails or produces a non-workspace path, the original resolved path is returned. This ensures no regression for edge cases (e.g. packages without an `exports` field, or workspace packages that only ship CJS).

The helper is applied at the three call sites where `createRequire().resolve()` results end up in browser code:

```typescript
// tryResolveImportFromPackageRoot
return resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));

// getLocalProviderImportPath
const resolved = resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));

// getProjectResolvedImportPath
return resolveWorkspaceEsmEntry(pkg, projectRequire.resolve(pkg));
```

### Files Changed

| File                                                          | Change                                                                                         |
| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| `src/virtualModules/virtualShared_preBuild.ts`                | Add `resolveWorkspaceEsmEntry()` helper; wrap `createRequire().resolve()` calls in 3 functions |
| `src/virtualModules/__tests__/virtualShared_preBuild.test.ts` | Add `workspace-dual-format` mock package and test case                                         |

### Test Coverage

A new test case `workspace-dual-format` is added with the following mock setup:

- `createRequire().resolve("workspace-dual-format")` returns the CJS entry (`/repo/packages/workspace-dual-format/dist/index.cjs`)
- `getInstalledPackageEntry` with ESM conditions returns the ESM entry (`/repo/packages/workspace-dual-format/dist/index.js`)
- `getInstalledPackageJson` finds the workspace `package.json` with dual `exports`

The test asserts that `writeLoadShareModule` generates code referencing the ESM entry (`/dist/index.js`) and never the CJS entry (`/dist/index.cjs`).

All 578 tests pass (including the new one).

### Impact

- **Scope**: Only affects workspace packages with dual ESM/CJS `exports`. Packages in `node_modules` are unaffected.
- **Behavior change**: Workspace packages shared via Module Federation will now use their ESM entry point in generated browser code instead of the CJS entry point.
- **Backward compatibility**: No breaking changes. Workspace packages that only ship ESM (the common case) already resolved correctly. Workspace packages that only ship CJS will fall back to the original behavior since the ESM re-resolution will fail gracefully.

### Reproduction

This bug reproduces in any pnpm/npm/yarn workspace monorepo where:

1. A workspace package has `exports` with both `import` and `require` conditions pointing to different files (`.js` vs `.cjs`)
2. The package is listed in `shared` in a `@module-federation/vite` configuration
3. The app is run in dev mode (`vite dev`)
