### PR TITLE
fix: preserve repeated runtime plugin option values

### DIFF
--- a/src/utils/__tests__/serializeRuntimeOptions.test.ts
+++ b/src/utils/__tests__/serializeRuntimeOptions.test.ts
@@ -47,4 +47,19 @@ describe('generateRuntimePluginOption - safe JS literal', () => {
       }, "dateVal": new Date("2023-10-10T10:00:00.000Z"), "regexVal": new RegExp("prod-test", "gi"), "arrayVal": [1, "a", true, [2, 3, [4, 5]]], "nestedObj": {"level1": {"level2": {"value": "deep"}}}, "mapVal": new Map([["key1", 100]]), "setVal": new Set([1, "x", new Date("2020-01-01T00:00:00.000Z")]), "emptyArray": [], "emptyObject": {}, "megaObject": {"arrInsideObj": [{"x": 10}, new Set(["s1", "s2"])], "mapInsideObj": new Map([["mapKey", new Set([12321])], ["mapSet", new Set([1, 2, 3])]]), "objInsideSet": new Set([{"a": 1}, new Map([["mk", {"nested": "value"}]])])}}`)
     );
   });
+
+  it('serializes repeated references without treating them as circular', () => {
+    const shared = { nested: { value: 1 } };
+
+    expect(serializeRuntimeOptions({ first: shared, second: shared })).toBe(
+      '{"first": {"nested": {"value": 1}}, "second": {"nested": {"value": 1}}}'
+    );
+  });
+
+  it('still marks references that are circular in the active path', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(serializeRuntimeOptions({ circular })).toBe('{"circular": {"self": "__circular__"}}');
+  });
 });

--- a/src/utils/serializeRuntimeOptions.ts
+++ b/src/utils/serializeRuntimeOptions.ts
@@ -8,8 +8,10 @@
  * @returns {string} The resulting JavaScript source code string.
  */
 export function serializeRuntimeOptions(options: Record<string, unknown>): string {
-  // Use a WeakSet to track objects already encountered, which helps in detecting circular references.
-  const seenObjects = new WeakSet<any>();
+  // Track only the active recursion path. Reusing the same object in separate
+  // branches is valid and should serialize its value again rather than being
+  // mistaken for a circular reference.
+  const ancestors = new WeakSet<object>();
 
   /**
    * Recursive inner function to serialize any value into a source code string.
@@ -39,51 +41,43 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
       return `new RegExp(${JSON.stringify(val.source)}, ${JSON.stringify(val.flags)})`;
     }
 
-    // 3. Check for circular references and mark object as seen
-    // This applies to objects, arrays, maps, and sets.
+    // 3. Handle objects while detecting cycles in the active recursion path.
     if (type === 'object') {
-      if (seenObjects.has(val)) {
-        // This object has been seen previously in the recursion path
+      if (ancestors.has(val)) {
         return `"__circular__"`;
       }
-      seenObjects.add(val);
-    }
+      ancestors.add(val);
 
-    // 4. Handle Array, Map, Set
-    if (Array.isArray(val)) {
-      // Recursively serialize each element
-      return `[${val.map(valueToCode).join(', ')}]`;
-    }
-
-    if (val instanceof Map) {
-      // Serialize Map entries into an array of [key, value] pairs
-      const entries = Array.from(val.entries()).map(
-        ([k, v]) => `[${valueToCode(k)}, ${valueToCode(v)}]`
-      );
-      return `new Map([${entries.join(', ')}])`;
-    }
-
-    if (val instanceof Set) {
-      // Serialize Set values into an array
-      const items = Array.from(val.values()).map(valueToCode);
-      return `new Set([${items.join(', ')}])`;
-    }
-
-    // 5. Handle plain objects (the default object type)
-    if (type === 'object') {
-      const properties: string[] = [];
-
-      // Iterate over the object's own enumerable properties
-      for (const key in val) {
-        if (Object.prototype.hasOwnProperty.call(val, key)) {
-          // Wrap the key in JSON.stringify to handle non-identifier keys
-          properties.push(`${JSON.stringify(key)}: ${valueToCode(val[key])}`);
+      try {
+        if (Array.isArray(val)) {
+          return `[${val.map(valueToCode).join(', ')}]`;
         }
+
+        if (val instanceof Map) {
+          const entries = Array.from(val.entries()).map(
+            ([k, v]) => `[${valueToCode(k)}, ${valueToCode(v)}]`
+          );
+          return `new Map([${entries.join(', ')}])`;
+        }
+
+        if (val instanceof Set) {
+          const items = Array.from(val.values()).map(valueToCode);
+          return `new Set([${items.join(', ')}])`;
+        }
+
+        const properties: string[] = [];
+        for (const key in val) {
+          if (Object.prototype.hasOwnProperty.call(val, key)) {
+            properties.push(`${JSON.stringify(key)}: ${valueToCode(val[key])}`);
+          }
+        }
+        return `{${properties.join(', ')}}`;
+      } finally {
+        ancestors.delete(val);
       }
-      return `{${properties.join(', ')}}`;
     }
 
-    // 6. Fallback case (e.g., BigInt, other object types)
+    // 4. Fallback case (e.g., BigInt)
     // Coerce to string and then JSON.stringify that string for safety
     return JSON.stringify(String(val));
   }


### PR DESCRIPTION
## Summary

- distinguish repeated runtime plugin option values from true circular references
- serialize repeated objects, arrays, maps, and sets in each independent branch
- keep the existing `__circular__` marker for cycles in the active recursion path

## Testing

- [x] `pnpm exec vitest run src/utils/__tests__/serializeRuntimeOptions.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm fmt.check`
- [x] `pnpm test`
- [x] `pnpm test:integration`
- [x] `pnpm build`
- [x] `pnpm e2e` (20 Playwright tests)

## Risks

Low. Runtime plugin options containing repeated object references now preserve their values instead of replacing later occurrences with the string `__circular__`. True circular references retain the previous fallback.