### PR TITLE
fix: resolve DTS Runtime Plugin Path

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1518,6 +1518,40 @@ describe('vite:module-federation-early-init', () => {
     expect(config.optimizeDeps.needsInterop).toBeUndefined();
   });
 
+  it('resolves only the dts hints runtime plugin for optimizeDeps', () => {
+    const dtsHintsPlugin = '@module-federation/dts-plugin/dynamic-remote-type-hints-plugin';
+    const userPlugin = '@module-federation/runtime-core';
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        runtimePlugins: [dtsHintsPlugin, userPlugin],
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'module-federation-vite');
+    if (!plugin) throw new Error('module-federation-vite plugin not found');
+
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: { include: [] },
+      resolve: { alias: [] },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps.include).not.toContain(dtsHintsPlugin);
+    expect(config.optimizeDeps.include).toContain(userPlugin);
+    expect(
+      config.optimizeDeps.include.some(
+        (dep: string) =>
+          dep.includes('@module-federation/dts-plugin') &&
+          dep.includes('dynamic-remote-type-hints-plugin')
+      )
+    ).toBe(true);
+  });
+
   it('aliases runtime to the ESM entry for non-Rolldown optimizeDeps', () => {
     const plugin = getModuleFederationVitePlugin();
     const config: any = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1151,7 +1151,15 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
             !pluginPath.startsWith('\0') &&
             !pluginPath.startsWith('virtual:')
           ) {
-            config.optimizeDeps!.include!.push(pluginPath);
+            let optimizeDep = pluginPath;
+            if (pluginPath === '@module-federation/dts-plugin/dynamic-remote-type-hints-plugin') {
+              try {
+                optimizeDep = normalizePathForImport(resolveImportPath(pluginPath));
+              } catch {
+                optimizeDep = pluginPath;
+              }
+            }
+            config.optimizeDeps!.include!.push(optimizeDep);
           }
         });
 


### PR DESCRIPTION
Fixes pnpm cold-start resolution for DTS dynamic remote type hints. The internally injected DTS runtime plugin is now resolved to an actual file path before being added to Vite’s optimizeDeps.include, while user runtime plugins remain unchanged. Adds a focused regression test covering the DTS-only behavior.