### PR TITLE
fix: preload exposed remote dependencies first

### DIFF
--- a/integration/fixtures/nested-remote-class/entry.js
+++ b/integration/fixtures/nested-remote-class/entry.js
@@ -1,0 +1,1 @@
+export const app = true;

--- a/integration/fixtures/nested-remote-class/exposed-init.js
+++ b/integration/fixtures/nested-remote-class/exposed-init.js
@@ -1,0 +1,7 @@
+import { View } from 'ckeditor5';
+
+class Foo extends View {}
+
+export default function init() {
+  return Foo;
+}

--- a/integration/fixtures/nested-remote-class/index.html
+++ b/integration/fixtures/nested-remote-class/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <script type="module" src="/entry.js"></script>
+  </body>
+</html>

--- a/integration/remote-dependency-pending.test.ts
+++ b/integration/remote-dependency-pending.test.ts
@@ -1,0 +1,44 @@
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+import type { ModuleFederationOptions } from '../src/utils/normalizeModuleFederationOptions';
+import { buildFixture, FIXTURES } from './helpers/build';
+import { getAllChunkCode } from './helpers/matchers';
+
+const REMOTE_DEPENDENCY_MF_OPTIONS = {
+  name: 'classRemote',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './init': resolve(FIXTURES, 'nested-remote-class', 'exposed-init.js'),
+  },
+  remotes: {
+    ckeditor5: {
+      name: 'ckeditor5',
+      entry: 'http://localhost:3002/remoteEntry.js',
+      type: 'module',
+    },
+  },
+  dts: false,
+} satisfies Partial<ModuleFederationOptions>;
+
+describe('remote dependency pending', () => {
+  it('waits at expose loading for nested remote named imports without TLA', async () => {
+    const output = await buildFixture({
+      fixture: 'nested-remote-class',
+      mfOptions: REMOTE_DEPENDENCY_MF_OPTIONS,
+    });
+
+    const allCode = getAllChunkCode(output);
+
+    expect(allCode).toMatch(/\b(?:const|var)\s+\{\s*View\s*\}\s*=\s*exportModule/);
+    expect(allCode).not.toContain('const pendingPrototype = {};');
+    expect(allCode).toContain('__loadRemote__ckeditor5__loadRemote__');
+    expect(allCode).toContain('const dependencyPending = importModule && importModule.__mf_remote_dependency_pending;');
+    expect(allCode).toContain('await dependencyPending;');
+    expect(allCode).toMatch(
+      /\b(?:const|var)\s+__mf_remote_dependency_pending\s*=\s*Promise\.all\(\[__mf_remote_pending\]\)/
+    );
+    expect(allCode).not.toMatch(
+      /\b(?:const|var)\s+__mf_remote_dependency_pending\s*=\s*await\b/
+    );
+  });
+});

--- a/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
+++ b/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
@@ -103,31 +103,36 @@ describe('pluginRemoteNamedExports', () => {
         'export const __mf_remote_dependency_pending = Promise.all([__mf_ns_0_pending]);'
       );
       expect(result).not.toContain('await ');
-      expect(result).toContain('__mfCreateNamedRemoteProxy');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
       expect(result).not.toContain('import { foo }');
+    });
+
+    it('rewrites class bases to direct named bindings without proxies', async () => {
+      const result = await transform(
+        ['import { View } from "remoteApp/utils";', 'class Foo extends View {}'].join('\n')
+      );
+
+      expect(result).toContain('const { View: View } = __mf_ns_0;');
+      expect(result).not.toContain('await ');
     });
 
     it('rewrites multiple named imports', async () => {
       const result = await transform('import { foo, bar, baz } from "remoteApp/utils";');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "bar")');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "baz")');
