### PR TITLE
fix: preserve remote aliases during resolution

### DIFF
--- a/src/plugins/__tests__/pluginProxyRemotes.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemotes.test.ts
@@ -131,6 +131,49 @@ describe('pluginProxyRemotes', () => {
     expect(alias.find.test('scheduler/SchedulePanel')).toBe(true);
   });
 
+  it('matches and records the consumer alias when it differs from the container name', () => {
+    const plugin = pluginProxyRemotes(
+      normalizeModuleFederationOptions({
+        name: 'host',
+        remotes: {
+          catalog: {
+            type: 'module',
+            name: 'catalogContainer',
+            entry: 'http://example.com/remoteEntry.js',
+          },
+        },
+      })
+    );
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    runConfig(plugin, config);
+
+    expect(config.resolve.alias[0].find.test('catalog/Product')).toBe(true);
+    expect(config.resolve.alias[0].find.test('catalogContainer/Product')).toBe(false);
+
+    const result = runResolveId(plugin, 'catalog/Product', '/repo/src/App.tsx');
+
+    expect(result).toBe(remoteModuleId);
+    expect(addUsedRemoteMock).toHaveBeenCalledWith('catalog', 'catalog/Product');
+  });
+
+  it('escapes remote aliases when constructing Vite aliases', () => {
+    const plugin = pluginProxyRemotes(
+      normalizeModuleFederationOptions({
+        name: 'host',
+        remotes: {
+          'catalog.v2': 'catalog@http://example.com/remoteEntry.js',
+        },
+      })
+    );
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    runConfig(plugin, config);
+
+    expect(config.resolve.alias[0].find.test('catalog.v2/Product')).toBe(true);
+    expect(config.resolve.alias[0].find.test('catalogXv2/Product')).toBe(false);
+  });
+
   it('runs before Vite package exports resolution', () => {
     const { plugin } = getSchedulerPluginAndConfig();
 

--- a/src/plugins/pluginProxyRemotes.ts
+++ b/src/plugins/pluginProxyRemotes.ts
@@ -11,6 +11,10 @@ function isNodeModulesImporter(importer?: string) {
   return importer?.includes('/node_modules/') || importer?.includes('\\node_modules\\');
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function appendAlias(config: Record<string, any>, alias: { find: RegExp; replacement: string }) {
   config.resolve ??= {};
   const existingAlias = config.resolve.alias;
@@ -63,10 +67,9 @@ export default function (options: NormalizedModuleFederationOptions): Plugin {
     config(config, { command: _command }) {
       command = _command;
       root = config.root || process.cwd();
-      Object.keys(remotes).forEach((key) => {
-        const remote = remotes[key];
+      Object.keys(remotes).forEach((remoteAlias) => {
         appendAlias(config as Record<string, any>, {
-          find: new RegExp(`^(${remote.name}(\/.*|$))`),
+          find: new RegExp(`^(${escapeRegExp(remoteAlias)}(\/.*|$))`),
           replacement: '$1',
         });
       });
@@ -83,9 +86,9 @@ export default function (options: NormalizedModuleFederationOptions): Plugin {
     },
     resolveId(source, importer) {
       if (!filterId(source)) return;
-      for (const remote of Object.values(remotes)) {
-        if (source !== remote.name && !source.startsWith(`${remote.name}/`)) continue;
-        return resolveRemoteId(this, source, importer, remote.name);
+      for (const remoteAlias of Object.keys(remotes)) {
+        if (source !== remoteAlias && !source.startsWith(`${remoteAlias}/`)) continue;
+        return resolveRemoteId(this, source, importer, remoteAlias);
       }
     },
   };

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   hasPackageDependencyMock,
   normalizedSharedMock,
+  normalizedRemotesMock,
   usedRemotesMapMock,
   writeSyncSpy,
   optionsMock,
 } = vi.hoisted(() => ({
   hasPackageDependencyMock: vi.fn<(pkg: string) => boolean>(() => false),
   normalizedSharedMock: vi.fn(() => ({})),
+  normalizedRemotesMock: vi.fn(() => ({})),
   usedRemotesMapMock: vi.fn(() => ({})),
   writeSyncSpy: vi.fn(),
   optionsMock: {
@@ -173,7 +175,7 @@ vi.mock('../../utils/normalizeModuleFederationOptions', () => {
       internalName: '__mfe_internal__host',
       name: 'host',
       filename: 'remoteEntry.js',
-      remotes: {},
+      remotes: normalizedRemotesMock(),
       shared: normalizedSharedMock(),
       shareScope: 'default',
       runtimePlugins: [],
@@ -234,6 +236,8 @@ describe('virtualRemoteEntry', () => {
     hasPackageDependencyMock.mockReset();
     normalizedSharedMock.mockReset();
     normalizedSharedMock.mockReturnValue({});
+    normalizedRemotesMock.mockReset();
+    normalizedRemotesMock.mockReturnValue({});
     usedRemotesMapMock.mockReset();
     usedRemotesMapMock.mockReturnValue({});
     writeSyncSpy.mockClear();
@@ -546,6 +550,24 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('initRes.loadShare(pkg');
     expect(code).not.toContain('import exposesMap from');
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
+  });
+
+  it('includes remote aliases in version-first remoteEntry initialization', async () => {
+    normalizedRemotesMock.mockReturnValue({
+      catalog: {
+        entryGlobalName: 'catalog',
+        name: 'catalogContainer',
+        type: 'module',
+        entry: 'http://localhost:4174/remoteEntry.js',
+      },
+    });
+    usedRemotesMapMock.mockReturnValue({ catalog: new Set(['catalog/Button']) });
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateLocalSharedImportMap();
+
+    expect(code).toContain('alias: "catalog"');
+    expect(code).toContain('name: "catalogContainer"');
   });
 
   it('does not eagerly preload remotes during host auto init', async () => {

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -46,6 +46,13 @@ vi.mock('../../utils/normalizeModuleFederationOptions', () => ({
         entry: 'http://localhost:4175/remoteEntry.js',
         shareScope: 'default',
       },
+      alias: {
+        entryGlobalName: 'remote_alias',
+        name: 'remote-container',
+        type: 'module',
+        entry: 'http://localhost:4177/remoteEntry.js',
+        shareScope: 'default',
+      },
     },
     shareStrategy: mockOptions.shareStrategy,
     virtualModuleDir: '__mf__virtual',
@@ -305,6 +312,14 @@ describe('generateRemotes', () => {
     expect(code).toContain('"name":"@scope/remote"');
     expect(code).toContain('"entryGlobalName":"scope_remote"');
     expect(code).toContain('"entry":"http://localhost:4175/remoteEntry.js"');
+  });
+
+  it('registers the consumer alias separately from the remote container name', () => {
+    mockOptions.shareStrategy = 'loaded-first';
+    const code = generateRemotes('alias/Button', 'serve');
+
+    expect(code).toContain('"name":"remote-container"');
+    expect(code).toContain('"alias":"alias"');
   });
 
   it('skips remote registration when a scoped id matches no configured remote', () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -156,6 +156,7 @@ export function generateLocalSharedImportMap() {
           if (!remote) return null;
           return `
                 {
+                  alias: ${JSON.stringify(key)},
                   entryGlobalName: ${JSON.stringify(remote.entryGlobalName)},
                   name: ${JSON.stringify(remote.name)},
                   type: ${JSON.stringify(remote.type)},

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -43,11 +43,17 @@ export function getUsedRemotesMap() {
 }
 
 export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
-  const remoteName = Object.keys(remotes)
+  const remoteAlias = Object.keys(remotes)
     .filter((name) => id === name || id.startsWith(name + '/'))
     .sort((a, b) => b.length - a.length)[0];
 
-  return remoteName ? remotes[remoteName] : undefined;
+  return remoteAlias ? remotes[remoteAlias] : undefined;
+}
+
+function getRemoteAliasFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
+  return Object.keys(remotes)
+    .filter((name) => id === name || id.startsWith(name + '/'))
+    .sort((a, b) => b.length - a.length)[0];
 }
 
 /**
@@ -247,11 +253,13 @@ export function generateRemotes(
   const initMode = resolveRemoteInitMode(options.shareStrategy, consumer);
   const deferRemoteLoad = shouldDeferRemoteLoad(initMode);
   const remote = getRemoteFromId(id, options.remotes);
+  const remoteAlias = getRemoteAliasFromId(id, options.remotes);
   const registerRemoteCode =
     isLoadedFirst && remote
       ? `runtime.registerRemotes([${JSON.stringify({
           entryGlobalName: remote.entryGlobalName,
           name: remote.name,
+          alias: remoteAlias,
           type: remote.type,
           entry: remote.entry,
           shareScope: remote.shareScope ?? 'default',

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -42,18 +42,15 @@ export function getUsedRemotesMap() {
   return usedRemotesMap;
 }
 
-export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
-  const remoteAlias = Object.keys(remotes)
-    .filter((name) => id === name || id.startsWith(name + '/'))
-    .sort((a, b) => b.length - a.length)[0];
-
-  return remoteAlias ? remotes[remoteAlias] : undefined;
-}
-
 function getRemoteAliasFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
   return Object.keys(remotes)
     .filter((name) => id === name || id.startsWith(name + '/'))
     .sort((a, b) => b.length - a.length)[0];
+}
+
+export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
+  const remoteAlias = getRemoteAliasFromId(id, remotes);
+  return remoteAlias ? remotes[remoteAlias] : undefined;
 }
 
 /**
@@ -252,8 +249,8 @@ export function generateRemotes(
   const isLoadedFirst = options.shareStrategy === 'loaded-first';
   const initMode = resolveRemoteInitMode(options.shareStrategy, consumer);
   const deferRemoteLoad = shouldDeferRemoteLoad(initMode);
-  const remote = getRemoteFromId(id, options.remotes);
   const remoteAlias = getRemoteAliasFromId(id, options.remotes);
+  const remote = remoteAlias ? options.remotes[remoteAlias] : undefined;
   const registerRemoteCode =
     isLoadedFirst && remote
       ? `runtime.registerRemotes([${JSON.stringify({


### PR DESCRIPTION
## Summary

- preserve the consumer-facing remote alias during Vite resolution
- escape aliases before using them in generated regular expressions
- register aliases in both loaded-first and version-first runtime initialization
- avoid repeating the remote-alias lookup during code generation
- add regression coverage for aliases that differ from container names

## Feedback addressed

The version-first `usedRemotes` configuration now includes `alias: key`, so imports such as `catalog/Button` resolve when the configured container name is `catalogContainer`.

## Verification

- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm test -- --run` — 691 passed, 1 skipped
- `pnpm test:integration -- --run` — 43 passed
- `pnpm build`
- `pnpm exec playwright test --project=vite-vite-host --project=vite-vite-remote` — 9 passed

No Rspack/API-parity changes are included.