### PR TITLE
fix: fix transitive remote expose preloading

### DIFF
--- a/integration/fixtures/nested-remote-transitive/entry.js
+++ b/integration/fixtures/nested-remote-transitive/entry.js
@@ -1,0 +1,1 @@
+export default {};

--- a/integration/fixtures/nested-remote-transitive/exposed-widget.js
+++ b/integration/fixtures/nested-remote-transitive/exposed-widget.js
@@ -1,0 +1,5 @@
+import { value } from './store.js';
+
+export default function widget() {
+  return value;
+}

--- a/integration/fixtures/nested-remote-transitive/index.html
+++ b/integration/fixtures/nested-remote-transitive/index.html
@@ -1,0 +1,1 @@
+<script type="module" src="./entry.js"></script>

--- a/integration/fixtures/nested-remote-transitive/store.js
+++ b/integration/fixtures/nested-remote-transitive/store.js
@@ -1,0 +1,3 @@
+import { helper } from 'remoteA/shared/helpers';
+
+export const value = helper;

--- a/integration/remote-dependency-pending.test.ts
+++ b/integration/remote-dependency-pending.test.ts
@@ -20,6 +20,22 @@ const REMOTE_DEPENDENCY_MF_OPTIONS = {
   dts: false,
 } satisfies Partial<ModuleFederationOptions>;
 
+const TRANSITIVE_REMOTE_DEPENDENCY_MF_OPTIONS = {
+  name: 'transitiveRemote',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './widget': resolve(FIXTURES, 'nested-remote-transitive', 'exposed-widget.js'),
+  },
+  remotes: {
+    remoteA: {
+      name: 'remoteA',
+      entry: 'http://localhost:3001/remoteEntry.js',
+      type: 'module',
+    },
+  },
+  dts: false,
+} satisfies Partial<ModuleFederationOptions>;
+
 describe('remote dependency pending', () => {
   it('waits at expose loading for nested remote named imports without TLA', async () => {
     const output = await buildFixture({
@@ -40,5 +56,22 @@ describe('remote dependency pending', () => {
     expect(allCode).not.toMatch(
       /\b(?:const|var)\s+__mf_remote_dependency_pending\s*=\s*await\b/
     );
+  });
+
+  it('preloads nested remotes discovered through local transitive imports', async () => {
+    const output = await buildFixture({
+      fixture: 'nested-remote-transitive',
+      mfOptions: TRANSITIVE_REMOTE_DEPENDENCY_MF_OPTIONS,
+    });
+
+    const allCode = getAllChunkCode(output);
+
+    expect(allCode).toContain('__loadRemote__remoteA_mf_1_shared_mf_1_helpers__loadRemote__');
+    expect(allCode).toContain('loadRemote("remoteA/shared/helpers")');
+    expect(allCode).toMatch(
+      /await Promise\.all\(\[.*remoteA_mf_1_shared_mf_1_helpers__loadRemote__.*__mf_remote_pending/
+    );
+    expect(allCode).toContain('var { helper } = exportModule;');
+    expect(allCode).toContain('Promise.all([__mf_remote_pending]);');
   });
 });

--- a/integration/remote-dependency-pending.test.ts
+++ b/integration/remote-dependency-pending.test.ts
@@ -71,7 +71,7 @@ describe('remote dependency pending', () => {
     expect(allCode).toMatch(
       /await Promise\.all\(\[.*remoteA_mf_1_shared_mf_1_helpers__loadRemote__.*__mf_remote_pending/
     );
-    expect(allCode).toContain('var { helper } = exportModule;');
+    expect(allCode).toMatch(/\b(?:const|var)\s+\{\s*helper(?:\s*:\s*helper)?\s*\}\s*=/);
     expect(allCode).toContain('Promise.all([__mf_remote_pending]);');
   });
 });

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -50,14 +50,52 @@ export default function ({
     );
   }
 
-  function collectRemoteDependencies(code: string): string[] {
-    const dependencies = new Set<string>();
+  function collectImportSources(code: string): string[] {
+    const sources = new Set<string>();
     const importRe =
       /(?:^|[;\n\r])\s*import\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']|import\(\s*["']([^"']+)["']\s*\)/g;
 
     for (const match of code.matchAll(importRe)) {
       const source = match[1] || match[2];
-      if (source && isRemoteImport(source)) dependencies.add(source);
+      if (source) sources.add(source);
+    }
+
+    return Array.from(sources).sort();
+  }
+
+  function shouldScanResolvedImport(id: string): boolean {
+    if (!id || id.includes('\0')) return false;
+    if (id.includes('/node_modules/') || id.includes('\\node_modules\\')) return false;
+    return /\.(?:[cm]?[jt]sx?|vue|svelte)(?:\?|$)/.test(id);
+  }
+
+  async function collectRemoteDependencies(
+    ctx: { resolve: Plugin['resolveId'] },
+    id: string,
+    seen = new Set<string>()
+  ): Promise<string[]> {
+    if (seen.has(id) || !shouldScanResolvedImport(id)) return [];
+    seen.add(id);
+
+    let code: string;
+    try {
+      code = readFileSync(id, 'utf8');
+    } catch {
+      return [];
+    }
+
+    const dependencies = new Set<string>();
+    for (const source of collectImportSources(code)) {
+      if (isRemoteImport(source)) {
+        dependencies.add(source);
+        continue;
+      }
+
+      const resolved = await (ctx as any).resolve(source, id);
+      if (!resolved?.id || !shouldScanResolvedImport(resolved.id)) continue;
+      for (const dependency of await collectRemoteDependencies(ctx, resolved.id, seen)) {
+        dependencies.add(dependency);
+      }
     }
 
     return Array.from(dependencies).sort();
@@ -67,12 +105,7 @@ export default function ({
     const next: Record<string, string[]> = {};
     for (const [exposeKey, expose] of Object.entries(options.exposes)) {
       const resolved = await (ctx as any).resolve(expose.import);
-      if (!resolved?.id || resolved.id.includes('\0')) continue;
-      try {
-        next[exposeKey] = collectRemoteDependencies(readFileSync(resolved.id, 'utf8'));
-      } catch {
-        next[exposeKey] = [];
-      }
+      next[exposeKey] = resolved?.id ? await collectRemoteDependencies(ctx, resolved.id) : [];
     }
     exposeRemoteDependencies = next;
   }


### PR DESCRIPTION
Close #887

Fixes transitive remote dependency preloading for exposed modules by recursively scanning local imports before loading the exposed chunk.