### PR TITLE
fix: solve runtime host shared singleton race

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -490,6 +490,7 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('const {usedShared, usedRemotes} = await getLocalSharedImportMap()');
     expect(code).toContain('const exposesMap = await getExposesMap()');
     expect(code).toContain('const mfName = "host"');
+    expect(code).toContain('await Promise.all(__mfModuleCache.pendingShareLoads)');
     expect(code).toContain('share.shareConfig?.import !== false');
     expect(code).toContain('const versions = shared?.[pkg]');
     expect(code.indexOf('share.shareConfig?.import !== false')).toBeLessThan(

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2128,6 +2128,9 @@ describe('writePreBuildLibPath', () => {
     // instead of a bare initPromise.then()
     expect(generatedCode).toContain('pendingShareLoads');
     expect(generatedCode).toContain('initPromise.then');
+    expect(generatedCode).toContain('__mfReadSharedCache(__mfModuleCache.share');
+    expect(generatedCode).toContain('if (exportModule !== undefined)');
+    expect(generatedCode).toContain('return import(');
 
     // Must use the ||= pattern for lazy initialization
     expect(generatedCode).toContain('||= []');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -583,6 +583,9 @@ export function generateRemoteEntry(
   async function getExposes(moduleName) {
     const exposesMap = await getExposesMap()
     if (!(moduleName in exposesMap)) throw new Error(\`[Module Federation] Module \${moduleName} does not exist in container.\`)
+    if (__mfModuleCache.pendingShareLoads) {
+      await Promise.all(__mfModuleCache.pendingShareLoads)
+    }
     return (exposesMap[moduleName])().then(res => () => res)
   }
   export {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -715,13 +715,18 @@ function generateLazyWorkspaceSingletonExports(
       if (import.meta.env.SSR) {
         ${applyLocalFallback}
       } else {
-        (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() =>
-          import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
+        (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() => {
+          exportModule = __mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor});
+          if (exportModule !== undefined) {
+            __mfApplyLazyShareExports(exportModule);
+            return;
+          }
+          return import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
             exportModule = __mfNormalizeShareModule(mod);
             __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);
             __mfApplyLazyShareExports(exportModule);
-          })
-        ));
+          });
+        }));
       }
     } else {
       __mfApplyLazyShareExports(exportModule);
@@ -738,9 +743,13 @@ export function prependWorkspaceSingletonSsrImport(code: string): string {
   if (!code.includes(WORKSPACE_SINGLETON_SSR_LOCAL_SHARE)) return code;
   if (code.includes('import * as __mfLocalShare')) return code;
 
-  const importMatch = code.match(
-    /initPromise\.then\(\(\)\s*=>\s*\n\s*import\((["'])(.+?)\1\)\.then\(\(mod\)\s*=>\s*\{[\s\S]*?__mfApplyLazyShareExports/
-  );
+  const importMatch =
+    code.match(
+      /initPromise\.then\(\(\)\s*=>\s*\{[\s\S]*?\breturn import\((["'])(.+?)\1\)\.then\(\(mod\)\s*=>\s*\{[\s\S]*?__mfApplyLazyShareExports/
+    ) ??
+    code.match(
+      /initPromise\.then\(\(\)\s*=>\s*\n\s*import\((["'])(.+?)\1\)\.then\(\(mod\)\s*=>\s*\{[\s\S]*?__mfApplyLazyShareExports/
+    );
   if (!importMatch) return code;
 
   const quote = importMatch[1];


### PR DESCRIPTION
Close #895

Fixes shared singleton races for runtime-only hosts by rechecking the shared cache after initialization and awaiting pending shared loads before exposing remote modules.
