### PR TITLE
fix: await pending share loads before entry import in bootstrap

### DIFF
--- a/integration/shared-cache-deferred-exports.test.ts
+++ b/integration/shared-cache-deferred-exports.test.ts
@@ -1,0 +1,248 @@
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+import type { ModuleFederationOptions } from '../src/utils/normalizeModuleFederationOptions';
+import { buildFixture, FIXTURES } from './helpers/build';
+import { findChunk, getAllChunkCode, getHtmlAsset } from './helpers/matchers';
+
+/**
+ * Integration tests for the pendingShareLoads / deferred export mechanism.
+ *
+ * Race condition: init() seeds __mfModuleCache.share with loadShare _exports
+ * whose getters return undefined until initPromise resolves + ESM import
+ * completes. When a cached exportModule exists at loadShare evaluation time
+ * (seeded by initHost -> runtime.loadShare), the else branch must apply exports
+ * synchronously — remotes have no bootstrap to await pendingShareLoads.
+ *
+ * The cache-miss branch (exportModule === undefined) defers via
+ * pendingShareLoads so the host bootstrap can await them.
+ */
+
+const SHARED_DEP = 'mock-shared-dep';
+
+const REMOTE_MF_OPTIONS = {
+  name: 'remoteApp',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './exposed': resolve(FIXTURES, 'shared-remote', 'exposed-module.js'),
+  },
+  shared: {
+    [SHARED_DEP]: { singleton: true, requiredVersion: '^1.0.0' },
+  },
+  dts: false,
+} satisfies Partial<ModuleFederationOptions>;
+
+const HOST_MF_OPTIONS = {
+  name: 'hostApp',
+  filename: 'remoteEntry.js',
+  hostInitInjectLocation: 'html',
+  remotes: {
+    remote1: {
+      name: 'remote1',
+      entry: 'http://localhost:3001/remoteEntry.js',
+      type: 'module',
+    },
+  },
+  shared: {
+    'mock-shared-dep': { singleton: true, requiredVersion: '^1.0.0' },
+  },
+  dts: false,
+} satisfies Partial<ModuleFederationOptions>;
+
+// ── Host bootstrap ─────────────────────────────────────────────────────────
+
+describe('host bootstrap pendingShareLoads', () => {
+  it('awaits Promise.all(pendingShareLoads) after initHost', async () => {
+    const output = await buildFixture({
+      fixture: 'basic-host',
+      mfOptions: HOST_MF_OPTIONS,
+    });
+
+    const bootstrapAsset = output.output.find(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+    expect(bootstrapAsset).toBeDefined();
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+
+    // Bootstrap must call initHost first
+    expect(bootstrapCode).toContain('initHost');
+    // Then await pendingShareLoads if any exist (guarded by if-check)
+    expect(bootstrapCode).toContain('pendingShareLoads');
+    expect(bootstrapCode).toContain('Promise.all');
+    // The pendingShareLoads await must come after initHost — no TLA
+    expect(bootstrapCode).not.toMatch(/^await /);
+  });
+
+  it('guards pendingShareLoads with existence check (remotes have no bootstrap)', async () => {
+    const output = await buildFixture({
+      fixture: 'basic-host',
+      mfOptions: HOST_MF_OPTIONS,
+    });
+
+    const bootstrapAsset = output.output.find(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+    expect(bootstrapAsset).toBeDefined();
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+
+    // Must use `if (__mfModuleCache.pendingShareLoads)` guard — not unconditional
+    // This ensures remotes (which never set pendingShareLoads) don't break.
+    expect(bootstrapCode).toMatch(/if\s*\(\s*__mfModuleCache\.pendingShareLoads\s*\)/);
+  });
+});
+
+// ── Remote side: import:false shares (host-provided) ───────────────────────
+
+describe('remote loadShare (import: false — host-provided)', () => {
+  const REMOTE_IMPORT_FALSE = {
+    ...REMOTE_MF_OPTIONS,
+    shared: {
+      [SHARED_DEP]: { import: false, singleton: true, requiredVersion: '^1.0.0' },
+    },
+  } satisfies Partial<ModuleFederationOptions>;
+
+  it('applies host-provided exports synchronously when cache is populated', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: REMOTE_IMPORT_FALSE,
+    });
+
+    const loadShareChunk = output.output
+      .filter((c) => c.type === 'chunk')
+      .find((c) => c.fileName.includes('__loadShare__'));
+
+    expect(loadShareChunk).toBeDefined();
+    const code = (loadShareChunk as { code: string }).code;
+
+    // Must use __mfApplyHostProvidedExports
+    expect(code).toContain('__mfApplyHostProvidedExports');
+
+    // The else branch (cache hit) must apply synchronously
+    // Structure: if (exportModule === void 0) initPromise.then(...) else { __mfApplyHostProvidedExports(exportModule) }
+    // Rollup/Vite versions differ on whether they keep braces or whitespace after `else`.
+    const elseMatch = code.match(/else\s*{?\s*__mfApplyHostProvidedExports\(exportModule\)/);
+    expect(elseMatch).not.toBeNull();
+
+    // Must NOT push to pendingShareLoads in the else branch
+    const elseIndex = code.lastIndexOf('else');
+    const afterElse = code.slice(elseIndex, elseIndex + 200);
+    expect(afterElse).not.toContain('pendingShareLoads');
+  });
+
+  it('does not unconditionally await pendingShareLoads in remote bootstrap', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: REMOTE_IMPORT_FALSE,
+    });
+
+    // Remote may have a bootstrap, but it must NOT unconditionally await
+    // pendingShareLoads. The host uses `if (__mfModuleCache.pendingShareLoads)`
+    // guard so remotes (which never set pendingShareLoads) don't crash.
+    const bootstrapAsset = output.output.find(
+      (item) =>
+        item.type === 'asset' &&
+        item.fileName.includes('mf-entry-bootstrap')
+    );
+    if (bootstrapAsset) {
+      const bootstrapCode = (
+        bootstrapAsset as unknown as { source: string }
+      ).source;
+      // Must be guarded with if-check, not bare await
+      if (bootstrapCode.includes('pendingShareLoads')) {
+        expect(bootstrapCode).toMatch(
+          /if\s*\(\s*__mfModuleCache\.pendingShareLoads\s*\)/
+        );
+      }
+    }
+  });
+});
+
+// ── Host side: import:true shares (workspace singleton) ─────────────────────
+
+describe('host loadShare (import: true — workspace singleton)', () => {
+  it('defers cache-miss exports via pendingShareLoads', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: REMOTE_MF_OPTIONS,
+    });
+
+    const loadShareChunk = output.output
+      .filter((c) => c.type === 'chunk')
+      .find((c) => c.fileName.includes('__loadShare__'));
+
+    expect(loadShareChunk).toBeDefined();
+    const code = (loadShareChunk as { code: string }).code;
+
+    // Cache-miss branch (if) must push to pendingShareLoads
+    expect(code).toContain('pendingShareLoads');
+    expect(code).toContain('initPromise');
+
+    // The if branch must push a promise to pendingShareLoads
+    // Structure: if (exportModule === void 0) (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(...))
+    const ifMatch = code.match(
+      /if\s*\(exportModule\s*===\s*void 0\)\s*\(__mfModuleCache\.pendingShareLoads\s*\||=\s*\[\]\)\.push\(/
+    );
+    expect(ifMatch).not.toBeNull();
+  });
+
+  it('applies lazy share exports synchronously when cache is populated', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: REMOTE_MF_OPTIONS,
+    });
+
+    const loadShareChunk = output.output
+      .filter((c) => c.type === 'chunk')
+      .find((c) => c.fileName.includes('__loadShare__'));
+
+    expect(loadShareChunk).toBeDefined();
+    const code = (loadShareChunk as { code: string }).code;
+
+    // Must use __mfApplyLazyShareExports
+    expect(code).toContain('__mfApplyLazyShareExports');
+
+    // The else branch (cache hit) must apply synchronously
+    // Structure: else { __mfApplyLazyShareExports(exportModule) }
+    // Rollup/Vite versions differ on whether they keep braces or whitespace after `else`.
+    const elseMatch = code.match(/else\s*{?\s*__mfApplyLazyShareExports\(exportModule\)/);
+    expect(elseMatch).not.toBeNull();
+
+    // Must NOT push to pendingShareLoads in the else branch
+    const elseIndex = code.lastIndexOf('else');
+    const afterElse = code.slice(elseIndex, elseIndex + 200);
+    expect(afterElse).not.toContain('pendingShareLoads');
+  });
+});
+
+// ── Cross-cutting: no TLAs ──────────────────────────────────────────────────
+
+describe('no top-level awaits in generated code', () => {
+  it('bootstrap uses async IIFE, not TLA', async () => {
+    const output = await buildFixture({
+      fixture: 'basic-host',
+      mfOptions: HOST_MF_OPTIONS,
+    });
+
+    const bootstrapAsset = output.output.find(
+      (item) =>
+        item.type === 'asset' &&
+        item.fileName.includes('mf-entry-bootstrap')
+    );
+    expect(bootstrapAsset).toBeDefined();
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+
+    // Bootstrap must use IIFE pattern: (async () => { ... })().then(...)
+    expect(bootstrapCode).toMatch(/\(\s*async\s*\(\)\s*=>/);
+    expect(bootstrapCode).toMatch(/\}\)\(\)\.then\(/);
+
+    // Must NOT have bare top-level await OUTSIDE the async IIFE.
+    // The IIFE pattern is: (async () => { ... })().then(...)
+    // Everything inside { } is fine — we only check outside.
+    const iifeStart = bootstrapCode.indexOf('async ()');
+    const iifeBodyStart = bootstrapCode.indexOf('{', iifeStart);
+    const iifeEnd = bootstrapCode.indexOf('})().then(');
+    const beforeIife = bootstrapCode.slice(0, iifeBodyStart);
+    const afterIife = iifeEnd >= 0 ? bootstrapCode.slice(iifeEnd + '})().then('.length) : '';
+    expect(beforeIife).not.toMatch(/^\s*await /m);
+    expect(afterIife).not.toMatch(/^\s*await /m);
+  });
+});

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -269,6 +269,65 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('globalThis.System.import(src)');
   });
 