+      expect(result).toContain('const { foo: foo, bar: bar, baz: baz } = __mf_ns_0;');
     });
 
     it('rewrites aliased import', async () => {
       const result = await transform('import { foo as myFoo } from "remoteApp/utils";');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const myFoo =');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: myFoo } = __mf_ns_0;');
     });
 
     it('rewrites default + named imports', async () => {
       const result = await transform('import Default, { foo } from "remoteApp/utils";');
       expect(result).toContain('default as Default');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
     });
 
     it('skips default-only import', async () => {
@@ -147,7 +152,7 @@ describe('pluginRemoteNamedExports', () => {
     it('handles bare remote name (no subpath)', async () => {
       const result = await transform('import { foo } from "remoteApp";');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
     });
 
     it('skips bare remote-name rewrites inside node_modules files', async () => {
@@ -164,7 +169,7 @@ describe('pluginRemoteNamedExports', () => {
         '/repo/node_modules/some-package/index.js'
       );
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
     });
 
     it('handles multiple remotes in one file', async () => {
@@ -173,18 +178,18 @@ describe('pluginRemoteNamedExports', () => {
         'import { bar } from "otherRemote/helpers";',
       ].join('\n');
       const result = await transform(code);
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_3, "bar")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('const { bar: bar } = __mf_ns_1;');
     });
 
-    it('declares named remote proxy helper once for multiple named remote imports', async () => {
+    it('rewrites multiple remote imports to direct named bindings', async () => {
       const code = [
         'import { useAuth } from "remoteApp/auth";',
         'import { useShellStore } from "otherRemote/shellStore";',
       ].join('\n');
       const result = await transform(code);
-      const declarations = result?.match(/function __mfCreateNamedRemoteProxy/g) ?? [];
-      expect(declarations).toHaveLength(1);
+      expect(result).toContain('const { useAuth: useAuth } = __mf_ns_0;');
+      expect(result).toContain('const { useShellStore: useShellStore } = __mf_ns_1;');
     });
   });
 
@@ -294,7 +299,7 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
     });
 
     it('rewrites namespace import via fallback', async () => {
@@ -319,7 +324,7 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toContain('default as Default');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
     });
 
     it('wraps dynamic import via fallback', async () => {
@@ -379,8 +384,7 @@ describe('pluginRemoteNamedExports', () => {
         '/src/app.tsx',
         true
       );
-      expect(result).toContain('const myFoo =');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
+      expect(result).toContain('const { foo: myFoo } = __mf_ns_0;');
     });
 
     it('keeps runtime specifiers and skips inline type specifiers via fallback', async () => {
@@ -396,9 +400,7 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toContain('default as Default');
-      expect(result).toContain('const myFoo =');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "foo")');
-      expect(result).toContain('__mfCreateNamedRemoteProxy(__mf_ns_0, "bar")');
+      expect(result).toContain('const { foo: myFoo, bar: bar } = __mf_ns_0;');
       expect(result).not.toContain('type Foo');
     });
 

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import { normalizePathForImport } from '../utils/buildPaths';
@@ -32,6 +33,41 @@ export default function ({
   virtualExposesId,
 }: ProxyRemoteEntryParams): Plugin {
   let viteConfig: any, _command: string, root: string;
+  let exposeRemoteDependencies: Record<string, string[]> = {};
+
+  function isRemoteImport(source: string): boolean {
+    return Object.keys(options.remotes).some(
+      (name) => source === name || source.startsWith(name + '/')
+    );
+  }
+
+  function collectRemoteDependencies(code: string): string[] {
+    const dependencies = new Set<string>();
+    const importRe =
+      /(?:^|[;\n\r])\s*import\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']|import\(\s*["']([^"']+)["']\s*\)/g;
+
+    for (const match of code.matchAll(importRe)) {
+      const source = match[1] || match[2];
+      if (source && isRemoteImport(source)) dependencies.add(source);
+    }
+
+    return Array.from(dependencies).sort();
+  }
+
+  async function refreshExposeRemoteDependencies(ctx: { resolve: Plugin['resolveId'] }) {
+    const next: Record<string, string[]> = {};
+    for (const [exposeKey, expose] of Object.entries(options.exposes)) {
+      const resolved = await (ctx as any).resolve(expose.import);
+      if (!resolved?.id || resolved.id.includes('\0')) continue;
+      try {
+        next[exposeKey] = collectRemoteDependencies(readFileSync(resolved.id, 'utf8'));
+      } catch {
+        next[exposeKey] = [];
+      }
+    }
+    exposeRemoteDependencies = next;
+  }
+
   return {
     name: 'proxyRemoteEntry',
     enforce: 'post',
@@ -43,6 +79,7 @@ export default function ({
       _command = command;
     },
     async buildStart() {
+      await refreshExposeRemoteDependencies(this);
       // Emit each exposed module as a chunk entry so the bundler properly
       // code-splits shared dependencies away from the main entry's side effects.
       // Without this, the bundler may merge exposed modules into the main entry
@@ -92,7 +129,7 @@ export default function ({
         return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
       }
       if (id === virtualExposesId) {
-        return generateExposes(options);
+        return generateExposes(options, exposeRemoteDependencies, _command);
       }
       if (_command === 'serve' && id.includes(getHostAutoInitPath())) {
         return id;
@@ -105,7 +142,7 @@ export default function ({
           return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
         }
         if (id === virtualExposesId) {
-          return generateExposes(options);
+          return generateExposes(options, exposeRemoteDependencies, _command);
         }
         if (id.includes(getHostAutoInitPath())) {
           if (_command === 'serve') {

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -180,26 +180,7 @@ function applyRewrites(
   let changed = false;
   // Per-file counter — deterministic regardless of file processing order.
   let counter = 0;
-  let namedProxyHelperDeclared = false;
   const dependencyPendingIds: string[] = [];
-  const namedProxyHelper = `function __mfCreateNamedRemoteProxy(ns, key) {
-  const target = function (...args) {
-    const value = ns[key];
-    return typeof value === "function" ? value.apply(this, args) : value;
-  };
-  return new Proxy(target, {
-    get(_target, prop) {
-      if (prop === "then") return undefined;
-      const value = ns[key];
-      if (prop === Symbol.toPrimitive) return () => value;
-      const item = value == null ? undefined : value[prop];
-      return typeof item === "function" ? item.bind(value) : item;
-    },
-    apply(target, thisArg, args) {
-      return target.apply(thisArg, args);
-    }
-  });
-}`;
 
   for (const imp of imports) {
     switch (imp.kind) {
@@ -227,20 +208,8 @@ function applyRewrites(
 
           let rewrite = `import { ${importParts.join(', ')} } from ${src};`;
           if (imp.named.length > 0) {
-            const isProxyId = `__mf_is_proxy_${counter++}`;
-            const tempNames = imp.named.map((_s) => `__mf_named_${counter++}`);
-            const destructParts = imp.named.map((s, index) => `${s.imported}: ${tempNames[index]}`);
-            const bindingLines = imp.named.map((s, index) => {
-              const temp = tempNames[index];
-              return `const ${s.local} = ${isProxyId} ? __mfCreateNamedRemoteProxy(${nsId}, ${JSON.stringify(s.imported)}) : ${temp};`;
-            });
-            if (!namedProxyHelperDeclared) {
-              rewrite += `\n${namedProxyHelper}`;
-              namedProxyHelperDeclared = true;
-            }
-            rewrite += `\nconst ${isProxyId} = ${nsId} && ${nsId}.__mf_is_remote_proxy;`;
-            rewrite += `\nconst { ${destructParts.join(', ')} } = ${isProxyId} ? {} : ${nsId};`;
-            rewrite += `\n${bindingLines.join('\n')}`;
+            const destructParts = imp.named.map((s) => `${s.imported}: ${s.local}`);
+            rewrite += `\nconst { ${destructParts.join(', ')} } = ${nsId};`;
           }
 
           ms.overwrite(imp.start, imp.end, rewrite);

--- a/src/virtualModules/__tests__/virtualExposes.test.ts
+++ b/src/virtualModules/__tests__/virtualExposes.test.ts
@@ -124,6 +124,7 @@ describe('virtualExposes', () => {
     const firstLoad = exposes['./one']();
     const secondLoad = exposes['./two']();
     await flushMicrotasks();
+    await flushMicrotasks();
 
     expect(appendedHrefs).toEqual(['file:///repo/style.css']);
     expect(dynamicImportStarts).toHaveLength(1);
@@ -144,6 +145,74 @@ describe('virtualExposes', () => {
     expect(secondModule).toMatchObject({ default: './two.js' });
     expect(dynamicImport).toHaveBeenCalledTimes(2);
     expect(document.head.appendChild).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for remote dependency pending before resolving an exposed module', async () => {
+    const code = generateExposes(
+      getDefaultMockOptions({
+        exposes: {
+          './one': { import: './one.js' } as any,
+        },
+      })
+    );
+
+    let resolveDependency!: () => void;
+    const dependencyPending = new Promise<void>((resolve) => {
+      resolveDependency = resolve;
+    });
+    const dynamicImport = vi.fn(() =>
+      Promise.resolve({
+        default: './one.js',
+        __mf_remote_dependency_pending: dependencyPending,
+      })
+    );
+
+    const exposes = await toRunnableModule(code)(
+      undefined,
+      URL,
+      dynamicImport,
+      'file:///repo/remoteEntry.js'
+    );
+
+    let settled = false;
+    const load = exposes['./one']().then((mod) => {
+      settled = true;
+      return mod;
+    });
+    await flushMicrotasks();
+
+    expect(settled).toBe(false);
+
+    resolveDependency();
+    await expect(load).resolves.toMatchObject({ default: './one.js' });
+    expect(settled).toBe(true);
+  });
+
+  it('rejects expose loading when remote dependency pending rejects', async () => {
+    const code = generateExposes(
+      getDefaultMockOptions({
+        exposes: {
+          './one': { import: './one.js' } as any,
+        },
+      })
+    );
+
+    const dependencyError = new Error('remote dependency failed');
+    const dynamicImport = vi.fn(() =>
+      Promise.resolve({
+        default: './one.js',
+        __mf_remote_dependency_pending: Promise.reject(dependencyError),
+      })
+    );
+
+    const exposes = await toRunnableModule(code)(
+      undefined,
+      URL,
+      dynamicImport,
+      'file:///repo/remoteEntry.js'
+    );
+
+    await expect(exposes['./one']()).rejects.toBe(dependencyError);
   });
 
   it('rejects when a css asset fails to load before importing module', async () => {

--- a/src/virtualModules/virtualExposes.ts
+++ b/src/virtualModules/virtualExposes.ts
@@ -1,4 +1,5 @@
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import { getRemoteVirtualModule } from './virtualRemotes';
 
 const EXPOSES_CSS_MAP_PLACEHOLDER = '__MF_EXPOSES_CSS_MAP__';
 
@@ -13,7 +14,11 @@ export function getVirtualExposesId(
   return `virtual:mf-exposes:${scopedKey}`;
 }
 
-export function generateExposes(options: NormalizedModuleFederationOptions) {
+export function generateExposes(
+  options: NormalizedModuleFederationOptions,
+  remoteDependencyMap: Record<string, string[]> = {},
+  command = 'build'
+) {
   return `
     const cssAssetMap = ${JSON.stringify(options.bundleAllCSS ? EXPOSES_CSS_MAP_PLACEHOLDER : {})};
     const injectedCssHrefs = new Set();
@@ -72,12 +77,24 @@ export function generateExposes(options: NormalizedModuleFederationOptions) {
     export default {
     ${Object.keys(options.exposes)
       .map((key) => {
+        const remoteDependencyPreloads = (remoteDependencyMap[key] ?? [])
+          .map((remoteId) => {
+            const virtualRemote = getRemoteVirtualModule(remoteId, command);
+            return `import(${JSON.stringify(virtualRemote.getImportId())})
+            .then((mod) => mod.__mf_remote_pending)`;
+          })
+          .join(',');
         return `
         ${JSON.stringify(key)}: async () => {
           await injectCssAssets(${JSON.stringify(key)})
+          await Promise.all([${remoteDependencyPreloads}])
           const importModule = await importExposedModule(
             () => import(${JSON.stringify(options.exposes[key].import)})
           )
+          const dependencyPending = importModule && importModule.__mf_remote_dependency_pending;
+          if (dependencyPending && typeof dependencyPending.then === "function") {
+            await dependencyPending;
+          }
           const exportModule = {}
           Object.assign(exportModule, importModule)
           Object.defineProperty(exportModule, "__esModule", {


### PR DESCRIPTION
Close #871 #875

Preloads direct remote dependencies before exposed module evaluation, removing named proxy identity mismatches while avoiding top-level await.
