### PR TITLE
fix: stop build load hook from reading arbitrary filesystem paths

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -394,6 +394,17 @@ describe('module-federation-esm-shims', () => {
     );
   });
 
+  it('returns null when build load hook cannot resolve a virtual module', () => {
+    const plugin = getEsmShimsPlugin();
+    runConfig(plugin, {} as ConfigPluginContext, { build: {} }, { command: 'build', mode: 'test' });
+    const result = callHook(
+      plugin.load,
+      {} as any,
+      `/etc/passwd${LOAD_SHARE_TAG}fake${LOAD_SHARE_TAG}.js`
+    );
+    expect(result).toBeNull();
+  });
+
   it('filters federation control chunks from js dynamic modulepreload deps', () => {
     const plugin = getEsmShimsPlugin();
     const config: any = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -963,7 +963,8 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       load(id: string) {
         if (id.includes(LOAD_SHARE_TAG) || id.includes(LOAD_REMOTE_TAG)) {
           const virtualModule = VirtualModule.findById(id);
-          let code = virtualModule?.code ?? readFileSync(id, 'utf-8');
+          if (!virtualModule?.code) return null;
+          let code = virtualModule.code;
 
           const environmentName = (this as { environment?: { name?: string } }).environment?.name;
           // Vite 5-7 SSR builds do not expose `this.environment`, so fall back to root


### PR DESCRIPTION
## Summary

Stops the build-time federation `load` hook from falling back to `readFileSync(id)` when a `loadShare` or `loadRemote` virtual module cannot be found in the in-memory virtual module registry.

Instead, the hook now returns `null` and lets Vite/Rollup continue normal resolution.

## Why

The hook currently checks for federation marker tags in the module id and then reads the id from disk if `VirtualModule.findById(id)` does not return code.

That fallback is too broad: a crafted id containing a federation marker can cause the build hook to attempt reading an arbitrary filesystem path. Missing virtual federation modules should not be resolved by reading from disk.

## Changes

- Return `null` when a matching `loadShare`/`loadRemote` id is not a registered virtual module.
- Keep the existing transformation behavior for valid registered virtual modules.
- Add a regression test that verifies a crafted path-like id is not read and returns `null`.

## Validation

- `./node_modules/.bin/vitest run src/__tests__/index.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
