### PR TITLE
fix: resolve remote init after import:false shared cache seeding

### DIFF
--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -110,6 +110,7 @@ describe('shared dependencies', () => {
     expect(allCode).toContain('__mfWriteSharedCache(__mfModuleCache.share');
     expect(allCode).not.toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');
+    expect(loadShare!.code).toContain('pendingShareLoads');
     expect(loadShare!.code).toContain('default:mock-shared-dep');
     expect(loadShare!.code).toContain('mock-shared-dep');
     expect(loadShare!.code).toContain('init');

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -492,6 +492,9 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('const mfName = "host"');
     expect(code).toContain('share.shareConfig?.import !== false');
     expect(code).toContain('const versions = shared?.[pkg]');
+    expect(code.indexOf('share.shareConfig?.import !== false')).toBeLessThan(
+      code.indexOf('initResolve(initRes)')
+    );
     expect(code).not.toContain('initRes.loadShare(pkg');
     expect(code).not.toContain('import exposesMap from');
     expect(code).not.toContain('import {usedShared, usedRemotes} from');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -560,7 +560,6 @@ export function generateRemoteEntry(
     if (initScope.indexOf(initToken) >= 0) return;
     initScope.push(initToken);
     initRes.initShareScopeMap('${options.shareScope}', shared);
-    initResolve(initRes)
     try {
       await retrySharedInit(async () => {
         await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
@@ -584,6 +583,7 @@ export function generateRemoteEntry(
       const resolved = await Promise.resolve(mod);
       __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, __mfNormalizeRuntimeShare(resolved));
     }
+    initResolve(initRes)
     return initRes
   }
 


### PR DESCRIPTION
# fix: resolve remote init after import:false shared cache seeding

fixes #873
Follow-up to #866

## Summary

This fixes the remaining `import: false` shared initialization race on top of the latest host bootstrap changes.

#866 added `pendingShareLoads` so host bootstraps can wait for deferred shared export binding before importing the application entry. However, the generated remote entry still resolved its federation init promise before it finished `initializeSharing` and before it seeded host-provided `import: false` shared modules into `__mf_module_cache__`.

That meant a generated `loadShare` wrapper waiting on `initPromise` could resume while the remote entry was still preparing the host-provided shared cache.

This change moves `initResolve(initRes)` after the `import: false` shared cache seeding loop, so consumers that wait for federation init only resume once the remote entry has finished populating those cache entries.

## Problem

Before this change, generated remote entry init was ordered like this:

```ts
initRes.initShareScopeMap("default", shared);
initResolve(initRes);

await initRes.initializeSharing("default", ...);

for (const [pkg, share] of Object.entries(usedShared)) {
  if (share.shareConfig?.import !== false) continue;
  __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, resolved);
}
```

For `import: false`, the remote has no local fallback. It must wait for the host-provided shared provider and seed the module cache before exposed modules read generated shared wrappers.

Resolving `initPromise` before that cache seeding created a timing window:

- generated `loadShare` wrappers could observe that federation init was complete;
- the `default:react` / default-scope compatible cache entry could still be missing;
- exposed modules could then evaluate against unready shared exports.

In React-based remotes, that can surface as named exports such as `createContext` being read before the host-provided React module is available.

## Changes

- Moved `initResolve(initRes)` after `initializeSharing` and after the `import: false` shared cache seeding loop in generated remote entries: [`virtualRemoteEntry.ts`](https://github.com/dmchoi77/vite/blob/3d9a79ec929d4acf02e869c2702a6c4d761d7c69/src/virtualModules/virtualRemoteEntry.ts#L562).
- Preserved the latest shared cache compatibility helpers from `main`, including `__mfReadSharedCache`, `__mfWriteSharedCache`, and default-scope aliases: [`virtualRemoteEntry.ts`](https://github.com/dmchoi77/vite/blob/3d9a79ec929d4acf02e869c2702a6c4d761d7c69/src/virtualModules/virtualRemoteEntry.ts#L574).
- Added a generated remote entry ordering assertion to keep `import: false` shared cache handling before `initResolve(initRes)`: [`virtualRemoteEntry.test.ts`](https://github.com/dmchoi77/vite/blob/3d9a79ec929d4acf02e869c2702a6c4d761d7c69/src/virtualModules/__tests__/virtualRemoteEntry.test.ts#L493).
- Tightened integration coverage to assert generated `loadShare` chunks use the latest `pendingShareLoads` path while the remote entry continues to seed the shared cache directly: [`shared-deps.test.ts`](https://github.com/dmchoi77/vite/blob/3d9a79ec929d4acf02e869c2702a6c4d761d7c69/integration/shared-deps.test.ts#L109).

## Tests

- Updated generated-code coverage for remote entry init ordering.
- Updated shared dependency integration coverage for the current `pendingShareLoads` + shared cache helper behavior.

## Verification

```sh
pnpm test
pnpm test:integration
pnpm run typecheck
pnpm run build
```

Results:

- Source tests passed: 37 files / 622 passed, 1 skipped.
- Integration tests passed: 10 files / 41 tests.
- TypeScript check passed.
- Package build passed.

`pnpm test` still prints the existing `MaxListenersExceededWarning`, but all tests pass.

I also re-verified the fix against a local Vite React Router Module Federation PoC with the local package linked in and the remote configured with `react` and `react-dom` as `import: false`.

PoC result:

- Remote entry served: pass.
- Remote manifest served: pass.
- Host index served: pass.
- Remote route SSR marker: pass.
- Remote data SSR marker: pass.
- Browser hydration and CSR click check: pass.
- Browser console errors: empty.
- Page errors: empty.