### PR TITLE
fix: resolve wildcard subpath patterns in package exports

### DIFF
--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -87,6 +87,118 @@ describe('getInstalledPackageJson', () => {
 
     expect(entry).toBe(path.join(packageDir, 'dist/browser.js'));
   });
+
+  it('resolves wildcard subpath exports (e.g. "./components/*")', () => {
+    const packageName = 'mf-test-wildcard-ui';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-wildcard-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'components'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: { './components/*': './components/*.tsx' },
+      })
+    );
+    writeFileSync(
+      path.join(packageDir, 'components/button.tsx'),
+      'export const Button = () => null;'
+    );
+
+    const entry = getInstalledPackageEntry(`${packageName}/components/button`, {
+      cwd: hostDir,
+      resolveSubpathWithRequire: false,
+    });
+
+    expect(entry).toContain('/components/button.tsx');
+  });
+
+  it('substitutes the wildcard into conditional exports targets', () => {
+    const packageName = 'mf-test-wildcard-conditions';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-wildcard-cond-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'esm'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: {
+          './features/*': { import: './esm/*.js', require: './cjs/*.cjs' },
+        },
+      })
+    );
+    writeFileSync(path.join(packageDir, 'esm/button.js'), 'export const Button = () => null;');
+
+    const entry = getInstalledPackageEntry(`${packageName}/features/button`, {
+      cwd: hostDir,
+      resolveSubpathWithRequire: false,
+    });
+
+    expect(entry).toContain('/esm/button.js');
+  });
+
+  it('substitutes the wildcard into fallback-array exports targets', () => {
+    const packageName = 'mf-test-wildcard-array';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-wildcard-arr-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'esm'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: { './features/*': ['./esm/*.js', './fallback/*.js'] },
+      })
+    );
+    writeFileSync(path.join(packageDir, 'esm/button.js'), 'export const Button = () => null;');
+
+    const entry = getInstalledPackageEntry(`${packageName}/features/button`, {
+      cwd: hostDir,
+      resolveSubpathWithRequire: false,
+    });
+
+    expect(entry).toContain('/esm/button.js');
+  });
+
+  it('prefers the most specific (longest-prefix) wildcard pattern', () => {
+    const packageName = 'mf-test-wildcard-specificity';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-wildcard-spec-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'components'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: {
+          './*': './src/*.js',
+          './components/*': './components/*.tsx',
+        },
+      })
+    );
+    writeFileSync(path.join(packageDir, 'components/card.tsx'), 'export const Card = () => null;');
+
+    const entry = getInstalledPackageEntry(`${packageName}/components/card`, {
+      cwd: hostDir,
+      resolveSubpathWithRequire: false,
+    });
+
+    expect(entry).toContain('/components/card.tsx');
+  });
 });
 
 describe('resolveImportPath', () => {

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -199,6 +199,35 @@ describe('getInstalledPackageJson', () => {
 
     expect(entry).toContain('/components/card.tsx');
   });
+
+  it('breaks ties between equal-length wildcard bases by longest key', () => {
+    const packageName = 'mf-test-wildcard-tiebreak';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-wildcard-tie-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'min'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: {
+          './*': './src/*.js',
+          './*.js': './min/*.js',
+        },
+      })
+    );
+    writeFileSync(path.join(packageDir, 'min/button.js'), 'export const Button = () => null;');
+
+    const entry = getInstalledPackageEntry(`${packageName}/button.js`, {
+      cwd: hostDir,
+      resolveSubpathWithRequire: false,
+    });
+
+    expect(entry).toContain('/min/button.js');
+  });
 });
 
 describe('resolveImportPath', () => {

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -79,13 +79,53 @@ function resolveExportsEntry(
   return undefined;
 }
 
+function substituteExportsWildcard(target: unknown, patternMatch: string): unknown {
+  if (typeof target === 'string') return target.split('*').join(patternMatch);
+  if (Array.isArray(target)) {
+    return target.map((entry) => substituteExportsWildcard(entry, patternMatch));
+  }
+  if (target && typeof target === 'object') {
+    const source = target as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(source))
+      out[key] = substituteExportsWildcard(source[key], patternMatch);
+    return out;
+  }
+  return target;
+}
+
+function matchExportsSubpath(record: Record<string, unknown>, subpath: string): unknown {
+  if (subpath in record) return record[subpath];
+
+  let bestKey: string | undefined;
+  let bestBaseLength = -1;
+  for (const key of Object.keys(record)) {
+    const wildcardIndex = key.indexOf('*');
+    if (wildcardIndex === -1) continue;
+    const patternBase = key.slice(0, wildcardIndex);
+    const patternTrailer = key.slice(wildcardIndex + 1);
+    if (patternTrailer.includes('*')) continue;
+    if (!subpath.startsWith(patternBase) || !subpath.endsWith(patternTrailer)) continue;
+    if (subpath.length <= patternBase.length + patternTrailer.length) continue;
+    if (patternBase.length > bestBaseLength) {
+      bestKey = key;
+      bestBaseLength = patternBase.length;
+    }
+  }
+  if (bestKey === undefined) return undefined;
+
+  const patternTrailer = bestKey.slice(bestKey.indexOf('*') + 1);
+  const patternMatch = subpath.slice(bestBaseLength, subpath.length - patternTrailer.length);
+  return substituteExportsWildcard(record[bestKey], patternMatch);
+}
+
 function getPackageExportsTarget(pkg: string, packageName: string, exportsField: unknown): unknown {
   if (typeof exportsField === 'string') return pkg === packageName ? exportsField : undefined;
   if (!exportsField || typeof exportsField !== 'object') return undefined;
 
   const record = exportsField as Record<string, unknown>;
   const subpath = pkg === packageName ? '.' : `.${pkg.slice(packageName.length)}`;
-  if (subpath !== '.') return record[subpath];
+  if (subpath !== '.') return matchExportsSubpath(record, subpath);
 
   return (
     record['.'] ?? (!Object.keys(record).some((key) => key.startsWith('.')) ? record : undefined)

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -99,6 +99,7 @@ function matchExportsSubpath(record: Record<string, unknown>, subpath: string): 
 
   let bestKey: string | undefined;
   let bestBaseLength = -1;
+  let bestKeyLength = -1;
   for (const key of Object.keys(record)) {
     const wildcardIndex = key.indexOf('*');
     if (wildcardIndex === -1) continue;
@@ -107,9 +108,13 @@ function matchExportsSubpath(record: Record<string, unknown>, subpath: string): 
     if (patternTrailer.includes('*')) continue;
     if (!subpath.startsWith(patternBase) || !subpath.endsWith(patternTrailer)) continue;
     if (subpath.length <= patternBase.length + patternTrailer.length) continue;
-    if (patternBase.length > bestBaseLength) {
+    if (
+      patternBase.length > bestBaseLength ||
+      (patternBase.length === bestBaseLength && key.length > bestKeyLength)
+    ) {
       bestKey = key;
       bestBaseLength = patternBase.length;
+      bestKeyLength = key.length;
     }
   }
   if (bestKey === undefined) return undefined;


### PR DESCRIPTION
### Problem

Sharing a workspace package whose `package.json` uses **wildcard `exports` subpaths** (the layout shadcn/ui and Base UI generate) fails in dev. Given:

```json
{
  "exports": {
    "./components/*": "./components/*.tsx"
  }
}
```

the generated `loadShare` module throws:

```
The requested module '...' does not provide an export named 'Button'
```

(same for `Select`, `CommandDialog`, etc.). The shared module exposes only a `default` export.

### Root Cause

`getPackageExportsTarget` (`src/utils/packageUtils.ts`) resolves a subpath against the `exports` map by **exact-key lookup only** (`record[subpath]`). For `@scope/ui/components/button`, `subpath` is `./components/button`, but the map only contains the wildcard key `./components/*`, so the lookup returns `undefined`, resolution falls back to `index.js`, and named-export detection yields `[]`.

The chain that surfaces it:

```
getSharedNamedExports
  -> getPackageNamedExports        // require() fails on a .tsx source
  -> getEsmNamedExports
  -> getPackageEsmEntryPath
  -> getInstalledPackageEntry({ resolveSubpathWithRequire: false })
  -> getPackageExportsTarget       // returns undefined for the wildcard subpath
```

### Fix

Replace the exact-key lookup in `getPackageExportsTarget` with Node's `exports` subpath pattern matching (`PACKAGE_IMPORTS_EXPORTS_RESOLVE`): the exact key wins first, otherwise the best pattern by `PATTERN_KEY_COMPARE` (longest literal `patternBase`, then longest key), and the captured `patternMatch` is substituted into the resolved target. Two small helpers do this (`matchExportsSubpath` and `substituteExportsWildcard`), covering string, conditional-object, and fallback-array targets.

### Tests

Adds 5 cases to `src/utils/__tests__/packageUtils.test.ts`: wildcard resolution into string, conditional-object, and fallback-array targets, plus longest-prefix and equal-base tiebreak selection.

- Verified the 5 new tests **fail on `main`** (exact-key lookup) and **pass with the fix**; the 13 pre-existing tests pass unchanged.
- Full suite: **636 passing**. `pnpm fmt.check` and `pnpm typecheck` clean.

### Impact / Scope

- **Purely additive.** The exact-key path is byte-identical, so every package that resolved before resolves identically. Only previously unresolved wildcard subpaths change, from broken to correct. The `.` (root) path is untouched.
- **Faithful to Node's resolution.** A shared package's subpaths resolve to the same target Node itself would, so the shared copy matches what the host app imports directly.
- This is the entry-resolver counterpart to the recent workspace named-export fixes (#864, #860, #870), which addressed `virtualShared_preBuild.ts` but not the `exports`-map resolution in `packageUtils.ts` where this gap lived.

### Reproduction

Any workspace monorepo where a shared package's `package.json` `exports` uses a wildcard subpath pointing at source (e.g. `"./components/*": "./components/*.tsx"`) and lists the package in `shared`. Importing any component subpath from the federated module then throws in dev.