+  it('awaits pendingShareLoads after initHost before importing entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-pending-'));
+    const htmlFile = path.join(tempDir, 'index.html');
+    fs.writeFileSync(
+      htmlFile,
+      [
+        '<!doctype html>',
+        '<html>',
+        '  <body>',
+        '    <script type="module" src="/src/main.tsx"></script>',
+        '  </body>',
+        '</html>',
+      ].join('\n')
+    );
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      'export const browserEntry = true;',
+      '/src/main.tsx'
+    )) as { code: string } | undefined;
+
+    expect(result?.code).toContain('__mfModuleCache.pendingShareLoads');
+    expect(result?.code).toContain('await Promise.all(__mfModuleCache.pendingShareLoads)');
+
+    const bootstrap = result?.code ?? '';
+    expect(bootstrap.indexOf('await initHost();')).toBeLessThan(
+      bootstrap.indexOf('__mfModuleCache.pendingShareLoads')
+    );
+    expect(bootstrap.indexOf('__mfModuleCache.pendingShareLoads')).toBeLessThan(
+      bootstrap.indexOf('.then(() => import(')
+    );
+  });
+
   it('wraps hydration entry fallback behind host init during build', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-build-hydration-'));
     const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -317,12 +317,24 @@ const addEntry = ({
     // (notably Safari/JavaScriptCore; V8 happens to win the race). Await the
     // module's exported `__tla` promise before reading `initHost`. No-op under
     // native TLA, where `__tla` is undefined.
+    // After initHost, also await any pending share loads queued by loadShare
+    // modules during init(). When init() seeds the cache with the loadShare
+    // module's _exports (getters returning undefined), the loadShare module
+    // defers real value assignment to an initPromise.then() + ESM import
+    // callback. Those promises are tracked in __mfModuleCache.pendingShareLoads
+    // so the bootstrap can await them before importing the entry, preventing
+    // a race where the entry renders before the ESM import resolves.
+    const pendingShareLoadsAwait = `
+  if (__mfModuleCache.pendingShareLoads) {
+    await Promise.all(__mfModuleCache.pendingShareLoads);
+  }`;
+
     const importCode = `
 (async () => {
   const __mfHostInit = await ${importExpression(initSrc)};
   await __mfHostInit.__tla;
   const { initHost } = __mfHostInit;
-  ${preloadBlock}
+  ${preloadBlock}${pendingShareLoadsAwait}
 })().then(() => ${importExpression(entrySrc)});
 `;
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1847,4 +1847,122 @@ describe('writePreBuildLibPath', () => {
       'export default __mfPrebuildExports.default ?? __mfPrebuildExports;'
     );
   });
+
+  // ── pendingShareLoads: deferred export assignment ──────────────────────────
+  //
+  // Race condition: init() seeds __mfModuleCache.share with the loadShare
+  // module's _exports (getters returning undefined until initPromise
+  // resolves + ESM import completes). When a cached exportModule exists at
+  // loadShare evaluation time (seeded by initHost -> runtime.loadShare), the
+  // else branch applies exports synchronously — the cache is already populated
+  // and remotes have no bootstrap to await pendingShareLoads.
+  // The undefined branch (cache miss) defers via pendingShareLoads for the
+  // host bootstrap to await.
+
+  it('applies lazy share exports synchronously in else branch (build mode)', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // The else branch (cached exportModule) must apply exports synchronously
+    // instead of deferring to pendingShareLoads (remotes have no bootstrap).
+    // There are two else branches: inner (SSR vs client) and outer (cached vs undefined).
+    // Find the outer else — the last one in the generated code.
+    const elseMatches = [...generatedCode.matchAll(/} else \{/g)];
+    const outerElse = elseMatches[elseMatches.length - 1];
+    expect(outerElse).toBeDefined();
+    const afterElse = generatedCode.slice(outerElse.index, outerElse.index + 200);
+    expect(afterElse).toContain('__mfApplyLazyShareExports');
+    expect(afterElse).not.toContain('pendingShareLoads');
+  });
+
+  it('pushes lazy share load to pendingShareLoads in client-side undefined branch (build mode)', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // The non-SSR undefined branch must also use pendingShareLoads
+    // instead of a bare initPromise.then()
+    expect(generatedCode).toContain('pendingShareLoads');
+    expect(generatedCode).toContain('initPromise.then');
+
+    // Must use the ||= pattern for lazy initialization
+    expect(generatedCode).toContain('||= []');
+  });
+
+  it('does not use bare initPromise.then without pendingShareLoads in build mode', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // Every initPromise.then() must be wrapped in a pendingShareLoads push.
+    const pushCount = (generatedCode.match(/pendingShareLoads/g) || []).length;
+    const thenCount = (generatedCode.match(/initPromise\.then/g) || []).length;
+    expect(pushCount).toBeGreaterThanOrEqual(thenCount);
+  });
+
+  it('pushes host-provided share load to pendingShareLoads in else branch (import: false)', () => {
+    const pkg = 'host-only-dep';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // For import:false shares using generateDeferredHostProvidedExports,
+    // the else branch (cache already populated) must apply exports synchronously
+    expect(generatedCode).toContain('__mfApplyHostProvidedExports');
+    expect(generatedCode).toContain('__mfModuleCache.share');
+    expect(generatedCode).toContain('initPromise.then');
+  });
 });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -695,13 +695,13 @@ function generateLazyWorkspaceSingletonExports(
           : `if (import.meta.env.SSR) {
         ${applyLocalFallback}
       } else {
-        initPromise.then(() =>
+        (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() =>
           import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
             exportModule = __mfNormalizeShareModule(mod);
             __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);
             __mfApplyLazyShareExports(exportModule);
           })
-        );
+        ));
       }`
       }
     } else {
@@ -761,13 +761,13 @@ function generateDeferredHostProvidedExports(
     };
     let exportModule = __mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor});
     if (exportModule === undefined) {
-      initPromise.then(() => {
+      (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() => {
         exportModule = __mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor});
         if (exportModule === undefined) {
           throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.");
         }
         __mfApplyHostProvidedExports(exportModule);
-      });
+      }));
     } else {
       __mfApplyHostProvidedExports(exportModule);
     }


### PR DESCRIPTION
The bootstrap code generated by pluginAddEntry calls initHost() then immediately imports the entry module. However, some loadShare modules (workspace singletons with lazy fallback, and import:false modules) do not populate their exports synchronously during init().

Instead they schedule an initPromise.then() callback that dynamically imports the real module and assigns exports asynchronously. The bootstrap never waited for these callbacks to complete.

This means the entry module (and any code it transitively runs) could access shared exports (e.g. react, react-dom) before the async initPromise.then() + import() chain resolved, reading undefined.

The fix tracks these deferred share load promises in __mfModuleCache.pendingShareLoads. Two code paths are wrapped:

1. generateLazyWorkspaceSingletonExports (virtualShared_preBuild.ts): the client-side initPromise.then(() => import(...)) that assigns workspace singleton exports after the ESM import resolves.

2. generateDeferredHostProvidedExports (virtualShared_preBuild.ts): the initPromise.then() that waits for the host runtime to provide a shared module the remote does not have locally (import: false).

The bootstrap in pluginAddEntry.ts now awaits
Promise.all(__mfModuleCache.pendingShareLoads) after initHost() and before importing the entry.