### PR TITLE
fix: lazy singleton fallback avoids duplicates

### DIFF
--- a/integration/shared-cache-navigation.test.ts
+++ b/integration/shared-cache-navigation.test.ts
@@ -1,0 +1,153 @@
+import { chromium, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import {
+  execFile as execFileCallback,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from 'child_process';
+import { resolve } from 'path';
+import { promisify } from 'util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const REPRO_ROOT = resolve(process.cwd(), 'test-issue');
+const execFile = promisify(execFileCallback);
+const APPS = [
+  { name: 'app-1', port: 5001 },
+  { name: 'app-2', port: 5002 },
+  { name: 'app-3', port: 5003 },
+  { name: 'shell', port: 5000 },
+] as const;
+
+const previewProcesses: ChildProcessWithoutNullStreams[] = [];
+
+async function waitForUrl(url: string, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`Unexpected status ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}
+
+function startPreview(appName: string) {
+  const child = spawn(
+    'npm',
+    ['--prefix', `apps/${appName}`, 'run', 'preview', '--', '--host', '127.0.0.1'],
+    {
+      cwd: REPRO_ROOT,
+      detached: true,
+    }
+  );
+
+  previewProcesses.push(child);
+  return child;
+}
+
+function stopPreview(child: ChildProcessWithoutNullStreams) {
+  if (child.pid && !child.killed) {
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      // The preview process can exit before cleanup if setup fails early.
+    }
+  }
+}
+
+describe('shared dependency cache across remote navigation', () => {
+  let browser: Browser;
+  let context: BrowserContext;
+  let page: Page;
+
+  beforeAll(async () => {
+    await execFile('npm', ['run', 'build'], {
+      cwd: REPRO_ROOT,
+      timeout: 90_000,
+    });
+
+    for (const app of APPS) {
+      startPreview(app.name);
+    }
+
+    await Promise.all(
+      APPS.map((app) => waitForUrl(`http://127.0.0.1:${app.port}`))
+    );
+
+    browser = await chromium.launch({ headless: true });
+    context = await browser.newContext();
+    page = await context.newPage();
+
+    const client = await context.newCDPSession(page);
+    await client.send('Network.enable');
+    await client.send('Network.setCacheDisabled', { cacheDisabled: true });
+  }, 120_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    for (const child of previewProcesses) {
+      stopPreview(child);
+    }
+  });
+
+  it('does not download shared React chunks again after a share-cache hit', async () => {
+    const sharedAssetResponses: Array<{ url: string; size: number }> = [];
+    const pendingSharedAssetResponses: Promise<void>[] = [];
+
+    page.on('response', (response) => {
+      const url = response.url();
+      if (url.includes('loadShare') || url.includes('prebuild')) {
+        pendingSharedAssetResponses.push(
+          response
+            .body()
+            .then((body) => {
+              sharedAssetResponses.push({ url, size: body.byteLength });
+            })
+            .catch(() => {})
+        );
+      }
+    });
+
+    await page.goto('http://127.0.0.1:5000/app-1', { waitUntil: 'networkidle' });
+    await page.getByText('app-1 page').waitFor();
+    await Promise.all(pendingSharedAssetResponses);
+    const afterApp1Count = sharedAssetResponses.length;
+
+    await page.getByRole('link', { name: 'App 2' }).click();
+    await page.getByText('app-2 page').waitFor();
+    await page.waitForLoadState('networkidle');
+    await Promise.all(pendingSharedAssetResponses);
+
+    const app2SharedAssetResponses = sharedAssetResponses.slice(afterApp1Count);
+    const shareCacheKeys = await page.evaluate(() => {
+      const moduleCache = (globalThis as unknown as {
+        __mf_module_cache__?: { share?: Record<string, unknown> };
+      }).__mf_module_cache__;
+
+      return Object.keys(moduleCache?.share ?? {});
+    });
+
+    expect(shareCacheKeys).toEqual(
+      expect.arrayContaining([
+        'react@19:react',
+        'react@19:react-dom',
+        'react@19:react-dom/client',
+      ])
+    );
+    expect(shareCacheKeys).toHaveLength(4);
+    expect(
+      app2SharedAssetResponses.filter(
+        ({ url, size }) => url.includes('prebuild') || size > 8_000
+      )
+    ).toEqual([]);
+  }, 30_000);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,12 @@ type CodeSplittingGroup = {
   priority?: number;
 };
 
+function isDeferredLocalLoadShareModule(id: string): boolean {
+  if (!id.includes(LOAD_SHARE_TAG)) return false;
+  const virtualModule = VirtualModule.findById(id);
+  return virtualModule?.code?.includes('__mfApplyLocalSharedExports') === true;
+}
+
 type ViteWatchOptions = NonNullable<NonNullable<UserConfig['server']>['watch']>;
 type ViteWatchConfig = ViteWatchOptions | boolean | null | undefined;
 
