### PR TITLE
fix: seed subpath shares before their package root

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -632,6 +632,97 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('for (const pkg of Object.keys(usedShared))');
   });
 
+  it('orders package subpath shares discovered after remoteEntry codegen before their package root', async () => {
+    const shareItem = (name: string) => ({
+      name,
+      from: '',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^1.0.0',
+        strictVersion: false,
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      '@repro/shared-lib': shareItem('@repro/shared-lib'),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/shared-lib');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    const seedOrderMatch = code.match(/const __mfSeedOrder = (\[[^\]]*\]);/);
+    expect(seedOrderMatch).not.toBeNull();
+    expect(JSON.parse(seedOrderMatch![1]) as string[]).toEqual(['@repro/shared-lib']);
+
+    const seedCodeMatch = code.match(/const __mfSeedOrder = [\s\S]*?\n\s+const __browserPlugins =/);
+    expect(seedCodeMatch).not.toBeNull();
+    const seedCode = seedCodeMatch![0].replace(/\n\s+const __browserPlugins =$/, '');
+    const calls: string[] = [];
+    const usedShared = {
+      '@repro/shared-lib': {
+        name: '@repro/shared-lib',
+        version: '1.0.0',
+        scope: ['default'],
+        shareConfig: { singleton: true },
+        get: async () => {
+          calls.push('@repro/shared-lib');
+          return () => ({});
+        },
+      },
+      '@repro/shared-lib/media': {
+        name: '@repro/shared-lib/media',
+        version: '1.0.0',
+        scope: ['default'],
+        shareConfig: { singleton: true },
+        get: async () => {
+          calls.push('@repro/shared-lib/media');
+          return () => ({});
+        },
+      },
+    };
+
+    await new Function(
+      'usedShared',
+      `
+        return (async () => {
+          const __mfModuleCache = { share: {} };
+          const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
+            const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
+            const id = singleton || !version ? pkg : pkg + '@' + version;
+            return { canonical: scopeName + ':' + id };
+          };
+          const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+          const __mfWriteSharedCache = (cache, descriptor, value) => {
+            cache[descriptor.canonical] = value;
+          };
+          ${seedCode}
+        })();
+      `
+    )(usedShared);
+
+    expect(calls.indexOf('@repro/shared-lib/media')).toBeLessThan(
+      calls.indexOf('@repro/shared-lib')
+    );
+  });
+
   it('does not seed import:false shared modules in hostAutoInit during build', async () => {
     normalizedSharedMock.mockReturnValue({
       vue: {

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -575,6 +575,63 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('for (const [pkg, share] of Object.entries(usedShared))');
   });
 
+  it('seeds package subpath shares and shared dependencies before their consumers', async () => {
+    const shareItem = (name: string) => ({
+      name,
+      from: '',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^1.0.0',
+        strictVersion: false,
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      '@repro/core': shareItem('@repro/core'),
+      '@repro/shared-lib': shareItem('@repro/shared-lib'),
+      '@repro/shared-lib/media': shareItem('@repro/shared-lib/media'),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/core');
+    mod.addUsedShares('@repro/shared-lib');
+    mod.addUsedShares('@repro/shared-lib/media');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    const seedOrderMatch = code.match(/const __mfSeedOrder = (\[[^\]]*\]);/);
+    expect(seedOrderMatch).not.toBeNull();
+    const seedOrder = JSON.parse(seedOrderMatch![1]) as string[];
+
+    // A package's modules can consume its own shared subpath exports through
+    // self-referencing bare specifiers at module-evaluation time, so the
+    // subpath must be cached before the package root is evaluated.
+    expect(seedOrder.indexOf('@repro/shared-lib/media')).toBeLessThan(
+      seedOrder.indexOf('@repro/shared-lib')
+    );
+    // Shared dependencies seed before their consumers (@repro/core depends
+    // on @repro/shared-lib).
+    expect(seedOrder.indexOf('@repro/shared-lib')).toBeLessThan(seedOrder.indexOf('@repro/core'));
+    // Share keys discovered after codegen still get seeded, after the ordered ones.
+    expect(code).toContain('for (const pkg of Object.keys(usedShared))');
+  });
+
   it('does not seed import:false shared modules in hostAutoInit during build', async () => {
     normalizedSharedMock.mockReturnValue({
       vue: {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -331,8 +331,26 @@ function generateRuntimeSharedCacheSeedCode() {
   return `
     const __mfSeedOrder = ${JSON.stringify(seedOrder)};
     const __mfSeedKeys = __mfSeedOrder.filter((pkg) => usedShared[pkg] !== undefined);
+    const __mfSeedPackageName = (pkg) => pkg.startsWith('@')
+      ? pkg.split('/').slice(0, 2).join('/')
+      : pkg.split('/')[0];
     for (const pkg of Object.keys(usedShared)) {
-      if (!__mfSeedKeys.includes(pkg)) __mfSeedKeys.push(pkg);
+      if (__mfSeedKeys.includes(pkg)) continue;
+      const packageName = __mfSeedPackageName(pkg);
+      const rootIndex = __mfSeedKeys.indexOf(packageName);
+      if (rootIndex === -1) {
+        __mfSeedKeys.push(pkg);
+        continue;
+      }
+      let insertIndex = rootIndex;
+      while (
+        insertIndex > 0 &&
+        __mfSeedPackageName(__mfSeedKeys[insertIndex - 1]) === packageName &&
+        __mfSeedKeys[insertIndex - 1] !== packageName
+      ) {
+        insertIndex--;
+      }
+      __mfSeedKeys.splice(insertIndex, 0, pkg);
     }
     for (const pkg of __mfSeedKeys) {
       const share = usedShared[pkg];

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -198,11 +198,17 @@ function getOrderedUsedShares() {
 
 function orderSharedDependenciesFirst(sharedPackages: string[]) {
   const sharedKeyByPackageName = new Map<string, string>();
+  const subpathKeysByPackageName = new Map<string, string[]>();
   sharedPackages.forEach((pkg) => {
     const packageName = getPackageName(pkg);
     const existing = sharedKeyByPackageName.get(packageName);
     if (!existing || pkg === packageName) {
       sharedKeyByPackageName.set(packageName, pkg);
+    }
+    if (pkg !== packageName) {
+      const subpaths = subpathKeysByPackageName.get(packageName);
+      if (subpaths) subpaths.push(pkg);
+      else subpathKeysByPackageName.set(packageName, [pkg]);
     }
   });
   const visiting = new Set<string>();
@@ -212,7 +218,10 @@ function orderSharedDependenciesFirst(sharedPackages: string[]) {
     if (visited.has(pkg)) return;
     if (visiting.has(pkg)) return;
     visiting.add(pkg);
-    const packageJson = getInstalledPackageJson(pkg)?.packageJson;
+    const packageName = getPackageName(pkg);
+    const packageJson =
+      getInstalledPackageJson(pkg)?.packageJson ??
+      (pkg !== packageName ? getInstalledPackageJson(packageName)?.packageJson : undefined);
     const dependencies = {
       ...((packageJson?.dependencies as Record<string, string> | undefined) || {}),
       ...((packageJson?.peerDependencies as Record<string, string> | undefined) || {}),
@@ -222,6 +231,12 @@ function orderSharedDependenciesFirst(sharedPackages: string[]) {
       const sharedDependency = sharedKeyByPackageName.get(dependency);
       if (sharedDependency) visit(sharedDependency);
     });
+    // A package's modules can consume its own shared subpath exports through
+    // self-referencing bare specifiers at module-evaluation time, so subpath
+    // share keys must come before their package root (see #767, #805).
+    if (pkg === packageName) {
+      (subpathKeysByPackageName.get(packageName) || []).forEach(visit);
+    }
     visiting.delete(pkg);
     visited.add(pkg);
     ordered.push(pkg);
@@ -307,8 +322,20 @@ function hasImportFalseShared(options: NormalizedModuleFederationOptions): boole
 }
 
 function generateRuntimeSharedCacheSeedCode() {
+  // Seeding a share evaluates its module graph, and every share proxy hit
+  // during that evaluation must already be cached — the proxies defer their
+  // local fallback until after init, so an unseeded proxy leaves its named
+  // exports undefined at module-evaluation time. Seed dependencies and a
+  // package's own subpath shares before the package itself.
+  const seedOrder = getOrderedUsedShares();
   return `
-    for (const [pkg, share] of Object.entries(usedShared)) {
+    const __mfSeedOrder = ${JSON.stringify(seedOrder)};
+    const __mfSeedKeys = __mfSeedOrder.filter((pkg) => usedShared[pkg] !== undefined);
+    for (const pkg of Object.keys(usedShared)) {
+      if (!__mfSeedKeys.includes(pkg)) __mfSeedKeys.push(pkg);
+    }
+    for (const pkg of __mfSeedKeys) {
+      const share = usedShared[pkg];
       const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
       if (share.shareConfig?.import === false || __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) {
         continue;


### PR DESCRIPTION
### Problem

Regression in **1.16.14** (works in 1.16.13), dev serve only. When a symlinked (`file:`/workspace) package is shared as a singleton **together with one of its exact-key subpath exports**, and the package's own source imports that subpath through a self-referencing bare specifier:

```js
// packages/widgets/index.js
import { builder } from 'widgets/api';

export const root = builder.post({ path: '/search' }); // ← TypeError
```

```js
// vite.config.js
shared: {
  widgets: { singleton: true },
  'widgets/api': { singleton: true },
}
```

the subpath share resolves with **undefined named exports** at module-evaluation time:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'post')
```

Sharing only the subpath (without the root) works; `vite build` is unaffected. This is the dev-serve reincarnation of the failure family previously fixed for production builds in #767 (fixed by #774) and #805 (fixed by #807).

### Root Cause

Two changes from #883 combine:

1. Serve-mode share proxies no longer bind an **eager local fallback** — on a cache miss they defer export assignment into `pendingShareLoads` until after federation init. Correct for cache reuse, but it makes seeding order load-bearing: any share proxy hit during seeding must already be cached.
2. The new runtime seed loop (`generateRuntimeSharedCacheSeedCode`) iterates `Object.entries(usedShared)`, whose key order is **alphabetical** (`getUsedShares().sort()`). `"widgets"` sorts before `"widgets/api"`, so seeding the package root `await share.get()` evaluates `widgets/index.js` while `widgets/api` is still unseeded — its proxy defers, its named exports stay `undefined`, and the root's top-level code crashes.

The dependency-first ordering from #807 (`orderSharedDependenciesFirst`) already exists but wasn't used by the new seed loop, and it didn't know that a package root implicitly depends on its own subpath shares.

### Fix

- `orderSharedDependenciesFirst` now treats a package's subpath share keys as dependencies of the package root: when visiting a root key, its subpath keys are visited (and therefore ordered) first. Subpath keys also resolve their dependency list through the root package's `package.json` when the subpath itself doesn't resolve to one.
- `generateRuntimeSharedCacheSeedCode` seeds in `getOrderedUsedShares()` order (embedded at codegen time) instead of `usedShared` insertion order, with a runtime fallback that appends any share keys discovered after codegen so nothing is skipped.

This preserves #883's cache-reuse semantics — no eager fallback is reintroduced; the fix only makes the seeding order match the evaluation-order requirements the deferred fallback created. For the example above the seed order becomes `['widgets/api', 'widgets']`, so by the time `widgets/index.js` evaluates, the `widgets/api` proxy hits a warm cache and applies its exports synchronously.

Known limitation: a genuine evaluation-time cycle (root imports subpath **and** subpath imports root) cannot be solved by ordering alone; that case was equally broken before this change.