### PR TITLE
feat(ssrEntryLoader): manifest-version-keyed caching, revalidate(), and opt-in vm share-scope strategy

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -34,7 +34,7 @@ function makeFetchMock(responses: Record<string, FetchEntry>) {
   });
 }
 
-async function freshLoader() {
+async function freshLoaderModule() {
   vi.resetModules();
   vi.mock('path', () => ({
     default: {
@@ -58,7 +58,11 @@ async function freshLoader() {
     default: { createRequire: vi.fn() },
     createRequire: vi.fn(),
   }));
-  const { default: factory } = await import('../ssrEntryLoader');
+  return await import('../ssrEntryLoader');
+}
+
+async function freshLoader() {
+  const { default: factory } = await freshLoaderModule();
   return factory;
 }
 
@@ -1118,6 +1122,157 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
       } else {
         process.env.NODE_ENV = previousNodeEnv;
       }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revalidation — maxAgeMs and revalidate()
+// ---------------------------------------------------------------------------
+
+describe('ssrEntryLoaderPlugin — revalidation', () => {
+  const entryUrl = 'http://localhost:5001/remoteEntry.js';
+  const manifestUrl = 'http://localhost:5001/mf-manifest.json';
+  const ssrEntryUrl = 'http://localhost:5001/remoteEntry.ssr.js';
+
+  // The ModuleRunner describe above doUnmocks path/fs/module, which removes
+  // the vi.mock registrations for every later dynamic import — re-register
+  // with doMock per test here so the loader (and the fs assertions) see mocks.
+  async function freshMockedLoaderModule() {
+    vi.resetModules();
+    vi.doMock('path', () => ({
+      default: {
+        join: (...p: string[]) => p.join('/'),
+        dirname: (p: string) => p.replace(/\/[^/]+$/, ''),
+      },
+      join: (...p: string[]) => p.join('/'),
+      dirname: (p: string) => p.replace(/\/[^/]+$/, ''),
+    }));
+    vi.doMock('fs', () => ({
+      default: { mkdirSync: vi.fn(), writeFileSync: vi.fn(), rmSync: vi.fn() },
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      rmSync: vi.fn(),
+    }));
+    vi.doMock('module', () => ({
+      default: { createRequire: vi.fn() },
+      createRequire: vi.fn(),
+    }));
+    return await import('../ssrEntryLoader');
+  }
+
+  function makeManifest(buildVersion: string) {
+    return {
+      metaData: {
+        buildInfo: { buildVersion },
+        ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '', type: 'module' },
+      },
+    };
+  }
+
+  function makeResponses(buildVersion: string, entryBody: string): Record<string, FetchEntry> {
+    return {
+      [manifestUrl]: { ok: true, json: makeManifest(buildVersion) },
+      [ssrEntryUrl]: {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+        text: entryBody,
+      },
+    };
+  }
+
+  it('re-fetches the manifest when the cached resolution is older than maxAgeMs', async () => {
+    const responses = makeResponses('1.0.0', 'export async function init() {}');
+    const fetch = makeFetchMock(responses);
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const { default: factory } = await freshMockedLoaderModule();
+    const plugin = factory({ maxAgeMs: 0 });
+
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+
+    const manifestFetches = fetch.mock.calls.filter(([url]) => url === manifestUrl);
+    expect(manifestFetches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not re-fetch the SSR entry when the manifest version is unchanged', async () => {
+    const responses = makeResponses('1.0.0', 'export async function init() {}');
+    global.fetch = makeFetchMock(responses) as unknown as typeof globalThis.fetch;
+    const { default: factory } = await freshMockedLoaderModule();
+    const fsMock = await import('fs');
+    const plugin = factory({ maxAgeMs: 0 });
+
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+    const writesAfterFirst = (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.length;
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+
+    expect((fsMock.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      writesAfterFirst
+    );
+  });
+
+  it('re-fetches the SSR entry when the manifest version changes', async () => {
+    const responses = makeResponses('1.0.0', 'export const marker = "v1";');
+    global.fetch = makeFetchMock(responses) as unknown as typeof globalThis.fetch;
+    const { default: factory } = await freshMockedLoaderModule();
+    const fsMock = await import('fs');
+    const plugin = factory({ maxAgeMs: 0 });
+
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+
+    Object.assign(responses, makeResponses('2.0.0', 'export const marker = "v2";'));
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+
+    const writes = (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mock.calls;
+    expect(writes.length).toBeGreaterThanOrEqual(2);
+    expect(String(writes[writes.length - 1][1])).toContain('v2');
+  });
+
+  it('revalidate() drops caches so the next load re-resolves', async () => {
+    const responses = makeResponses('1.0.0', 'export const marker = "v1";');
+    global.fetch = makeFetchMock(responses) as unknown as typeof globalThis.fetch;
+    const loader = await freshMockedLoaderModule();
+    const fsMock = await import('fs');
+    const plugin = loader.default();
+
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+
+    Object.assign(responses, makeResponses('2.0.0', 'export const marker = "v2";'));
+    // Without revalidation the loader would reuse its cached resolution.
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+    const writesBefore = (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    loader.revalidate(entryUrl);
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+
+    const writes = (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mock.calls;
+    expect(writes.length).toBeGreaterThan(writesBefore);
+    expect(String(writes[writes.length - 1][1])).toContain('v2');
+  });
+
+  it('revalidate() without arguments clears everything and resets runtime module caches', async () => {
+    const responses = makeResponses('1.0.0', 'export const marker = "v1";');
+    const fetch = makeFetchMock(responses);
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const loader = await freshMockedLoaderModule();
+    const plugin = loader.default();
+
+    await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+    const manifestFetchesBefore = fetch.mock.calls.filter(([url]) => url === manifestUrl).length;
+
+    const moduleCache = new Map([['remote', {}]]);
+    (globalThis as Record<string, unknown>).__FEDERATION__ = {
+      __INSTANCES__: [{ moduleCache }],
+    };
+    try {
+      loader.revalidate();
+      expect(moduleCache.size).toBe(0);
+
+      await plugin.loadEntry!({ remoteInfo: { name: 'r', entry: entryUrl } });
+      const manifestFetchesAfter = fetch.mock.calls.filter(([url]) => url === manifestUrl).length;
+      expect(manifestFetchesAfter).toBeGreaterThan(manifestFetchesBefore);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__FEDERATION__;
     }
   });
 });

--- a/src/utils/__tests__/ssrVmStrategy.test.ts
+++ b/src/utils/__tests__/ssrVmStrategy.test.ts
@@ -1,0 +1,234 @@
+/**
+ * ssrVmStrategy tests.
+ *
+ * The vm strategy depends on the experimental `vm.SourceTextModule` /
+ * `vm.SyntheticModule` APIs, which only exist when Node runs with
+ * `--experimental-vm-modules` (enabled through vitest's execArgv option).
+ * Every evaluation test is guarded with skipIf so the suite still passes when
+ * the flag is unavailable; the fallback test asserts the graceful null return
+ * in that case.
+ *
+ * Like ssrEntryLoader, ssrVmStrategy keeps module-level caches, so tests use
+ * vi.resetModules() + dynamic import for a fresh instance.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const hasVmModules = await (async () => {
+  const vm = (await import('vm')) as { SourceTextModule?: unknown };
+  return typeof vm.SourceTextModule === 'function';
+})();
+
+type FetchEntry = { ok: boolean; status?: number; statusText?: string; text?: string };
+
+function makeFetchMock(responses: Record<string, FetchEntry>) {
+  return vi.fn(async (url: string) => {
+    const entry = responses[url] ?? { ok: false };
+    return {
+      ok: entry.ok,
+      status: entry.status ?? (entry.ok ? 200 : 404),
+      statusText: entry.statusText ?? (entry.ok ? 'OK' : 'Not Found'),
+      text: async () => entry.text ?? '',
+    };
+  });
+}
+
+async function freshStrategy() {
+  vi.resetModules();
+  return await import('../ssrVmStrategy');
+}
+
+const baseOptions = { resolvedShared: {}, shareScopeName: 'default', versionKey: 'v1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete (globalThis as Record<string, unknown>).__FEDERATION__;
+});
+
+describe('ssrVmStrategy — availability', () => {
+  it('reports availability matching the runtime environment', async () => {
+    const strategy = await freshStrategy();
+    expect(await strategy.isVmStrategyAvailable()).toBe(hasVmModules);
+  });
+
+  it.skipIf(hasVmModules)('loadViaVmStrategy returns null without SourceTextModule', async () => {
+    const strategy = await freshStrategy();
+    const result = await strategy.loadViaVmStrategy('http://localhost:5001/remoteEntry.ssr.js', {
+      ...baseOptions,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe.skipIf(!hasVmModules)('ssrVmStrategy — module graph evaluation', () => {
+  it('evaluates an entry with relative imports resolved over HTTP', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { msg } from "./chunks/chunk.js"; export const got = msg;',
+      },
+      'http://localhost:5001/chunks/chunk.js': {
+        ok: true,
+        text: 'export const msg = "hello-from-chunk";',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions }
+    )) as { got: string };
+
+    expect(namespace.got).toBe('hello-from-chunk');
+  });
+
+  it('links bare shared imports through the host federation share scope', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text:
+          'import lib, { v } from "shared-lib";' + 'export const val = v; export const def = lib;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+
+    const loadShare = vi.fn(async () => () => ({ v: 42, default: { name: 'host-shared' } }));
+    (globalThis as Record<string, unknown>).__FEDERATION__ = {
+      __INSTANCES__: [{ options: { shared: { 'shared-lib': {} } }, loadShare }],
+    };
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions }
+    )) as { val: number; def: { name: string } };
+
+    expect(loadShare).toHaveBeenCalledWith('shared-lib');
+    expect(namespace.val).toBe(42);
+    expect(namespace.def.name).toBe('host-shared');
+  });
+
+  it('skips instances that do not declare the package as shared', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { v } from "shared-lib"; export const val = v;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+
+    const wrongLoadShare = vi.fn(async () => () => ({ v: -1 }));
+    const rightLoadShare = vi.fn(async () => () => ({ v: 7 }));
+    (globalThis as Record<string, unknown>).__FEDERATION__ = {
+      __INSTANCES__: [
+        { options: { shared: { 'other-lib': {} } }, loadShare: wrongLoadShare },
+        { options: { shared: { 'shared-lib': {} } }, loadShare: rightLoadShare },
+      ],
+    };
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions }
+    )) as { val: number };
+
+    expect(wrongLoadShare).not.toHaveBeenCalled();
+    expect(namespace.val).toBe(7);
+  });
+
+  it('falls back to the resolvedShared file map when no instance shares the package', async () => {
+    const { mkdtempSync, writeFileSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const dir = mkdtempSync(join(tmpdir(), 'mf-vm-shared-'));
+    const sharedFile = join(dir, 'file-shared.mjs');
+    writeFileSync(sharedFile, 'export const v = "from-file";', 'utf8');
+
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { v } from "file-shared"; export const val = v;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions, resolvedShared: { 'file-shared': sharedFile } }
+    )) as { val: string };
+
+    expect(namespace.val).toBe('from-file');
+  });
+
+  it('neutralizes Vite preload-helper imports before evaluation', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text:
+          'import { _ as __vitePreload } from "./assets/preload-helper-abc.js";' +
+          'export const r = await __vitePreload(() => "preloaded");',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions }
+    )) as { r: string };
+
+    expect(namespace.r).toBe('preloaded');
+  });
+
+  it('throws HTTP status details for non-ok module responses', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { t } from "./missing.js"; export const val = t;',
+      },
+      'http://localhost:5001/missing.js': {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: 'missing chunk',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const strategy = await freshStrategy();
+
+    await expect(
+      strategy.loadViaVmStrategy('http://localhost:5001/remoteEntry.ssr.js', { ...baseOptions })
+    ).rejects.toThrow(
+      'Failed to fetch SSR module "http://localhost:5001/missing.js": 500 Internal Server Error'
+    );
+  });
+
+  it('keys the module cache by versionKey so redeploys load fresh code', async () => {
+    const responses: Record<string, FetchEntry> = {
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'export const marker = "v1";',
+      },
+    };
+    global.fetch = makeFetchMock(responses) as unknown as typeof globalThis.fetch;
+    const strategy = await freshStrategy();
+    const entryUrl = 'http://localhost:5001/remoteEntry.ssr.js';
+
+    const first = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      versionKey: 'v1',
+    })) as { marker: string };
+    expect(first.marker).toBe('v1');
+
+    responses[entryUrl] = { ok: true, text: 'export const marker = "v2";' };
+
+    // Same version key → cached namespace, no re-fetch.
+    const cached = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      versionKey: 'v1',
+    })) as { marker: string };
+    expect(cached.marker).toBe('v1');
+
+    // New version key → fresh fetch and evaluation.
+    const next = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      versionKey: 'v2',
+    })) as { marker: string };
+    expect(next.marker).toBe('v2');
+  });
+});

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -143,6 +143,7 @@ interface RemoteInfo {
 interface ManifestMetaData {
   ssrRemoteEntry?: { name: string; path: string; type: string };
   remoteEntry?: { name: string; path: string; type: string };
+  buildInfo?: { buildVersion?: string };
   publicPath?: string;
   getPublicPath?: string;
 }
@@ -151,8 +152,40 @@ interface Manifest {
   metaData?: ManifestMetaData;
 }
 
-// Process-level cache: remote entry URL → resolved SSR entry
-const ssrEntryCache = new Map<string, Promise<{ url: string; type: string } | null>>();
+/**
+ * Version key for a resolved SSR entry. Derived from the remote's manifest
+ * content so a redeploy at the same URL produces a different key, which in
+ * turn produces different temp-file names — busting both our caches and
+ * Node's ESM module cache. Convention-resolved entries (no manifest) get a
+ * stable placeholder key and cannot be revalidated automatically.
+ */
+const UNVERSIONED = 'unversioned';
+
+// FNV-1a — cheap, dependency-free, stable across processes. Not cryptographic;
+// only used to key caches and temp file names.
+function hashString(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function computeManifestVersionKey(manifest: Manifest): string {
+  const buildVersion = manifest.metaData?.buildInfo?.buildVersion;
+  const contentHash = hashString(JSON.stringify(manifest));
+  return buildVersion ? `${buildVersion}-${contentHash}` : contentHash;
+}
+
+interface SsrEntryCacheRecord {
+  promise: Promise<SsrEntryCandidate | null>;
+  resolvedAt: number;
+}
+
+// Process-level cache: remote entry URL → resolved SSR entry (+ resolution time
+// so `maxAgeMs` can trigger revalidation against the remote's manifest).
+const ssrEntryCache = new Map<string, SsrEntryCacheRecord>();
 // Dedupe manifest fetches when multiple entry URLs resolve to the same manifest.
 const manifestFetchCache = new Map<string, Promise<Manifest | null>>();
 
@@ -168,9 +201,10 @@ interface EntryContext {
 interface SsrEntryCandidate {
   url: string;
   type: string;
+  versionKey: string;
 }
 
-class SsrEntryHttpError extends Error {
+export class SsrEntryHttpError extends Error {
   constructor(
     readonly url: string,
     readonly status: number,
@@ -251,7 +285,11 @@ function resolveSSREntryUrl(manifest: Manifest, manifestUrl: string): SsrEntryCa
   const base = manifestUrl.replace(/\/[^/]+$/, '/');
   const entryPath = (meta.ssrRemoteEntry.path || '') + meta.ssrRemoteEntry.name;
   const url = new URL(entryPath, base).href;
-  return { url, type: meta.ssrRemoteEntry.type || 'module' };
+  return {
+    url,
+    type: meta.ssrRemoteEntry.type || 'module',
+    versionKey: computeManifestVersionKey(manifest),
+  };
 }
 
 /**
@@ -260,10 +298,7 @@ function resolveSSREntryUrl(manifest: Manifest, manifestUrl: string): SsrEntryCa
  * remoteEntry.js → /__mf_ssr__/remoteEntry.ssr.js (dev middleware)
  * Returns the first URL that responds with a 200.
  */
-async function headCheckSsrEntry(candidate: {
-  url: string;
-  type: string;
-}): Promise<SsrEntryCandidate | null> {
+async function headCheckSsrEntry(candidate: SsrEntryCandidate): Promise<SsrEntryCandidate | null> {
   try {
     const res = await fetch(candidate.url, { method: 'HEAD' });
     const ct = res.headers.get('content-type') ?? '';
@@ -308,12 +343,17 @@ function buildSsrEntryCandidates(
     candidates.push({
       url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
       type: 'module',
+      versionKey: UNVERSIONED,
     });
   }
 
   candidates.push(
-    { url: `${base}.ssr.js`, type: 'module' },
-    { url: `${remoteOrigin}/__mf_ssr__/${filename}.ssr.js`, type: 'module' }
+    { url: `${base}.ssr.js`, type: 'module', versionKey: UNVERSIONED },
+    {
+      url: `${remoteOrigin}/__mf_ssr__/${filename}.ssr.js`,
+      type: 'module',
+      versionKey: UNVERSIONED,
+    }
   );
 
   return candidates;
@@ -331,7 +371,7 @@ async function resolveFirstReachableCandidate(
 
 async function resolveSSREntryImpl(remoteEntryUrl: string): Promise<SsrEntryCandidate | null> {
   if (isSsrEntry(remoteEntryUrl)) {
-    return { url: remoteEntryUrl, type: 'module' };
+    return { url: remoteEntryUrl, type: 'module', versionKey: UNVERSIONED };
   }
 
   // For JS entries, probe the dedicated server build before fetching the manifest.
@@ -341,6 +381,7 @@ async function resolveSSREntryImpl(remoteEntryUrl: string): Promise<SsrEntryCand
     const fromServerBuild = await headCheckSsrEntry({
       url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
       type: 'module',
+      versionKey: UNVERSIONED,
     });
     if (fromServerBuild) return fromServerBuild;
   }
@@ -355,11 +396,91 @@ async function resolveSSREntryImpl(remoteEntryUrl: string): Promise<SsrEntryCand
   );
 }
 
-async function getSSREntry(remoteEntryUrl: string): Promise<SsrEntryCandidate | null> {
-  if (!ssrEntryCache.has(remoteEntryUrl)) {
-    ssrEntryCache.set(remoteEntryUrl, resolveSSREntryImpl(remoteEntryUrl));
+function setSsrEntryCache(remoteEntryUrl: string): SsrEntryCacheRecord {
+  const record: SsrEntryCacheRecord = {
+    promise: resolveSSREntryImpl(remoteEntryUrl),
+    resolvedAt: Date.now(),
+  };
+  ssrEntryCache.set(remoteEntryUrl, record);
+  return record;
+}
+
+async function getSSREntry(
+  remoteEntryUrl: string,
+  maxAgeMs?: number
+): Promise<SsrEntryCandidate | null> {
+  const cached = ssrEntryCache.get(remoteEntryUrl);
+  if (!cached) return setSsrEntryCache(remoteEntryUrl).promise;
+
+  const isStale =
+    typeof maxAgeMs === 'number' && maxAgeMs >= 0 && Date.now() - cached.resolvedAt >= maxAgeMs;
+  if (!isStale) return cached.promise;
+
+  // Stale: re-fetch the manifest and re-resolve. If the version key changed
+  // (remote redeployed at the same URL), the new key flows into temp-file
+  // names, so the fresh entry is imported instead of Node's cached module.
+  const previous = await cached.promise.catch(() => null);
+  manifestFetchCache.delete(getManifestUrl(remoteEntryUrl));
+  const record = setSsrEntryCache(remoteEntryUrl);
+  const next = await record.promise.catch(() => null);
+
+  if (previous && next && previous.versionKey !== next.versionKey) {
+    dropRemoteCaches(remoteEntryUrl);
   }
-  return ssrEntryCache.get(remoteEntryUrl)!;
+  return record.promise;
+}
+
+/**
+ * Drop per-remote caches after a version change so old artifacts stop being
+ * reused. Temp-file cache keys hold SSR entry/chunk URLs (not the browser
+ * entry URL), so scope the invalidation by origin.
+ */
+function dropRemoteCaches(remoteEntryUrl: string): void {
+  let origin: string;
+  try {
+    origin = new URL(remoteEntryUrl).origin;
+  } catch {
+    return;
+  }
+  for (const key of tempFileCache.keys()) {
+    const url = key.slice(key.indexOf('::') + 2);
+    if (url.startsWith(origin)) tempFileCache.delete(key);
+  }
+}
+
+/**
+ * Drop the loader's caches so the next `loadEntry` re-resolves and re-fetches
+ * remote SSR entries. Pass a remote entry URL to scope the invalidation to one
+ * remote; call with no arguments to invalidate everything.
+ *
+ * Note: the MF runtime keeps its own container/module caches per federation
+ * instance. This function best-effort clears the module caches of all global
+ * federation instances so re-renders load fresh remote modules, but hosts that
+ * hold direct references to previously loaded modules keep those references.
+ */
+export function revalidate(remoteEntryUrl?: string): void {
+  if (remoteEntryUrl) {
+    ssrEntryCache.delete(remoteEntryUrl);
+    manifestFetchCache.delete(getManifestUrl(remoteEntryUrl));
+    dropRemoteCaches(remoteEntryUrl);
+  } else {
+    ssrEntryCache.clear();
+    manifestFetchCache.clear();
+    tempFileCache.clear();
+  }
+
+  const federation = (
+    globalThis as {
+      __FEDERATION__?: { __INSTANCES__?: Array<{ moduleCache?: Map<string, unknown> }> };
+    }
+  ).__FEDERATION__;
+  for (const instance of federation?.__INSTANCES__ ?? []) {
+    try {
+      instance?.moduleCache?.clear?.();
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -395,33 +516,11 @@ async function getSSRCacheDir(): Promise<string> {
   return ssrCacheDirPromise;
 }
 
-function transformSsrCode(code: string, base: string, sharedPkgMap?: Map<string, string>): string {
-  // Rewrite relative specifiers to absolute HTTP URLs.
-  code = code.replace(
-    /((?:from|export\s*\*\s*from)\s*)(["'`])(\.\.?\/[^"'`\s][^"'`]*)["'`]/g,
-    (_m, prefix, _q, specifier) => `${prefix}"${new URL(specifier, base).href}"`
-  );
-  code = code.replace(
-    /(import\s*)(["'`])(\.\.?\/[^"'`\s][^"'`]*)["'`]/g,
-    (_m, prefix, _q, specifier) => `${prefix}"${new URL(specifier, base).href}"`
-  );
-  code = code.replace(
-    /(import\s*\(\s*)(["'`])(\.\.?\/[^"'`\s][^"'`]*)["'`](\s*\))/g,
-    (_m, prefix, _q, specifier, suffix) => `${prefix}"${new URL(specifier, base).href}"${suffix}`
-  );
-  // Rewrite bare shared package specifiers to absolute file:// paths so all
-  // temp-file modules use the same physical module instance as the host app.
-  // Without this, Node resolves bare "react" from the workspace root which
-  // may be a different version than the one bundled into the host's server.
-  if (sharedPkgMap && sharedPkgMap.size > 0) {
-    code = code.replace(
-      /(?:from|import\s*\()\s*(["'`])([^"'`./][^"'`]*)["'`]/g,
-      (m, _q, specifier) => {
-        const resolved = sharedPkgMap.get(specifier);
-        return resolved ? m.replace(specifier, `file://${resolved}`) : m;
-      }
-    );
-  }
+/**
+ * Neutralize browser-only preload machinery in Vite/Rolldown output so the
+ * code can evaluate in Node. Shared by the temp-file and vm strategies.
+ */
+export function neutralizeBrowserPreloadHelpers(code: string): string {
   // Replace Vite's preload-helper (uses document) with a server no-op,
   // preserving the local binding name so call-sites still work.
   code = code.replace(
@@ -449,6 +548,36 @@ function transformSsrCode(code: string, base: string, sharedPkgMap?: Map<string,
   return code;
 }
 
+function transformSsrCode(code: string, base: string, sharedPkgMap?: Map<string, string>): string {
+  // Rewrite relative specifiers to absolute HTTP URLs.
+  code = code.replace(
+    /((?:from|export\s*\*\s*from)\s*)(["'`])(\.\.?\/[^"'`\s][^"'`]*)["'`]/g,
+    (_m, prefix, _q, specifier) => `${prefix}"${new URL(specifier, base).href}"`
+  );
+  code = code.replace(
+    /(import\s*)(["'`])(\.\.?\/[^"'`\s][^"'`]*)["'`]/g,
+    (_m, prefix, _q, specifier) => `${prefix}"${new URL(specifier, base).href}"`
+  );
+  code = code.replace(
+    /(import\s*\(\s*)(["'`])(\.\.?\/[^"'`\s][^"'`]*)["'`](\s*\))/g,
+    (_m, prefix, _q, specifier, suffix) => `${prefix}"${new URL(specifier, base).href}"${suffix}`
+  );
+  // Rewrite bare shared package specifiers to absolute file:// paths so all
+  // temp-file modules use the same physical module instance as the host app.
+  // Without this, Node resolves bare "react" from the workspace root which
+  // may be a different version than the one bundled into the host's server.
+  if (sharedPkgMap && sharedPkgMap.size > 0) {
+    code = code.replace(
+      /(?:from|import\s*\()\s*(["'`])([^"'`./][^"'`]*)["'`]/g,
+      (m, _q, specifier) => {
+        const resolved = sharedPkgMap.get(specifier);
+        return resolved ? m.replace(specifier, `file://${resolved}`) : m;
+      }
+    );
+  }
+  return neutralizeBrowserPreloadHelpers(code);
+}
+
 function isVitePreloadHelperSpecifier(specifier: string): boolean {
   return specifier.includes('preload-helper');
 }
@@ -457,15 +586,21 @@ function isVitePreloadHelperSpecifier(specifier: string): boolean {
  * Fetch an HTTP ESM module, transform it, write it to a temp .js file and
  * return the file path. Recursively does the same for HTTP transitive imports
  * so that `import('file:///...temp.js')` can resolve them.
+ *
+ * `versionKey` participates in both the cache key and the temp file name, so
+ * a remote redeploy (new manifest → new key) produces new files and bypasses
+ * Node's ESM module cache instead of serving the stale build.
  */
 async function fetchEsmToTempFile(
   url: string,
   tmpDir: string,
   visited: Map<string, string>,
-  sharedPkgMap?: Map<string, string>
+  sharedPkgMap?: Map<string, string>,
+  versionKey: string = UNVERSIONED
 ): Promise<string> {
+  const cacheKey = `${versionKey}::${url}`;
   if (visited.has(url)) return visited.get(url)!;
-  if (tempFileCache.has(url)) return tempFileCache.get(url)!;
+  if (tempFileCache.has(cacheKey)) return tempFileCache.get(cacheKey)!;
 
   const promise = (async () => {
     const res = await fetch(url);
@@ -496,7 +631,7 @@ async function fetchEsmToTempFile(
       [...new Set(relImports)]
         .filter((u) => u.startsWith('http://') || u.startsWith('https://'))
         .map(async (u) => {
-          const tmpPath = await fetchEsmToTempFile(u, tmpDir, visited, sharedPkgMap);
+          const tmpPath = await fetchEsmToTempFile(u, tmpDir, visited, sharedPkgMap, versionKey);
           subMap.set(u, `file://${tmpPath}`);
         })
     );
@@ -511,26 +646,59 @@ async function fetchEsmToTempFile(
     const { createHash } = await _crypto();
     const { join } = await _path();
     const { writeFileSync } = await _fs();
-    const hash = createHash('sha1').update(url).digest('hex').slice(0, 12);
+    const hash = createHash('sha1').update(cacheKey).digest('hex').slice(0, 12);
     const tmpFile = join(tmpDir, `${hash}.js`);
     writeFileSync(tmpFile, code, 'utf8');
     visited.set(url, tmpFile);
     return tmpFile;
   })();
 
-  tempFileCache.set(url, promise);
+  tempFileCache.set(cacheKey, promise);
   return promise;
 }
 
-async function importTempModule(filePath: string): Promise<{ init: unknown; get: unknown }> {
-  return (await import(/* @vite-ignore */ filePath)) as { init: unknown; get: unknown };
+async function importTempModule(
+  filePath: string,
+  versionKey: string
+): Promise<{ init: unknown; get: unknown }> {
+  // The version query busts Node's ESM module cache (and any stale resolution
+  // state) when a remote redeploys: same temp path + new version → fresh module.
+  const specifier = `${filePath}?v=${encodeURIComponent(versionKey)}`;
+  return (await import(/* @vite-ignore */ specifier)) as { init: unknown; get: unknown };
+}
+
+let warnedVmUnavailable = false;
+
+async function tryVmStrategy(
+  ssrEntry: SsrEntryCandidate,
+  options: ResolvedLoaderOptions
+): Promise<{ init: unknown; get: unknown } | null> {
+  const { loadViaVmStrategy, isVmStrategyAvailable } = await import('./ssrVmStrategy');
+
+  if (!(await isVmStrategyAvailable())) {
+    if (!warnedVmUnavailable) {
+      warnedVmUnavailable = true;
+      console.warn(
+        '[mf-vite:ssr-entry-loader] strategy "vm" requires vm.SourceTextModule ' +
+          '(run Node with --experimental-vm-modules); falling back to the temp-file strategy.'
+      );
+    }
+    return null;
+  }
+
+  return (await loadViaVmStrategy(ssrEntry.url, {
+    resolvedShared: options.resolvedShared,
+    shareScopeName: options.shareScopeName,
+    versionKey: ssrEntry.versionKey,
+  })) as { init: unknown; get: unknown } | null;
 }
 
 async function loadSSRRemoteEntry(
-  ssrEntry: { url: string; type: string },
-  resolvedShared: Record<string, string> = {}
+  ssrEntry: SsrEntryCandidate,
+  options: ResolvedLoaderOptions
 ): Promise<{ init: unknown; get: unknown } | null> {
-  const { url, type } = ssrEntry;
+  const { url, type, versionKey } = ssrEntry;
+  const { resolvedShared } = options;
 
   if (type === 'commonjs-module' || type === 'commonjs') {
     // CJS: use createRequire so we get the same Node module-cache singleton
@@ -577,6 +745,21 @@ async function loadSSRRemoteEntry(
       }
     }
 
+    // Opt-in vm.SourceTextModule strategy: evaluates the remote's ESM graph in
+    // the current context and links bare shared imports through the host's
+    // federation share scope (true version negotiation) instead of rewriting
+    // them to file:// paths. Falls back to the temp-file strategy when the
+    // SourceTextModule API is unavailable or evaluation fails.
+    if (options.strategy === 'vm') {
+      try {
+        const fromVm = await tryVmStrategy(ssrEntry, options);
+        if (fromVm) return fromVm;
+      } catch (error) {
+        if (isSsrEntryHttpError(error)) throw error;
+        // fall through to the temp-file strategy
+      }
+    }
+
     // Production build HTTP entries: fetch source and write to temp file so
     // Node can import it via file:// URL (avoids --experimental-network-imports).
     // Production previews may also mount built SSR assets under /__mf_ssr__/
@@ -592,8 +775,8 @@ async function loadSSRRemoteEntry(
     const sharedPkgMap = new Map(Object.entries(resolvedShared));
 
     try {
-      const tmpFile = await fetchEsmToTempFile(url, cacheDir, new Map(), sharedPkgMap);
-      return await importTempModule(tmpFile);
+      const tmpFile = await fetchEsmToTempFile(url, cacheDir, new Map(), sharedPkgMap, versionKey);
+      return await importTempModule(tmpFile, versionKey);
     } catch (error) {
       if (isSsrEntryHttpError(error)) throw error;
       return null;
@@ -625,21 +808,60 @@ interface SsrEntryLoaderOptions {
    * in remote SSR entry temp files — no runtime createRequire walk-up needed.
    */
   resolvedShared?: Record<string, string>;
+  /**
+   * How to evaluate remote SSR entries on the server.
+   *
+   * - `'temp-file'` (default): fetch the ESM graph, rewrite specifiers, write
+   *   temp files and `import()` them. Works on stock Node; shared packages are
+   *   pinned to the host's copies via `resolvedShared` (no version negotiation).
+   * - `'vm'`: evaluate the graph with `vm.SourceTextModule` and link bare
+   *   shared imports through the host's federation share scope (`loadShare`),
+   *   restoring version negotiation. Requires `--experimental-vm-modules`;
+   *   falls back to `'temp-file'` when unavailable.
+   */
+  strategy?: 'temp-file' | 'vm';
+  /**
+   * Share scope consulted by the `'vm'` strategy when linking bare imports.
+   * Defaults to `'default'`.
+   */
+  shareScopeName?: string;
+  /**
+   * Re-check each remote's manifest when the cached SSR entry resolution is
+   * older than this many milliseconds. When the manifest's version changes
+   * (remote redeployed at the same URL), the loader drops its caches for that
+   * remote so subsequent loads use the new build. Omit to cache until process
+   * exit or an explicit `revalidate()` call. Only manifest-resolved entries
+   * can be revalidated this way — convention-resolved entries have no version
+   * source.
+   */
+  maxAgeMs?: number;
+}
+
+interface ResolvedLoaderOptions {
+  resolvedShared: Record<string, string>;
+  strategy: 'temp-file' | 'vm';
+  shareScopeName: string;
+  maxAgeMs?: number;
 }
 
 // Default export so the module can be referenced as a runtimePlugin path string.
 export default function ssrEntryLoaderPlugin(options: SsrEntryLoaderOptions = {}) {
-  const resolvedShared = options.resolvedShared ?? {};
+  const resolved: ResolvedLoaderOptions = {
+    resolvedShared: options.resolvedShared ?? {},
+    strategy: options.strategy ?? 'temp-file',
+    shareScopeName: options.shareScopeName ?? 'default',
+    maxAgeMs: options.maxAgeMs,
+  };
   return {
     name: 'mf-vite:ssr-entry-loader',
     async loadEntry({ remoteInfo }: { remoteInfo: RemoteInfo }) {
       // Only intercept on the server — browser should use the normal path.
       if (!isNodeServer()) return;
 
-      const ssrEntry = await getSSREntry(remoteInfo.entry);
+      const ssrEntry = await getSSREntry(remoteInfo.entry, resolved.maxAgeMs);
       if (!ssrEntry) return;
 
-      const mod = await loadSSRRemoteEntry(ssrEntry, resolvedShared);
+      const mod = await loadSSRRemoteEntry(ssrEntry, resolved);
       if (!mod) return;
 
       return mod;

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -1,0 +1,268 @@
+/**
+ * vm.SourceTextModule strategy for loading remote SSR entries.
+ *
+ * Unlike the temp-file strategy (which rewrites bare shared imports to
+ * host-resolved file:// paths at fetch time), this strategy evaluates the
+ * remote's ESM graph with `vm.SourceTextModule` in the current context and
+ * resolves bare imports through a linker, in order:
+ *
+ *  1. The host's federation share scope — `instance.loadShare(name)` on the
+ *     global `__FEDERATION__` instances. This restores real share-scope
+ *     semantics (version negotiation, loaded-first reuse) on the server.
+ *  2. The build-time `resolvedShared` file map (same source as the temp-file
+ *     strategy) as a fallback when no instance shares the package.
+ *  3. Plain host `import(specifier)` for everything else (node builtins,
+ *     packages the remote expects the host to provide).
+ *
+ * Requires Node with `--experimental-vm-modules`; callers must check
+ * `isVmStrategyAvailable()` and fall back to the temp-file strategy when the
+ * API is missing.
+ */
+import { neutralizeBrowserPreloadHelpers, SsrEntryHttpError } from './ssrEntryLoader';
+
+interface VmStrategyOptions {
+  resolvedShared: Record<string, string>;
+  shareScopeName: string;
+  versionKey: string;
+}
+
+// Minimal structural typings for the experimental vm module APIs so this file
+// compiles without @types/node exposing them (they are flag-gated).
+interface VmModule {
+  status: 'unlinked' | 'linking' | 'linked' | 'evaluating' | 'evaluated' | 'errored';
+  identifier: string;
+  namespace: unknown;
+  link(linker: Linker): Promise<void>;
+  evaluate(): Promise<void>;
+}
+
+type Linker = (specifier: string, referencingModule: VmModule) => VmModule | Promise<VmModule>;
+
+interface VmApi {
+  SourceTextModule: new (
+    code: string,
+    options: {
+      identifier?: string;
+      initializeImportMeta?: (meta: { url?: string }) => void;
+      importModuleDynamically?: (
+        specifier: string,
+        referencingModule: VmModule
+      ) => VmModule | Promise<VmModule>;
+    }
+  ) => VmModule;
+  SyntheticModule: new (
+    exportNames: string[],
+    evaluateCallback: () => void,
+    options?: { identifier?: string }
+  ) => VmModule & { setExport(name: string, value: unknown): void };
+}
+
+let vmApiPromise: Promise<VmApi | null> | undefined;
+async function getVmApi(): Promise<VmApi | null> {
+  if (!vmApiPromise) {
+    vmApiPromise = (async () => {
+      try {
+        const vm = (await import(/* @vite-ignore */ 'vm')) as unknown as Partial<VmApi>;
+        if (typeof vm.SourceTextModule !== 'function' || typeof vm.SyntheticModule !== 'function') {
+          return null;
+        }
+        return vm as VmApi;
+      } catch {
+        return null;
+      }
+    })();
+  }
+  return vmApiPromise;
+}
+
+export async function isVmStrategyAvailable(): Promise<boolean> {
+  return (await getVmApi()) !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Share-scope resolution for bare specifiers
+// ---------------------------------------------------------------------------
+
+interface FederationInstanceLike {
+  options?: { shared?: Record<string, unknown> };
+  loadShare?: (name: string) => Promise<false | (() => unknown | undefined) | undefined>;
+}
+
+function getFederationInstances(): FederationInstanceLike[] {
+  const federation = (
+    globalThis as { __FEDERATION__?: { __INSTANCES__?: FederationInstanceLike[] } }
+  ).__FEDERATION__;
+  return federation?.__INSTANCES__ ?? [];
+}
+
+/**
+ * Resolve a bare specifier to a module namespace: share scope first, then the
+ * build-time resolvedShared file map, then plain host import.
+ */
+async function loadBareModule(specifier: string, options: VmStrategyOptions): Promise<unknown> {
+  for (const instance of getFederationInstances()) {
+    if (typeof instance?.loadShare !== 'function') continue;
+    // Only consult instances that actually declare the package as shared —
+    // loadShare on an unknown package can register it as a side effect.
+    if (!instance.options?.shared || !(specifier in instance.options.shared)) continue;
+    try {
+      const factory = await instance.loadShare(specifier);
+      if (typeof factory === 'function') {
+        const shared = factory();
+        if (shared) return shared;
+      }
+    } catch {
+      // Try the next instance / fallback chain.
+    }
+  }
+
+  const resolvedPath = options.resolvedShared[specifier];
+  if (resolvedPath) {
+    return import(/* @vite-ignore */ `file://${resolvedPath}`);
+  }
+
+  return import(/* @vite-ignore */ specifier);
+}
+
+function createSyntheticModule(vm: VmApi, specifier: string, namespace: unknown): VmModule {
+  const source =
+    namespace && typeof namespace === 'object'
+      ? (namespace as Record<string, unknown>)
+      : { default: namespace };
+  const exportNames = new Set(Object.keys(source));
+  exportNames.add('default');
+
+  const syntheticModule = new vm.SyntheticModule(
+    [...exportNames],
+    () => {
+      for (const exportName of exportNames) {
+        if (exportName === 'default') {
+          syntheticModule.setExport(
+            'default',
+            source.default !== undefined ? source.default : namespace
+          );
+        } else {
+          syntheticModule.setExport(exportName, source[exportName]);
+        }
+      }
+    },
+    { identifier: `mf-shared:${specifier}` }
+  );
+  return syntheticModule;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP module graph
+// ---------------------------------------------------------------------------
+
+// `${versionKey}::${url}` → module. Version-keyed so a remote redeploy loads a
+// fresh graph instead of the cached one.
+const httpModuleCache = new Map<string, Promise<VmModule>>();
+// Evaluated entry namespaces, same keying.
+const namespaceCache = new Map<string, Promise<unknown>>();
+
+function getBodyPreview(body: string): string {
+  return body.slice(0, 240).replace(/\s+/g, ' ').trim();
+}
+
+async function fetchModuleSource(url: string): Promise<string> {
+  const res = await fetch(url);
+  const text = await res.text();
+  if (!res.ok) {
+    throw new SsrEntryHttpError(url, res.status, res.statusText, getBodyPreview(text));
+  }
+  return neutralizeBrowserPreloadHelpers(text);
+}
+
+function isHttpUrl(value: string): boolean {
+  return value.startsWith('http://') || value.startsWith('https://');
+}
+
+/** Resolve a specifier against the referencing module's URL; null for bare specifiers. */
+function resolveSpecifierUrl(specifier: string, referencerUrl: string): string | null {
+  if (isHttpUrl(specifier)) return specifier;
+  if (specifier.startsWith('./') || specifier.startsWith('../') || specifier.startsWith('/')) {
+    return new URL(specifier, referencerUrl).href;
+  }
+  return null;
+}
+
+function getHttpModule(vm: VmApi, url: string, options: VmStrategyOptions): Promise<VmModule> {
+  const cacheKey = `${options.versionKey}::${url}`;
+  if (!httpModuleCache.has(cacheKey)) {
+    httpModuleCache.set(
+      cacheKey,
+      (async () => {
+        const code = await fetchModuleSource(url);
+        return new vm.SourceTextModule(code, {
+          identifier: url,
+          initializeImportMeta(meta) {
+            meta.url = url;
+          },
+          importModuleDynamically: (specifier, referencingModule) =>
+            importDynamically(vm, specifier, referencingModule, options),
+        });
+      })().catch((error) => {
+        httpModuleCache.delete(cacheKey);
+        throw error;
+      })
+    );
+  }
+  return httpModuleCache.get(cacheKey)!;
+}
+
+async function linkModule(
+  vm: VmApi,
+  specifier: string,
+  referencingModule: VmModule,
+  options: VmStrategyOptions
+): Promise<VmModule> {
+  const url = resolveSpecifierUrl(specifier, referencingModule.identifier);
+  if (url) return getHttpModule(vm, url, options);
+  return createSyntheticModule(vm, specifier, await loadBareModule(specifier, options));
+}
+
+async function importDynamically(
+  vm: VmApi,
+  specifier: string,
+  referencingModule: VmModule,
+  options: VmStrategyOptions
+): Promise<VmModule> {
+  const linker: Linker = (spec, referencer) => linkModule(vm, spec, referencer, options);
+  const module = await linker(specifier, referencingModule);
+  if (module.status === 'unlinked') await module.link(linker);
+  if (module.status === 'linked') await module.evaluate();
+  return module;
+}
+
+/**
+ * Load and evaluate a remote SSR entry as a `vm.SourceTextModule` graph and
+ * return its namespace (the federation container with `init`/`get`).
+ * Returns null when the vm module APIs are unavailable.
+ */
+export async function loadViaVmStrategy(
+  entryUrl: string,
+  options: VmStrategyOptions
+): Promise<unknown | null> {
+  const vm = await getVmApi();
+  if (!vm) return null;
+
+  const cacheKey = `${options.versionKey}::${entryUrl}`;
+  if (!namespaceCache.has(cacheKey)) {
+    namespaceCache.set(
+      cacheKey,
+      (async () => {
+        const entryModule = await getHttpModule(vm, entryUrl, options);
+        const linker: Linker = (specifier, referencingModule) =>
+          linkModule(vm, specifier, referencingModule, options);
+        if (entryModule.status === 'unlinked') await entryModule.link(linker);
+        if (entryModule.status === 'linked') await entryModule.evaluate();
+        return entryModule.namespace;
+      })().catch((error) => {
+        namespaceCache.delete(cacheKey);
+        throw error;
+      })
+    );
+  }
+  return namespaceCache.get(cacheKey)!;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,8 @@ export default defineConfig({
     env: {
       MFE_VITE_NO_TEST_ENV_CHECK: 'true',
     },
+    // vm.SourceTextModule (used by the ssrEntryLoader 'vm' strategy) is gated
+    // behind this flag; the vm strategy tests skip themselves when it's absent.
+    execArgv: ['--experimental-vm-modules'],
   },
 });


### PR DESCRIPTION
## Summary

Closes two gaps in the SSR entry loader compared to the webpack/rspack node runtime (`@module-federation/node`): **stale remotes on long-running servers** and **no share-scope semantics on the server**. Both are additive and default-off; the default temp-file behavior is unchanged.

### 1. Revalidation — remote redeploys without host restarts

Today the loader's caches (`ssrEntryCache`, `manifestFetchCache`, `tempFileCache`) plus Node's ESM module cache live until process exit, so a remote redeployed at the same URL is served stale until the host restarts.

- Every SSR entry resolution now carries a **version key** derived from the remote's manifest (`metaData.buildInfo.buildVersion` + FNV content hash). The key flows into temp-file names, all cache keys, and the entry import itself (`?v=<versionKey>` query), so a new version can never be served from Node's module cache for a reused path.
- New **`maxAgeMs`** plugin option: when a cached resolution is older than this, the loader re-fetches the manifest; if the version changed, per-remote caches are dropped and the new build is loaded. Omit for today's cache-forever behavior.
- New **`revalidate(entryUrl?)`** export (analogue of `@module-federation/node/utils`' revalidate): clears loader caches (scoped by remote origin or globally) and best-effort clears global federation instances' module caches.

### 2. Opt-in `strategy: 'vm'` — real share scope on the server

The temp-file strategy pins bare shared imports to host-resolved `file://` paths (`resolvedShared`) — singletons, but no version negotiation. The new opt-in strategy evaluates the remote's ESM graph with `vm.SourceTextModule` and links bare imports through a linker:

1. the host's federation share scope (`instance.loadShare` on `globalThis.__FEDERATION__` instances that declare the package as shared) — real share-scope semantics,
2. the build-time `resolvedShared` file map (same source as the temp-file strategy),
3. plain host `import(specifier)`.

Requires `--experimental-vm-modules`; degrades to the temp-file strategy with a one-time warning when the API is unavailable. The browser-preload neutralization is extracted as `neutralizeBrowserPreloadHelpers()` and shared by both strategies. The vm strategy is a lazily imported chunk, so nothing changes for consumers who don't opt in.

```ts
federation({
  runtimePlugins: [
    ['@module-federation/vite/ssrEntryLoader', {
      resolvedShared,
      maxAgeMs: 30_000,     // optional: revalidate remotes every 30s
      strategy: 'vm',       // optional: share-scope linking on the server
    }],
  ],
})
```

## Tests

- ~12 new tests: revalidation semantics (stale-manifest re-fetch, version-change reload, scoped/global `revalidate()`), and real `vm.SourceTextModule` evaluation — relative-import graphs, share-scope linking, share-declaration-based instance selection, `resolvedShared` fallback, preload-helper neutralization, HTTP error propagation, and version-keyed cache separation.
- vitest now passes `--experimental-vm-modules` to workers (top-level `execArgv`) so the vm tests exercise the real API; they skip themselves where the flag is absent.
- Full suite: **610 passed, 1 environment-skipped**; no new `tsc` errors; build emits the new lazy `ssrVmStrategy` chunk.

While adding these tests I also fixed a latent order-dependence in the suite: mocked-crypto temp-file names collide across tests, and a failed import of that path poisons Node's resolution cache for later tests — the `?v=` import query resolves this structurally.

## Notes for reviewers

- `revalidate()` clears the loader's caches, but hosts holding direct references to previously loaded remote modules keep those references — documented on the function.
- Convention-resolved entries (no manifest) get a stable `unversioned` key and cannot be auto-revalidated; only manifest-resolved entries can.
- Pre-existing on `main` and untouched here: `tsc` fails on `pluginDts.ts` (duplicate `@module-federation/dts-plugin` type identity via lockfile). Happy to fix in a follow-up.

Context: this incubates "node runtime parity" pieces for the Vite loader discussed while building `@module-federation/nuxt` SSR support — revalidation and server share-scope semantics being the two biggest gaps versus `@module-federation/node`.