### PR TITLE
fix(virtualExposes): broaden CSS dedup selector to match any existing stylesheet

### DIFF
--- a/src/virtualModules/__tests__/virtualExposes.test.ts
+++ b/src/virtualModules/__tests__/virtualExposes.test.ts
@@ -94,7 +94,7 @@ describe('virtualExposes', () => {
         }),
       },
       querySelector: vi.fn((selector: string) => {
-        const href = selector.match(/data-mf-href="([^"]+)"/)?.[1];
+        const href = selector.match(/href="([^"]+)"/)?.[1];
         return href ? (links.get(href) ?? null) : null;
       }),
       createElement: vi.fn(() => ({

--- a/src/virtualModules/virtualExposes.ts
+++ b/src/virtualModules/virtualExposes.ts
@@ -46,8 +46,12 @@ export function generateExposes(options: NormalizedModuleFederationOptions) {
           }
           injectedCssHrefs.add(href);
 
+          // Check for any existing stylesheet with the same href, not just
+          // MF-injected ones. This prevents duplicate <link> tags when Vite's
+          // own CSS module injection or MF runtime's createLink has already
+          // created a <link rel="stylesheet"> for the same URL.
           const existingLink = document.querySelector(
-            \`link[rel="stylesheet"][data-mf-href="\${href}"]\`
+            \`link[rel="stylesheet"][href="\${href}"]\`
           );
           if (existingLink) {
             return Promise.resolve();
@@ -57,7 +61,6 @@ export function generateExposes(options: NormalizedModuleFederationOptions) {
             const link = document.createElement("link");
             link.rel = "stylesheet";
             link.href = href;
-            link.setAttribute("data-mf-href", href);
             link.onload = () => resolve();
             link.onerror = () => reject(new Error(\`[Module Federation] Failed to load CSS asset: \${href}\`));
             document.head.appendChild(link);


### PR DESCRIPTION
The dedup check in injectCssAssets only matched links with the data-mf-href attribute, meaning stylesheets injected by Vite's own CSS module system or MF runtime's createLink were invisible to the check. This caused duplicate <link> tags for the same CSS URL.

Replace the selector from link[rel="stylesheet"][data-mf-href="..."] to link[rel="stylesheet"][href="..."] so it detects any existing stylesheet with the same URL regardless of who created it. Remove the data-mf-href attribute from newly created links since it is no longer needed for dedup.

---

I had a case of both code paths triggering causing duplicate css, while trying to do webapp perf optimizations. This has resolved that.