### PR TITLE
fix: unwrap namespace.default in prebuild named-exports branch

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1848,6 +1848,22 @@ describe('writePreBuildLibPath', () => {
     );
   });
 
+  // Regression: the namedExports branch previously emitted
+  // `export default __mfPrebuildExports` (the namespace object) instead of
+  // unwrapping `.default`. That broke CJS-interop `import React from 'react'`
+  // consumers, whose real default lives at `namespace.default`.
+  // Fix: emit `namespace.default ?? namespace`, matching the fallback branch.
+  it('unwraps namespace.default in the named-exports branch for CJS-interop consumers', () => {
+    writePreBuildLibPath('mock-package-with-reserved');
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'export default __mfPrebuildNamespace.default ?? __mfPrebuildNamespace;'
+    );
+    expect(generatedCode).not.toMatch(/export default __mfPrebuildExports;\s*$/m);
+  });
+
   // ── pendingShareLoads: deferred export assignment ──────────────────────────
   //
   // Race condition: init() seeds __mfModuleCache.share with the loadShare

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -530,7 +530,7 @@ export function writePreBuildLibPath(pkg: string, shareItem?: ShareItem) {
     const __mfPrebuildExports = __mfPrebuildNamespace;
     ${declarations}
     ${namedExportLine}
-    export default __mfPrebuildExports;
+    export default __mfPrebuildNamespace.default ?? __mfPrebuildNamespace;
   `,
       true
     );


### PR DESCRIPTION
## Summary

Fixes a CJS-interop default-export bug in the `writePreBuildLibPath` codegen for shared modules.

The branch selected when a shared package has any named exports emits:

```js
import * as __mfPrebuildNamespace from '<pkg>';
const __mfPrebuildExports = __mfPrebuildNamespace;
...
export default __mfPrebuildExports;   // ← the raw namespace object
```

But the three sibling branches in the same function — `react/jsx-runtime`, `react/jsx-dev-runtime`, and the fallback for packages with no named exports — all use `namespace.default ?? namespace`. This was inconsistent codegen and caused a real interop regression for consumers.

## Impact

For any shared package that exports named symbols **and** has a CJS default via ESM interop (`react`, `react-dom`, `styled-components`, `react-router`, etc.), `import Pkg from 'pkg'` through the prebuild shim returned the module namespace object instead of the real default export.

Concretely, when a host prebundles a shared `react` this way, downstream consumers see `Pkg.createElement` as `undefined` because the default they got was `{ default: React, useState, useEffect, ... }` rather than `React` itself. This tends to surface as `Cannot read properties of undefined (reading 'createElement')` from prebundled shared React.

## Fix

Emit `__mfPrebuildNamespace.default ?? __mfPrebuildNamespace` in the named-exports branch, matching the other three branches.

## Tests

Added a regression test in `src/virtualModules/__tests__/virtualShared_preBuild.test.ts` that verifies the emitted code for a package with named exports (a) contains `export default __mfPrebuildNamespace.default ?? __mfPrebuildNamespace;` and (b) does not emit the old `export default __mfPrebuildExports;` line.

- `pnpm test` — 598/598 passing (was 597/597; +1 new test).
- `pnpm fmt.check` / `pnpm typecheck` clean.
- Verified the new test fails against `main` without the source fix and passes with it.
