### PR TITLE
fix: report remote container names in manifest stats

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -116,7 +116,7 @@ async function runGenerateBundleWithManifest(
   manifestOptions: unknown,
   runtime: {
     usedShares?: Set<string>;
-    usedRemotes?: Map<string, Set<string>>;
+    usedRemotes?: Map<string, Set<string>> | Record<string, Set<string>>;
     exposePaths?: Record<string, { import: string }>;
     shareItems?: Record<
       string,
@@ -129,6 +129,7 @@ async function runGenerateBundleWithManifest(
     dts?: unknown;
     filename?: string;
     varFilename?: string;
+    remotes?: Record<string, { name: string; entry: string; type?: string }>;
     bundle?: OutputBundle;
     environmentName?: string;
   } = {},
@@ -143,7 +144,7 @@ async function runGenerateBundleWithManifest(
     dts: runtime.dts,
     manifest: manifestOptions,
     exposes: runtime.exposePaths || {},
-    remotes: {},
+    remotes: runtime.remotes || {},
     shared: {},
     bundleAllCSS: false,
     shareStrategy: 'version-first',
@@ -268,6 +269,28 @@ describe('pluginMFManifest', () => {
       name: 'remoteEntry.var.js',
       path: '',
       type: 'var',
+    });
+  });
+
+  it('reports the remote container name separately from its entry URL', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, {
+      remotes: {
+        catalog: {
+          name: 'catalogContainer',
+          entry: 'https://cdn.example.com/remoteEntry.js',
+          type: 'module',
+        },
+      },
+      usedRemotes: { catalog: new Set(['catalog/Product']) },
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+    expect(manifest.remotes).toContainEqual({
+      federationContainerName: 'catalogContainer',
+      moduleName: 'Product',
+      alias: 'catalog',
+      entry: '*',
     });
   });
 

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -129,7 +129,10 @@ async function runGenerateBundleWithManifest(
     dts?: unknown;
     filename?: string;
     varFilename?: string;
-    remotes?: Record<string, { name: string; entry: string; type?: string }>;
+    remotes?: Record<
+      string,
+      { name: string; entry: string; entryGlobalName?: string; type?: string }
+    >;
     bundle?: OutputBundle;
     environmentName?: string;
   } = {},
@@ -290,6 +293,29 @@ describe('pluginMFManifest', () => {
       federationContainerName: 'catalogContainer',
       moduleName: 'Product',
       alias: 'catalog',
+      entry: '*',
+    });
+  });
+
+  it('reports entryGlobalName for string-form remotes', async () => {
+    const emitted = await runGenerateBundleWithManifest(true, {
+      remotes: {
+        remote1: {
+          name: 'remote1',
+          entryGlobalName: 'Button',
+          entry: 'https://cdn.example.com/remoteEntry.js',
+          type: 'var',
+        },
+      },
+      usedRemotes: { remote1: new Set(['remote1/Button']) },
+    });
+
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+
+    expect(manifest.remotes).toContainEqual({
+      federationContainerName: 'Button',
+      moduleName: 'Button',
+      alias: 'remote1',
       entry: '*',
     });
   });

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -373,7 +373,7 @@ const Manifest = (): Plugin[] => {
     const remotes = Array.from(Object.entries(getUsedRemotesMap())).flatMap(
       ([remoteKey, modules]) =>
         Array.from(modules).map((moduleKey) => ({
-          federationContainerName: options.remotes[remoteKey].entry,
+          federationContainerName: options.remotes[remoteKey].name,
           moduleName: moduleKey.replace(remoteKey, '').replace('/', ''),
           alias: remoteKey,
           entry: '*',

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -3,6 +3,7 @@ import { Plugin } from 'vite';
 import {
   getNormalizeModuleFederationOptions,
   getNormalizeShareItem,
+  type RemoteObjectConfig,
 } from '../utils/normalizeModuleFederationOptions';
 import { getUsedRemotesMap, getUsedShares } from '../virtualModules';
 
@@ -78,6 +79,16 @@ function createRemoteEntryAssetMap(fileName: string) {
     js: { async: [], sync: [fileName] },
     css: { async: [], sync: [] },
   };
+}
+
+function getRemoteContainerName(remoteKey: string, remote: RemoteObjectConfig) {
+  // Object-form remotes default entryGlobalName to the alias during
+  // normalization, while string-form remotes use it for `Name@entry`.
+  const entryGlobalName = remote.entryGlobalName;
+  if (entryGlobalName && entryGlobalName !== remoteKey && entryGlobalName !== remote.entry) {
+    return entryGlobalName;
+  }
+  return remote.name;
 }
 
 const Manifest = (): Plugin[] => {
@@ -371,13 +382,15 @@ const Manifest = (): Plugin[] => {
 
     // Process remotes
     const remotes = Array.from(Object.entries(getUsedRemotesMap())).flatMap(
-      ([remoteKey, modules]) =>
-        Array.from(modules).map((moduleKey) => ({
-          federationContainerName: options.remotes[remoteKey].name,
+      ([remoteKey, modules]) => {
+        const remote = options.remotes[remoteKey];
+        return Array.from(modules).map((moduleKey) => ({
+          federationContainerName: getRemoteContainerName(remoteKey, remote),
           moduleName: moduleKey.replace(remoteKey, '').replace('/', ''),
           alias: remoteKey,
           entry: '*',
-        }))
+        }));
+      }
     );
 
     // Process shared dependencies


### PR DESCRIPTION
## Summary

- report the configured federation container name in manifest stats
- handle string-form remotes where `entryGlobalName` differs from the alias
- retain object-form remote names when normalization defaults `entryGlobalName` to the alias
- add regression coverage for both object-form and string-form remotes

## Feedback addressed

For `remote1: Button@https://...`, the manifest now reports `Button` as `federationContainerName` and `remote1` as `alias`.

## Verification

- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm test -- --run` — 689 passed, 1 skipped
- `pnpm test:integration -- --run` — 43 passed
- `pnpm build`
- `pnpm exec playwright test --project=vite-vite-host --project=vite-vite-remote` — 9 passed

No Rspack/API-parity changes are included.