### PR TITLE
fix: reuse shared cache before loading

### DIFF
--- a/e2e/vite-webpack-rspack/tests/index.spec.ts
+++ b/e2e/vite-webpack-rspack/tests/index.spec.ts
@@ -1,5 +1,15 @@
 import { expect, test } from '@playwright/test';
 
+function isDynamicRemoteSharedPayload(url: string) {
+  if (!url.startsWith('http://localhost:4002/')) return false;
+  if (url.includes('__loadShare__')) return false;
+  return (
+    url.includes('__prebuild__react') ||
+    url.includes('__prebuild__lodash') ||
+    /\/node_modules\/\.vite\/deps\/(?:react|react-dom|lodash)(?:[._-]|$)/.test(url)
+  );
+}
+
 test.describe('Vite Host Tests', () => {
   test.beforeEach(async ({ page, baseURL }) => {
     await page.goto(baseURL!);
@@ -206,6 +216,46 @@ test.describe('Dynamic remote', () => {
     await expect(lodashVersionDisplay).toBeVisible();
     const versionText2 = await lodashVersionDisplay.textContent();
     expect(versionText2).toMatch(/Shared lodash v\d+\.\d+\.\d+/);
+  });
+
+  test('does not download shared dependency payloads when dynamic remote hits cache', async ({
+    page,
+    baseURL,
+  }) => {
+    const dynamicRemoteSharedPayloads: string[] = [];
+    page.on('response', (response) => {
+      const url = response.url();
+      if (response.request().resourceType() === 'script' && isDynamicRemoteSharedPayload(url)) {
+        dynamicRemoteSharedPayloads.push(url);
+      }
+    });
+
+    await page.goto(baseURL!);
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Basic Tee',
+        exact: true,
+      })
+    ).toBeVisible();
+
+    dynamicRemoteSharedPayloads.length = 0;
+
+    const showAdToggle = page.getByRole('checkbox', {
+      name: 'Show Dynamic Ad',
+      exact: true,
+    });
+    await showAdToggle.check({ force: true });
+
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: 'Up to 50% off!',
+        exact: true,
+      })
+    ).toBeVisible();
+
+    expect(dynamicRemoteSharedPayloads).toEqual([]);
   });
 });
 

--- a/examples/vite-webpack-rspack/host/vite.config.js
+++ b/examples/vite-webpack-rspack/host/vite.config.js
@@ -29,7 +29,11 @@ const mfConfig = {
       type: 'module',
     },
   },
-  shared: ['react', 'react-dom', 'lodash'],
+  shared: {
+    react: { singleton: true },
+    'react-dom': { singleton: true },
+    lodash: {},
+  },
   moduleParseTimeout: 2,
   dts: false,
 };

--- a/integration/remote-entry-isolation.test.ts
+++ b/integration/remote-entry-isolation.test.ts
@@ -64,7 +64,7 @@ describe('remote entry isolation', () => {
 
     expect(hostInit!.code).not.toContain('__loadShare__');
     expect(hostInit!.code).not.toContain('__vite__mapDeps');
-    expect(hostInit!.code).not.toContain('localSharedImportMap');
+    expect(hostInit!.code).toContain('localSharedImportMap');
     expect(hostInit!.code).toContain('__mf_module_cache__');
     expect(hostInit!.code).not.toContain('virtualExposes');
   });

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -305,7 +305,12 @@ function normalizeShared(
     shared.forEach((key) => {
       if (isModuleFederationRuntimePackage(key)) return;
       const normalizedKey = normalizeSharedKey(key);
+      const hadConfiguredPackageSubpath =
+        (result[normalizedKey]?.shareConfig as any)?.__mfConfiguredPackageSubpath === true;
       result[normalizedKey] = normalizeShareItem(normalizedKey, normalizedKey);
+      if (key.endsWith('/') || hadConfiguredPackageSubpath) {
+        (result[normalizedKey].shareConfig as any).__mfConfiguredPackageSubpath = true;
+      }
       explicitSharedKeys.add(normalizedKey);
       sourceEntries.push([normalizedKey, normalizedKey]);
     });
@@ -314,7 +319,12 @@ function normalizeShared(
       if (isModuleFederationRuntimePackage(key)) return;
       const normalizedKey = normalizeSharedKey(key);
       const value = shared[key] as any;
+      const hadConfiguredPackageSubpath =
+        (result[normalizedKey]?.shareConfig as any)?.__mfConfiguredPackageSubpath === true;
       result[normalizedKey] = normalizeShareItem(normalizedKey, value);
+      if (key.endsWith('/') || hadConfiguredPackageSubpath) {
+        (result[normalizedKey].shareConfig as any).__mfConfiguredPackageSubpath = true;
+      }
       explicitSharedKeys.add(normalizedKey);
       sourceEntries.push([normalizedKey, value]);
     });

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -524,7 +524,7 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('"lit/decorators.js"');
   });
 
