### PR TITLE
fix: fix dev host auto init hash

### DIFF
--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -52,4 +52,41 @@ describe('pluginProxyRemoteEntry', () => {
       `const remoteEntryImport = typeof window !== 'undefined' ? origin + "/remoteEntry.js" : "data:text/javascript,export%20async%20function%20init()%7Breturn%20%7BloadRemote%3Aasync()%3D%3E(%7B%7D)%2CloadShare%3Aasync()%3D%3E(%7B%7D)%7D%7D"`
     );
   });
+
+  it('uses a dev-safe filename for hash-pattern host init remote entry imports', async () => {
+    normalizeModuleFederationOptions({ name: 'test' });
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions({ filename: 'remoteEntry-[hash]' }),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    callHook(
+      plugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        root: '/repo',
+        base: '/',
+        server: { host: '0.0.0.0', port: 4173 },
+      } as unknown as ResolvedConfig
+    );
+
+    const result = (await callHook(
+      plugin.transform,
+      {} as Rollup.TransformPluginContext,
+      '',
+      getHostAutoInitPath()
+    )) as {
+      code: string;
+    };
+
+    expect(result.code).toContain('origin + "/remoteEntry.js"');
+    expect(result.code).not.toContain('remoteEntry-[hash]');
+  });
 });

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -26,6 +26,15 @@ interface ProxyRemoteEntryParams {
   virtualExposesId: string;
 }
 
+function resolveDevHashEntryFileName(fileName: string) {
+  if (!fileName.includes('[hash')) return fileName;
+
+  const normalized = fileName.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
+  const baseName = path.basename(normalized);
+
+  return path.extname(baseName) ? normalized : `${normalized}.js`;
+}
+
 export default function ({
   options,
   remoteEntryId,
@@ -115,7 +124,8 @@ export default function ({
                 : 'localhost';
             const resolvedPublicPath = resolvePublicPath(options, viteConfig.base);
             const publicPath = JSON.stringify(
-              (resolvedPublicPath === 'auto' ? '/' : resolvedPublicPath) + options.filename
+              (resolvedPublicPath === 'auto' ? '/' : resolvedPublicPath) +
+                resolveDevHashEntryFileName(options.filename)
             );
             const fallbackOrigin = `//${host}:${viteConfig.server?.port}`;
             const ssrRemoteEntry =


### PR DESCRIPTION
Ensures dev host auto init resolves hash-pattern remote entry filenames to stable URLs, preventing literal placeholder imports during serve.