### PR TITLE
fix: identify var remote entry in production manifest

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -128,6 +128,7 @@ async function runGenerateBundleWithManifest(
     >;
     dts?: unknown;
     filename?: string;
+    varFilename?: string;
     bundle?: OutputBundle;
     environmentName?: string;
   } = {},
@@ -138,7 +139,7 @@ async function runGenerateBundleWithManifest(
     name: 'basicRemote',
     filename: runtime.filename || 'remoteEntry.js',
     getPublicPath: undefined,
-    varFilename: undefined,
+    varFilename: runtime.varFilename,
     dts: runtime.dts,
     manifest: manifestOptions,
     exposes: runtime.exposePaths || {},
@@ -253,6 +254,20 @@ describe('pluginMFManifest', () => {
     expect(manifest.metaData.ssrRemoteEntry).toMatchObject({
       name: 'remoteEntry.ssr.js',
       type: 'module',
+    });
+  });
+
+  it('identifies the production var remote entry as a var container', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, {
+      varFilename: 'remoteEntry.var.js',
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+    expect(manifest.metaData.varRemoteEntry).toEqual({
+      name: 'remoteEntry.var.js',
+      path: '',
+      type: 'var',
     });
   });
 

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -365,7 +365,7 @@ const Manifest = (): Plugin[] => {
       ? {
           name: varFilename,
           path: '',
-          type: 'module',
+          type: 'var',
         }
       : undefined;
 


### PR DESCRIPTION
## Summary

- identify `varRemoteEntry` as a `var` container in production manifests
- align production metadata with the dev manifest and generated global wrapper
- add regression coverage for the emitted manifest metadata

## Testing

- [x] `pnpm exec vitest run src/plugins/__tests__/pluginMFManifest.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm fmt.check`
- [x] `pnpm test`
- [x] `pnpm test:integration`
- [x] `pnpm build`
- [x] `pnpm e2e` (20 Playwright tests)

## Risks

Low. This changes only the reported type of the optional production `varRemoteEntry` metadata from `module` to `var`; the generated remote entry asset is unchanged.