@@ -839,6 +845,9 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
               return 'runtimeInit';
             }
             if (id.includes(LOAD_SHARE_TAG)) {
+              if (isDeferredLocalLoadShareModule(id)) {
+                return null;
+              }
               // Use the virtual module path as the chunk name
               const match = id.match(/([^/\\]+__loadShare__[^/\\]+)/);
               return match ? match[1] : 'loadShare';

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -723,10 +723,9 @@ describe('writeLoadShareModule', () => {
     expect(writeSyncSpy).toHaveBeenCalled();
     const generatedCode = writeSyncSpy.mock.calls[0][0];
 
-    // Destructuring should alias the keys
-    // const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;
+    // Destructuring should alias the keys while assigning exported live bindings.
     expect(generatedCode).toContain(
-      'const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;'
+      '({ delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule);'
     );
 
     // Export uses aliased keys AS the original keys
@@ -926,8 +925,8 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const __mfDefaultExport = (() => {');
-    expect(generatedCode).toContain('export default __mfDefaultExport;');
+    expect(generatedCode).toContain('__mf_default = exportModule.default ?? exportModule;');
+    expect(generatedCode).toContain('export { __mf_default as default, __mf_remote_pending };');
   });
 
   it('uses shareConfig.import as the concrete import source when provided', () => {
@@ -973,17 +972,18 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
+    expect(generatedCode).not.toContain(
       'import * as __mfLocalShare from "/repo/packages/custom-shared-source";'
     );
+    expect(generatedCode).toContain('import("/repo/packages/custom-shared-source")');
     expect(generatedCode).toContain(
-      'const { sharedValue: __mf_0, useSharedFeature: __mf_1 } = exportModule;'
+      '({ sharedValue: __mf_0, useSharedFeature: __mf_1 } = exportModule);'
     );
     expect(generatedCode).toContain(
       'export { __mf_0 as sharedValue, __mf_1 as useSharedFeature };'
     );
     expect(generatedCode).not.toContain('export * from "/repo/packages/custom-shared-source"');
-    expect(generatedCode).not.toContain('mock-import-id');
+    expect(generatedCode).not.toContain('import("mock-import-id")');
   });
 
   it('falls back to package-based named export detection when shareConfig.import cannot be inspected', () => {
@@ -1005,11 +1005,12 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
+    expect(generatedCode).not.toContain(
       'import * as __mfLocalShare from "/missing/mock-package-with-reserved/index.js";'
     );
+    expect(generatedCode).toContain('import("/missing/mock-package-with-reserved/index.js")');
     expect(generatedCode).toContain(
-      'const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;'
+      '({ delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule);'
     );
     expect(generatedCode).toContain(
       'export { __mf_0 as delete, __mf_1 as get, __mf_2 as request };'
@@ -1035,10 +1036,11 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
+    expect(generatedCode).not.toContain(
       'import * as __mfLocalShare from "mock-package-browser-conditional";'
     );
-    expect(generatedCode).toContain('const { clientOnly: __mf_0 } = exportModule;');
+    expect(generatedCode).toContain('import("mock-package-browser-conditional")');
+    expect(generatedCode).toContain('({ clientOnly: __mf_0 } = exportModule);');
     expect(generatedCode).toContain('export { __mf_0 as clientOnly };');
     expect(generatedCode).not.toContain('serverOnly');
   });
@@ -1113,9 +1115,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
-      'const { useCounter: __mf_0, useLogger: __mf_1 } = exportModule;'
-    );
+    expect(generatedCode).toContain('({ useCounter: __mf_0, useLogger: __mf_1 } = exportModule);');
     expect(generatedCode).toContain('export { __mf_0 as useCounter, __mf_1 as useLogger };');
     expect(generatedCode).not.toContain('export * from');
   });
@@ -1138,7 +1138,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const { ångstrom: __mf_0, café: __mf_1 } = exportModule;');
+    expect(generatedCode).toContain('({ ångstrom: __mf_0, café: __mf_1 } = exportModule);');
     expect(generatedCode).toContain('export { __mf_0 as ångstrom, __mf_1 as café };');
   });
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -774,6 +774,44 @@ function generateDeferredHostProvidedExports(
     export { __mf_default as default };${namedExportLine}`;
 }
 
+function generateDeferredLocalSharedExports(
+  namedExports: string[],
+  importSource: string,
+  cacheDescriptor: string
+) {
+  const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+  const declarations = ['let __mf_default;', ...namedExportVars.map((name) => `let ${name};`)].join(
+    '\n    '
+  );
+  const assignments = `({ ${namedExports.map((name, i) => `${name}: ${namedExportVars[i]}`).join(', ')} } = exportModule);
+      __mf_default = exportModule.default ?? exportModule;`;
+  const namedExportLine =
+    namedExports.length > 0
+      ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(', ')} };`
+      : '';
+
+  return `${declarations}
+    const __mfApplyLocalSharedExports = (exportModule) => {
+      ${assignments}
+    };
+    let exportModule = __mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor});
+    let __mf_remote_pending = Promise.resolve();
+    if (exportModule === undefined) {
+      const __mfLoadLocalShare = initPromise.then(() =>
+        import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
+          exportModule = __mfNormalizeShareModule(mod);
+          __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);
+          __mfApplyLocalSharedExports(exportModule);
+        })
+      );
+      __mf_remote_pending = __mfLoadLocalShare;
+      (__mfModuleCache.pendingShareLoads ||= []).push(__mfLoadLocalShare);
+    } else {
+      __mfApplyLocalSharedExports(exportModule);
+    }
+    export { __mf_default as default, __mf_remote_pending };${namedExportLine}`;
+}
+
 function generateShareModuleUnwrapCode({
   source,
   preserveNamedExports,
@@ -863,6 +901,13 @@ export function writeLoadShareModule(
   const usesEagerWorkspaceFallback =
     isWorkspaceSingleton && isWorkspaceSingletonConsumedByPeer(pkg);
   const namedExports = getSharedNamedExports(pkg, shareItem);
+  const hasConfiguredRemotes =
+    Object.keys(getNormalizeModuleFederationOptions()?.remotes || {}).length > 0;
+  const usesDeferredLocalSharedExports =
+    command === 'build' &&
+    !hasConfiguredRemotes &&
+    !isWorkspaceSingleton &&
+    namedExports.length > 0;
   let exportLine: string;
   let initBlock = '';
   if (usesEagerWorkspaceFallback) {
@@ -880,9 +925,17 @@ export function writeLoadShareModule(
       command !== 'build'
     );
   } else if (namedExports.length > 0) {
-    const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(', ')} } = exportModule;`;
-    const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(', ')} };`;
-    exportLine = `const __mfDefaultExport = (() => {
+    if (usesDeferredLocalSharedExports) {
+      importLine = `${getRuntimeInitPromiseBootstrapCode()}\n    ${importLine}`;
+      exportLine = generateDeferredLocalSharedExports(
+        namedExports,
+        sharedImportSource,
+        cacheDescriptor
+      );
+    } else {
+      const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(', ')} } = exportModule;`;
+      const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(', ')} };`;
+      exportLine = `const __mfDefaultExport = (() => {
       ${generateShareModuleUnwrapCode({
         source: 'exportModule',
         preserveNamedExports: false,
@@ -892,8 +945,9 @@ export function writeLoadShareModule(
     export default __mfDefaultExport;
     ${destructure}
     ${namedExportLine}`;
-    initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
+      initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
       __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);`;
+    }
   } else {
     exportLine = `export default exportModule.default ?? exportModule\n    export * from ${escapeGeneratedStringLiteral(sharedImportSource)}`;
     initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
@@ -902,7 +956,9 @@ export function writeLoadShareModule(
 
   const staticLocalShareSource = skipServePrebuildWarmup ? devImportSource : sharedImportSource;
   const prebuildImportLine =
-    isWorkspaceSingleton || (isWorkspacePackage && command !== 'build')
+    isWorkspaceSingleton ||
+    usesDeferredLocalSharedExports ||
+    (isWorkspacePackage && command !== 'build')
       ? ''
       : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(staticLocalShareSource)};`;
   const devDynamicImportLine = isWorkspacePackage
@@ -911,8 +967,9 @@ export function writeLoadShareModule(
       ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});`
       : '';
 
-  const moduleBody = isWorkspaceSingleton
-    ? `
+  const moduleBody =
+    isWorkspaceSingleton || usesDeferredLocalSharedExports
+      ? `
     ${prebuildImportLine}
     ${devDynamicImportLine}
     ${importLine}
@@ -920,7 +977,7 @@ export function writeLoadShareModule(
     ${normalizeLocalShareModuleCode}
     ${exportLine}
   `
-    : `
+      : `
     ${prebuildImportLine}
     ${devDynamicImportLine}
     ${importLine}


### PR DESCRIPTION
Close #881 

Changed build-mode singleton shared wrappers to read from the federation share cache before loading their local prebuild fallback, preventing duplicate shared dependency payload downloads across remotes.