-  it('preloads root shared package dependencies before consumers and subpaths', async () => {
+  it('loads the finalized local shared map for host auto init preloads', async () => {
     normalizedSharedMock.mockReturnValue({
       '@repro/core': {
         name: '@repro/core',
@@ -569,60 +569,10 @@ describe('virtualRemoteEntry', () => {
 
     const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
 
-    expect(code.indexOf('"@repro/shared-lib"')).toBeLessThan(code.indexOf('"@repro/core"'));
-    expect(code.indexOf('"@repro/core"')).toBeLessThan(code.indexOf('"@repro/shared-lib/media"'));
-  });
-
-  it('does not seed a bare package for trailing slash shared packages', async () => {
-    normalizedSharedMock.mockReturnValue({
-      'wildcard-pkg/': {
-        name: 'wildcard-pkg/',
-        from: '',
-        version: '1.0.0',
-        scope: 'default',
-        shareConfig: {
-          singleton: true,
-          requiredVersion: '^1.0.0',
-          strictVersion: false,
-        },
-      },
-    });
-    const mod = await import('../virtualRemoteEntry');
-
-    mod.getUsedShares().clear();
-
-    const code = mod.generateDirectSharedCacheSeedCode('build');
-
-    expect(code).not.toContain('wildcard-pkg');
-    expect(code).not.toContain('index.js');
-  });
-
-  it('seeds the actual used subpath for trailing slash shared packages', async () => {
-    normalizedSharedMock.mockReturnValue({
-      'wildcard-pkg/': {
-        name: 'wildcard-pkg/',
-        from: '',
-        version: '1.0.0',
-        scope: 'default',
-        shareConfig: {
-          singleton: true,
-          requiredVersion: '^1.0.0',
-          strictVersion: false,
-        },
-      },
-    });
-    const mod = await import('../virtualRemoteEntry');
-
-    mod.getUsedShares().clear();
-    mod.addUsedShares('wildcard-pkg/button');
-
-    const code = mod.generateDirectSharedCacheSeedCode('build');
-
     expect(code).toContain(
-      '__mfReadSharedCache(__mfModuleCache.share, {"canonical":"default:wildcard-pkg/button","aliases":["wildcard-pkg/button"]})'
+      'const {usedShared} = await import("virtual:mf-localSharedImportMap:__mfe_internal__host")'
     );
-    expect(code).toContain('await import("/repo/node_modules/wildcard-pkg/dist/button.js")');
-    expect(code).not.toContain('"canonical":"default:wildcard-pkg","aliases":["wildcard-pkg"]');
+    expect(code).toContain('for (const [pkg, share] of Object.entries(usedShared))');
   });
 
   it('does not seed import:false shared modules in hostAutoInit during build', async () => {
@@ -867,9 +817,48 @@ describe('virtualRemoteEntry', () => {
       '__mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, singletonModule);'
     );
     expect(code.indexOf('const singletonCacheDescriptor')).toBeLessThan(
-      code.indexOf(
-        'if (__mfReadSharedCache(__mfModuleCache.share, {"canonical":"default:react@18.3.1","aliases":["react@18.3.1"]}) === undefined)'
-      )
+      code.indexOf('const initRes = runtimeInit({')
+    );
+  });
+
+  it('does not directly seed import-enabled shared modules before runtime sharing', async () => {
+    normalizedSharedMock.mockReturnValue({
+      react: {
+        name: 'react',
+        from: '',
+        version: '19.2.4',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^19.2.4',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).not.toContain('initRes.loadShare(pkg');
+    expect(code).not.toContain(
+      'const mod = await import("virtual:mf:remote__prebuild__react__prebuild__.js")'
     );
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1804,7 +1804,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('await ');
   });
 
-  it('keeps static bare package singleton fallbacks for remote-only dev containers without subpath sharing', () => {
+  it('defers bare package singleton fallbacks for remote-only dev containers without subpath sharing', () => {
     normalizeModuleFederationOptions({
       name: 'remote',
       exposes: {
@@ -1833,9 +1833,10 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('import * as __mfLocalShare from "lit";');
-    expect(generatedCode).toContain('export default __mfDefaultExport;');
-    expect(generatedCode).not.toContain('import("lit").then((mod) => {');
+    expect(generatedCode).not.toContain('import * as __mfLocalShare from "lit";');
+    expect(generatedCode).toContain('import("lit").then((mod) => {');
+    expect(generatedCode).toContain('export { __mf_default as default };');
+    expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('await ');
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1768,6 +1768,115 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('await ');
   });
 
+  it('defers bare package singleton fallbacks for remote-only containers in serve mode', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: {
+        './App': './src/App.jsx',
+      },
+      shared: {
+        'lit/': {
+          singleton: true,
+        },
+      },
+    });
+    const pkg = 'lit';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).not.toContain('import * as __mfLocalShare from "lit";');
+    expect(generatedCode).toContain('import("lit").then((mod) => {');
+    expect(generatedCode).toContain('export { __mf_default as default };');
+    expect(generatedCode).not.toContain('__prebuild__');
+    expect(generatedCode).not.toContain('await ');
+  });
+
+  it('keeps static bare package singleton fallbacks for remote-only dev containers without subpath sharing', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: {
+        './App': './src/App.jsx',
+      },
+      shared: {
+        lit: {
+          singleton: true,
+        },
+      },
+    });
+    const pkg = 'lit';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('import * as __mfLocalShare from "lit";');
+    expect(generatedCode).toContain('export default __mfDefaultExport;');
+    expect(generatedCode).not.toContain('import("lit").then((mod) => {');
+    expect(generatedCode).not.toContain('await ');
+  });
+
+  it('defers package subpath singleton fallbacks for remote-only containers in serve mode', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: {
+        './App': './src/App.jsx',
+      },
+      shared: {
+        'lit/': {
+          singleton: true,
+        },
+      },
+    });
+    const pkg = 'lit/directives/class-map.js';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '3.3.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^3.3.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).not.toContain(
+      'import * as __mfLocalShare from "lit/directives/class-map.js";'
+    );
+    expect(generatedCode).toContain('import("lit/directives/class-map.js").then((mod) => {');
+    expect(generatedCode).toContain('export { __mf_default as default };');
+    expect(generatedCode).not.toContain('__prebuild__');
+    expect(generatedCode).not.toContain('await ');
+  });
+
   it('generates ESM loadShare wrappers for vue root share in serve mode', () => {
     const pkg = 'vue';
     const mockShareItem: ShareItem = {

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -8,7 +8,6 @@ import { writeRuntimeInitStatus } from './virtualRuntimeInitStatus';
 export {
   addUsedShares,
   generateHostAutoInitCode,
-  generateDirectSharedCacheSeedCode,
   generateLocalSharedImportMap,
   generateRemoteEntry,
   getHostAutoInitImportId,

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -176,33 +176,14 @@ export function generateLocalSharedImportMap() {
       `;
 }
 
-function generateUsedSharedPreloadConfig() {
-  return `{
-      ${getOrderedUsedShares()
-        .map((pkg) => {
-          const shareItem = getShareItemForPreload(pkg);
-          if (!shareItem) return null;
-          return `${JSON.stringify(pkg)}: {
-            version: ${JSON.stringify(shareItem.version)},
-            scope: ${JSON.stringify(shareItem.scope)},
-            shareConfig: {
-              singleton: ${shareItem.shareConfig.singleton},
-              requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
-              strictVersion: ${shareItem.shareConfig.strictVersion},
-              ${shareItem.shareConfig.import === false ? 'import: false,' : ''}
-            }
-          }`;
-        })
-        .filter((item) => item !== null)
-        .join(',\n')}
-    }`;
-}
-
 function getOrderedUsedShares() {
   const shares = new Set(getUsedShares());
   try {
     Object.keys(getNormalizeModuleFederationOptions().shared).forEach((pkg) => {
-      if (!pkg.endsWith('/')) shares.add(pkg);
+      if (!pkg.endsWith('/')) {
+        shares.add(pkg);
+        return;
+      }
     });
   } catch {
     // Some isolated unit tests call generators before normalized options exist.
@@ -325,19 +306,31 @@ function hasImportFalseShared(options: NormalizedModuleFederationOptions): boole
   return Object.values(options.shared ?? {}).some((share) => share?.shareConfig?.import === false);
 }
 
-export function generateDirectSharedCacheSeedCode(command = 'build') {
-  return getOrderedUsedShares()
-    .map((pkg) => {
-      const shareItem = getShareItemForPreload(pkg);
-      if (!shareItem || shareItem.shareConfig.import === false) return null;
-      const importPath =
-        command === 'serve'
-          ? getLocalSharedPackagePath(pkg, shareItem)
-          : getDirectSharedCacheSeedImportPath(pkg, shareItem);
-      return generateSharedCacheSeedItem(pkg, shareItem, importPath);
-    })
-    .filter((item) => item !== null)
-    .join('\n');
+function generateRuntimeSharedCacheSeedCode() {
+  return `
+    for (const [pkg, share] of Object.entries(usedShared)) {
+      const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
+      if (share.shareConfig?.import === false || __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) {
+        continue;
+      }
+      const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);
+      const singletonModule = __mfReadSharedCache(__mfModuleCache.share, singletonCacheDescriptor);
+      if (singletonModule !== undefined) {
+        __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, singletonModule);
+        continue;
+      }
+      const factory = await share.get();
+      const mod = typeof factory === "function" ? factory() : factory;
+      const resolved = await Promise.resolve(mod);
+      ${normalizeRuntimeShareCode}
+      const normalizedModule = __mfNormalizeRuntimeShare(resolved);
+      const exportModule = normalizedModule === resolved ? {...resolved} : normalizedModule;
+      Object.defineProperty(exportModule, "__esModule", {
+        value: true,
+        enumerable: false
+      });
+      __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, exportModule);
+    }`;
 }
 
 function getBrowserImportPath(importPath: string) {
@@ -531,7 +524,7 @@ export function generateRemoteEntry(
         __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, singletonModule);
       }
     }
-    ${generateDirectSharedCacheSeedCode(command)}
+    ${generateRuntimeSharedCacheSeedCode()}
     const __browserPlugins = [${pluginImportNames
       .filter((item) => !isSsrOnlyPlugin(item[1]))
       .map((item) => `${item[0]}(${item[2]})`)
@@ -620,7 +613,7 @@ export function generateHostAutoInitCode(remoteEntryImport: string, _command = '
           ${generateHostAutoInitSharedCacheSeedCode(_command)}
           const remoteEntry = await import(${remoteEntryImport});
           const runtime = await remoteEntry.init();
-          const usedShared = ${generateUsedSharedPreloadConfig()};
+          const {usedShared} = await import("${getLocalSharedImportMapPath()}");
           ${normalizeRuntimeShareCode}
           ${
             shouldPreloadShares

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -442,22 +442,6 @@ function isRemoteOnlyContainer() {
   );
 }
 
-function hasConfiguredSharedPackageSubpath(pkg: string) {
-  const packageName = getPackageName(pkg);
-  const options = getNormalizeModuleFederationOptions();
-  return Object.keys(options.shared || {}).some((key) => {
-    const share = options.shared[key];
-    if (
-      (share?.shareConfig as any)?.__mfConfiguredPackageSubpath &&
-      getPackageName(key) === packageName
-    ) {
-      return true;
-    }
-    if (key === packageName || key === packageName + '/') return key !== packageName;
-    return getPackageName(key) === packageName && key !== packageName;
-  });
-}
-
 function tryResolveImportFromPackageRoot(pkg: string, root: string): string | undefined {
   try {
     const projectRequire = createRequire(pathToFileURL(path.join(root, 'package.json')));
@@ -891,24 +875,18 @@ export function writeLoadShareModule(
       : concreteSharedImportSource || localProviderPath || sharedImportSource;
   const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
   const isWorkspaceSingleton = isWorkspacePackage && shareItem.shareConfig.singleton === true;
-  const hasPackageSubpathSharing = hasConfiguredSharedPackageSubpath(pkg);
   const isDefaultShareScope =
     shareItem.scope === undefined ||
     shareItem.scope === 'default' ||
     (Array.isArray(shareItem.scope) && shareItem.scope[0] === 'default');
   const usesDeferredSingletonFallback =
     isWorkspaceSingleton ||
-    (command !== 'build' &&
-      isRemoteOnlyContainer() &&
-      shareItem.shareConfig.singleton === true &&
-      hasPackageSubpathSharing) ||
+    (command !== 'build' && isRemoteOnlyContainer() && shareItem.shareConfig.singleton === true) ||
     (command === 'build' &&
       isRemoteOnlyContainer() &&
       shareItem.shareConfig.singleton === true &&
       !isDefaultShareScope);
-  const usesEagerWorkspaceFallback =
-    (isWorkspaceSingleton && isSharedSingletonConsumedByPeer(pkg)) ||
-    (command !== 'build' && usesDeferredSingletonFallback && isSharedSingletonConsumedByPeer(pkg));
+  const usesEagerWorkspaceFallback = isWorkspaceSingleton && isSharedSingletonConsumedByPeer(pkg);
   const namedExports = getSharedNamedExports(pkg, shareItem);
   let exportLine: string;
   let initBlock = '';

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -368,6 +368,23 @@ function getWorkspacePackageJson(pkg: string) {
   })?.packageJson;
 }
 
+function getSharedDependencyGraphPackageJson(pkg: string) {
+  const installedPackageJson = getInstalledPackageJson(pkg, {
+    packageName: getPackageName(pkg),
+  })?.packageJson;
+  if (installedPackageJson) return installedPackageJson;
+  try {
+    const projectRequire = createRequire(
+      pathToFileURL(path.join(getPackageDetectionCwd(), 'package.json'))
+    );
+    const packageJsonPath = projectRequire.resolve(`${getPackageName(pkg)}/package.json`);
+    return JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  } catch {
+    // Fall back to workspace detection below.
+  }
+  return getWorkspacePackageJson(pkg);
+}
+
 function getDependencyNames(packageJson: Record<string, unknown> | undefined) {
   if (!packageJson) return [];
   const names = new Set<string>();
@@ -379,7 +396,7 @@ function getDependencyNames(packageJson: Record<string, unknown> | undefined) {
   return Array.from(names);
 }
 
-function isWorkspaceSingletonConsumedByPeer(pkg: string) {
+function isSharedSingletonConsumedByPeer(pkg: string) {
   const options = getNormalizeModuleFederationOptions();
   const shared = options?.shared || {};
   const sharedKeyByPackageName = new Map<string, string>();
@@ -401,7 +418,7 @@ function isWorkspaceSingletonConsumedByPeer(pkg: string) {
   // This covers both cyclic graphs and acyclic ones where a package is shared
   // together with one of its subpath exports (see issue #823).
   const reachesPkg = (current: string, seen: Set<string>): boolean => {
-    const packageJson = getWorkspacePackageJson(current);
+    const packageJson = getSharedDependencyGraphPackageJson(current);
     for (const dependency of getDependencyNames(packageJson)) {
       const sharedDependency = sharedKeyByPackageName.get(dependency);
       if (!sharedDependency) continue;
@@ -416,6 +433,29 @@ function isWorkspaceSingletonConsumedByPeer(pkg: string) {
   return Array.from(sharedKeyByPackageName.values()).some(
     (sharedPkg) => sharedPkg !== pkg && reachesPkg(sharedPkg, new Set([sharedPkg]))
   );
+}
+
+function isRemoteOnlyContainer() {
+  const options = getNormalizeModuleFederationOptions();
+  return (
+    Object.keys(options.exposes || {}).length > 0 && Object.keys(options.remotes || {}).length === 0
+  );
+}
+
+function hasConfiguredSharedPackageSubpath(pkg: string) {
+  const packageName = getPackageName(pkg);
+  const options = getNormalizeModuleFederationOptions();
+  return Object.keys(options.shared || {}).some((key) => {
+    const share = options.shared[key];
+    if (
+      (share?.shareConfig as any)?.__mfConfiguredPackageSubpath &&
+      getPackageName(key) === packageName
+    ) {
+      return true;
+    }
+    if (key === packageName || key === packageName + '/') return key !== packageName;
+    return getPackageName(key) === packageName && key !== packageName;
+  });
 }
 
 function tryResolveImportFromPackageRoot(pkg: string, root: string): string | undefined {
@@ -658,8 +698,7 @@ function generateEagerWorkspaceSingletonExports(
 function generateLazyWorkspaceSingletonExports(
   namedExports: string[],
   importSource: string,
-  cacheDescriptor: string,
-  eagerLocalFallback: boolean
+  cacheDescriptor: string
 ) {
   const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
   const declarations =
@@ -689,10 +728,7 @@ function generateLazyWorkspaceSingletonExports(
     };
     let exportModule = __mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor});
     if (exportModule === undefined) {
-      ${
-        eagerLocalFallback
-          ? applyLocalFallback
-          : `if (import.meta.env.SSR) {
+      if (import.meta.env.SSR) {
         ${applyLocalFallback}
       } else {
         (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() =>
@@ -702,20 +738,13 @@ function generateLazyWorkspaceSingletonExports(
             __mfApplyLazyShareExports(exportModule);
           })
         ));
-      }`
       }
     } else {
       __mfApplyLazyShareExports(exportModule);
     }
     export { __mf_default as default };${namedExportLine}`;
 
-  // Serve mode eagerly binds the local fallback. Build mode omits the static
-  // import here so client chunks never evaluate workspace singleton side effects
-  // before federation init; the SSR build prepends it in the load hook instead.
-  return eagerLocalFallback
-    ? `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(importSource)};
-    ${body}`
-    : body;
+  return body;
 }
 
 const WORKSPACE_SINGLETON_SSR_LOCAL_SHARE = '__mfNormalizeShareModule(__mfLocalShare)';
@@ -857,11 +886,29 @@ export function writeLoadShareModule(
     isWorkspacePackageEntry(pkg, localProviderPath) ||
     isWorkspacePackageEntry(pkg, concreteSharedImportSource);
   const lazyLocalFallbackSource =
-    concreteSharedImportSource || localProviderPath || sharedImportSource;
+    command !== 'build'
+      ? concreteSharedImportSource || localProviderPath || devImportSource
+      : concreteSharedImportSource || localProviderPath || sharedImportSource;
   const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
   const isWorkspaceSingleton = isWorkspacePackage && shareItem.shareConfig.singleton === true;
+  const hasPackageSubpathSharing = hasConfiguredSharedPackageSubpath(pkg);
+  const isDefaultShareScope =
+    shareItem.scope === undefined ||
+    shareItem.scope === 'default' ||
+    (Array.isArray(shareItem.scope) && shareItem.scope[0] === 'default');
+  const usesDeferredSingletonFallback =
+    isWorkspaceSingleton ||
+    (command !== 'build' &&
+      isRemoteOnlyContainer() &&
+      shareItem.shareConfig.singleton === true &&
+      hasPackageSubpathSharing) ||
+    (command === 'build' &&
+      isRemoteOnlyContainer() &&
+      shareItem.shareConfig.singleton === true &&
+      !isDefaultShareScope);
   const usesEagerWorkspaceFallback =
-    isWorkspaceSingleton && isWorkspaceSingletonConsumedByPeer(pkg);
+    (isWorkspaceSingleton && isSharedSingletonConsumedByPeer(pkg)) ||
+    (command !== 'build' && usesDeferredSingletonFallback && isSharedSingletonConsumedByPeer(pkg));
   const namedExports = getSharedNamedExports(pkg, shareItem);
   let exportLine: string;
   let initBlock = '';
@@ -871,13 +918,12 @@ export function writeLoadShareModule(
       lazyLocalFallbackSource,
       cacheDescriptor
     );
-  } else if (isWorkspaceSingleton) {
+  } else if (usesDeferredSingletonFallback) {
     importLine = `${getRuntimeInitPromiseBootstrapCode()}\n    ${importLine}`;
     exportLine = generateLazyWorkspaceSingletonExports(
       namedExports,
       lazyLocalFallbackSource,
-      cacheDescriptor,
-      command !== 'build'
+      cacheDescriptor
     );
   } else if (namedExports.length > 0) {
     const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(', ')} } = exportModule;`;
@@ -902,16 +948,18 @@ export function writeLoadShareModule(
 
   const staticLocalShareSource = skipServePrebuildWarmup ? devImportSource : sharedImportSource;
   const prebuildImportLine =
-    isWorkspaceSingleton || (isWorkspacePackage && command !== 'build')
+    usesDeferredSingletonFallback || (isWorkspacePackage && command !== 'build')
       ? ''
       : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(staticLocalShareSource)};`;
   const devDynamicImportLine = isWorkspacePackage
     ? ''
-    : command !== 'build' && !skipServePrebuildWarmup
-      ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});`
-      : '';
+    : usesDeferredSingletonFallback
+      ? ''
+      : command !== 'build' && !skipServePrebuildWarmup
+        ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});`
+        : '';
 
-  const moduleBody = isWorkspaceSingleton
+  const moduleBody = usesDeferredSingletonFallback
     ? `
     ${prebuildImportLine}
     ${devDynamicImportLine}


### PR DESCRIPTION
Close #881 

Make singleton shared fallback lazy during build and reuse cached shared modules before importing local providers, preventing duplicate downloads.