### PR TITLE
fix: preserve requiredVersion false in shared config

### DIFF
--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -288,6 +288,23 @@ describe('normalizeModuleFederationOption', () => {
       });
     });
 
+    it('preserves requiredVersion: false to disable version constraints', () => {
+      const shared = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          dep1: {
+            requiredVersion: false,
+            strictVersion: true,
+          },
+        },
+      }).shared;
+
+      expect(shared.dep1.shareConfig).toMatchObject({
+        requiredVersion: false,
+        strictVersion: true,
+      });
+    });
+
     it('normalizes docs-style trailing slash keys for common subpath shares', () => {
       const shared = normalizeModuleFederationOptions({
         ...minimalOptions,

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -165,8 +165,10 @@ function searchPackageVersion(sharedName: string): string | undefined {
   return typeof version === 'string' ? version : undefined;
 }
 
-function inferVersionFromRequiredVersion(requiredVersion?: string): string | undefined {
-  if (!requiredVersion) return undefined;
+function inferVersionFromRequiredVersion(
+  requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion']
+): string | undefined {
+  if (typeof requiredVersion !== 'string') return undefined;
   const match = requiredVersion.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/);
   return match?.[0];
 }
@@ -195,7 +197,7 @@ function normalizeShareItem(
         version?: string;
         shareScope?: string;
         singleton?: boolean;
-        requiredVersion?: string;
+        requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion'];
         strictVersion?: boolean;
       }
 ): ShareItem {
@@ -241,8 +243,13 @@ function normalizeShareItem(
       import: shareItem.import,
       singleton: shareItem.singleton || false,
       requiredVersion:
-        shareItem.requiredVersion ||
-        (isImportFalse || shareItem.version ? '*' : version ? `^${version}` : '*'),
+        shareItem.requiredVersion !== undefined
+          ? shareItem.requiredVersion
+          : isImportFalse || shareItem.version
+            ? '*'
+            : version
+              ? `^${version}`
+              : '*',
       strictVersion: !!shareItem.strictVersion,
     },
   };
@@ -266,7 +273,7 @@ function normalizeShared(
             version?: string;
             shareScope?: string;
             singleton?: boolean;
-            requiredVersion?: string;
+            requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion'];
             strictVersion?: boolean;
           }
       >
@@ -438,7 +445,7 @@ export type ModuleFederationOptions = {
             version?: string;
             shareScope?: string;
             singleton?: boolean;
-            requiredVersion?: string;
+            requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion'];
             strictVersion?: boolean;
             import?: moduleFederationPlugin.SharedConfig['import'];
           }

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -176,7 +176,7 @@ vi.mock('../../utils/normalizeModuleFederationOptions', () => {
       shareConfig: {
         import: pkg === 'custom-import' ? '/abs/custom-import.js' : undefined,
         singleton: true,
-        requiredVersion: '^19.2.4',
+        requiredVersion: pkg === 'unconstrained' ? false : '^19.2.4',
         strictVersion: false,
       },
     }),
@@ -327,6 +327,17 @@ describe('virtualRemoteEntry', () => {
 
     expect(code).toContain('from: "host"');
     expect(code).not.toContain('from: "__mfe_internal__host"');
+  });
+
+  it('emits requiredVersion: false in generated shared records', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('unconstrained');
+
+    const code = mod.generateLocalSharedImportMap();
+
+    expect(code).toContain('requiredVersion: false');
   });
 
   it('writes host auto init before init', async () => {


### PR DESCRIPTION
## Summary

- support the official `requiredVersion: false` shared configuration
- preserve `false` during normalization instead of replacing it with an inferred semver range
- align Vite behavior with the Module Federation 2.0 SDK, runtime, and Rspack implementation

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm fmt.check`
- [x] `pnpm test`
- [x] `pnpm test:integration`
- [x] `pnpm build`
- [x] `pnpm e2e` (20 Playwright tests)

## Risks

Low. The change only affects configurations that explicitly set `requiredVersion: false`. Omitted and string-valued requirements retain their existing behavior.