### PR TITLE
fix: fix workspace singleton named exports

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type {
   ConfigEnv,
   ConfigPluginContext,
@@ -44,6 +45,8 @@ import { federation } from '../index';
 import VirtualModule from '../utils/VirtualModule';
 import { getPreBuildLibImportId, LOAD_SHARE_TAG, PREBUILD_TAG } from '../virtualModules';
 import { virtualRuntimeInitStatus } from '../virtualModules/virtualRuntimeInitStatus';
+
+const REACT_EXAMPLE_ROOT = path.join(process.cwd(), 'examples/vite-vite/vite-host');
 
 type FederationPlugin = Plugin;
 function createChunk(fileName: string, code: string): Rollup.OutputBundle[string] {
@@ -1193,7 +1196,7 @@ describe('vite:module-federation-early-init', () => {
   it('registers common shared subpath loadShare modules during early init', () => {
     const plugin = getEarlyInitPluginWithReactShared();
     const config: any = {
-      root: process.cwd(),
+      root: REACT_EXAMPLE_ROOT,
       optimizeDeps: {
         include: [],
         exclude: [],

--- a/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
+++ b/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
@@ -1,9 +1,12 @@
+import path from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { HtmlTagDescriptor, MinimalPluginContextWithoutEnvironment } from 'vite';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import pluginDevRemoteHmr, { shouldIgnoreFile } from '../pluginDevRemoteHmr';
 import { normalizeModuleFederationOptions } from '../../utils/normalizeModuleFederationOptions';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
+
+const REACT_EXAMPLE_ROOT = path.join(process.cwd(), 'examples/vite-vite/vite-remote');
 const { mfWarn } = vi.hoisted(() => ({
   mfWarn: vi.fn(),
 }));
@@ -283,7 +286,10 @@ describe('pluginDevRemoteHmr', () => {
 
     function createReactRemoteServer() {
       return createServer({
-        config: { plugins: [{ name: 'vite:react-refresh' }] },
+        config: {
+          root: REACT_EXAMPLE_ROOT,
+          plugins: [{ name: 'vite:react-refresh' }],
+        },
       });
     }
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -242,6 +242,7 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/workspace-cycle-a/package.json') ||
       filePath.endsWith('/repo/packages/workspace-cycle-b/package.json') ||
       filePath.endsWith('/repo/packages/workspace-producer/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-producer/src/index.ts') ||
       filePath.endsWith('/repo/packages/workspace-consumer/package.json') ||
       filePath.endsWith('/repo/packages/workspace-dual-format/package.json') ||
       filePath.endsWith('/repo/packages/workspace-dual-format/dist/index.js') ||
@@ -421,6 +422,9 @@ export const [firstItem, ...restItems] = tuple;`;
         dependencies: { 'workspace-cycle-a': 'workspace:*' },
       });
     }
+    if (filePath.endsWith('/repo/packages/workspace-producer/src/index.ts')) {
+      return 'export const useProducer = () => 1; export function createProducer() {}';
+    }
     if (filePath.endsWith('/repo/packages/workspace-dual-format/package.json')) {
       return JSON.stringify({
         name: 'workspace-dual-format',
@@ -495,6 +499,14 @@ vi.mock('module', async (importOriginal) => {
             ångstrom: 1,
             café: 2,
             default: 3,
+            __esModule: true,
+          };
+        }
+        if (pkg === 'workspace-producer') {
+          return {
+            useProducer: () => 1,
+            createProducer: () => ({}),
+            default: {},
             __esModule: true,
           };
         }
@@ -1534,6 +1546,10 @@ describe('writeLoadShareModule', () => {
       'import * as __mfLocalShare from "/repo/packages/workspace-producer/src/index.ts";'
     );
     expect(generatedCode).toContain('export { __mf_default as default };');
+    expect(generatedCode).toContain('const __mf_0 = exportModule["useProducer"];');
+    expect(generatedCode).toContain('const __mf_1 = exportModule["createProducer"];');
+    expect(generatedCode).toContain('export { __mf_0 as useProducer, __mf_1 as createProducer };');
+    expect(generatedCode).not.toContain('export { useProducer, createProducer } from');
     expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).toContain('Promise.resolve().then');
   });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -612,9 +612,19 @@ function generateEagerWorkspaceSingletonExports(
   importSource: string,
   cacheKey: string
 ) {
+  const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+  const namedExportAssignments =
+    namedExports.length > 0
+      ? `\n    ${namedExports
+          .map(
+            (name, i) =>
+              `const ${namedExportVars[i]} = exportModule[${escapeGeneratedStringLiteral(name)}];`
+          )
+          .join('\n    ')}`
+      : '';
   const namedExportLine =
     namedExports.length > 0
-      ? `\n    export { ${namedExports.join(', ')} } from ${escapeGeneratedStringLiteral(importSource)};`
+      ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(', ')} };`
       : '';
 
   return `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(importSource)};
@@ -627,10 +637,9 @@ function generateEagerWorkspaceSingletonExports(
       });
       exportModule = __mfLocalShare;
     }
-    const __mf_default = exportModule.default ?? exportModule;
+    const __mf_default = exportModule.default ?? exportModule;${namedExportAssignments}
     export { __mf_default as default };${namedExportLine}`;
 }
-
 function generateLazyWorkspaceSingletonExports(
   namedExports: string[],
   importSource: string,


### PR DESCRIPTION
Close #863

Fixes eager workspace singleton named exports to read from the resolved shared module instance instead of re-exporting the local fallback, preventing duplicate shared state between host and remote.