### PR TITLE
fix: refresh nested remote dependencies before exposes

### DIFF
--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -4,6 +4,7 @@ import type {
   ResolvedConfig,
   Rollup,
 } from 'vite';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getDefaultMockOptions } from '../../utils/__tests__/helpers';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
@@ -12,6 +13,54 @@ import { getHostAutoInitPath } from '../../virtualModules';
 import pluginProxyRemoteEntry from '../pluginProxyRemoteEntry';
 
 describe('pluginProxyRemoteEntry', () => {
+  it('refreshes nested remote dependencies before generating virtual exposes', async () => {
+    normalizeModuleFederationOptions({ name: 'test' });
+    const expose = resolve('integration/fixtures/nested-remote-transitive/exposed-widget.js');
+    const store = resolve('integration/fixtures/nested-remote-transitive/store.js');
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions({
+        exposes: { './widget': { import: expose } as any },
+        remotes: {
+          remoteA: {
+            name: 'remoteA',
+            entry: 'http://localhost:3001/remoteEntry.js',
+            type: 'module',
+          },
+        },
+      }),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+
+    let exposeResolveCalls = 0;
+    const context = {
+      resolve: async (source: string) => {
+        if (source === expose) {
+          exposeResolveCalls += 1;
+          return { id: expose };
+        }
+        if (source === './store.js') return { id: store };
+        return undefined;
+      },
+    } as any;
+
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    const generated = await callHook(plugin.load, context, 'virtual:mf-exposes');
+
+    expect(generated).toContain('__loadRemote__remoteA_mf_1_shared_mf_1_helpers__loadRemote__');
+    await callHook(plugin.load, context, 'virtual:mf-exposes');
+    expect(exposeResolveCalls).toBe(1);
+
+    callHook(plugin.watchChange, context, store, { event: 'update' });
+    await callHook(plugin.transform, context, '', 'virtual:mf-exposes');
+    expect(exposeResolveCalls).toBe(2);
+  });
+
   it('uses an inlined data-URL origin for dev host init in SSR/module-runner contexts, protocol relative fallback origin otherwise', async () => {
     normalizeModuleFederationOptions({ name: 'test' });
     const plugin = pluginProxyRemoteEntry({

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -43,6 +43,9 @@ export default function ({
 }: ProxyRemoteEntryParams): Plugin {
   let viteConfig: any, _command: string, root: string;
   let exposeRemoteDependencies: Record<string, string[]> = {};
+  let exposeRemoteDependenciesDirty = true;
+  let refreshPromise: Promise<void> | undefined;
+  let dependencyInvalidationVersion = 0;
 
   function isRemoteImport(source: string): boolean {
     return Object.keys(options.remotes).some(
@@ -102,12 +105,29 @@ export default function ({
   }
 
   async function refreshExposeRemoteDependencies(ctx: { resolve: Plugin['resolveId'] }) {
-    const next: Record<string, string[]> = {};
-    for (const [exposeKey, expose] of Object.entries(options.exposes)) {
-      const resolved = await (ctx as any).resolve(expose.import);
-      next[exposeKey] = resolved?.id ? await collectRemoteDependencies(ctx, resolved.id) : [];
+    if (!exposeRemoteDependenciesDirty) return;
+    if (!refreshPromise) {
+      const refreshVersion = dependencyInvalidationVersion;
+      refreshPromise = (async () => {
+        const next: Record<string, string[]> = {};
+        for (const [exposeKey, expose] of Object.entries(options.exposes)) {
+          const resolved = await (ctx as any).resolve(expose.import);
+          next[exposeKey] = resolved?.id ? await collectRemoteDependencies(ctx, resolved.id) : [];
+        }
+        exposeRemoteDependencies = next;
+        if (refreshVersion === dependencyInvalidationVersion) {
+          exposeRemoteDependenciesDirty = false;
+        }
+      })().finally(() => {
+        refreshPromise = undefined;
+      });
     }
-    exposeRemoteDependencies = next;
+    await refreshPromise;
+  }
+
+  function invalidateExposeRemoteDependencies() {
+    exposeRemoteDependenciesDirty = true;
+    dependencyInvalidationVersion += 1;
   }
 
   return {
@@ -138,6 +158,12 @@ export default function ({
         }
       }
     },
+    watchChange() {
+      invalidateExposeRemoteDependencies();
+    },
+    handleHotUpdate() {
+      invalidateExposeRemoteDependencies();
+    },
     async resolveId(id: string, importer?: string) {
       if (id === remoteEntryId) {
         return remoteEntryId;
@@ -166,24 +192,26 @@ export default function ({
         if (resolved) return resolved;
       }
     },
-    load(id: string) {
+    async load(id: string) {
       if (id === remoteEntryId) {
         return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
       }
       if (id === virtualExposesId) {
+        await refreshExposeRemoteDependencies(this);
         return generateExposes(options, exposeRemoteDependencies, _command);
       }
       if (_command === 'serve' && id.includes(getHostAutoInitPath())) {
         return id;
       }
     },
-    transform(code: string, id: string) {
-      const transformedCode = (() => {
+    async transform(code: string, id: string) {
+      const transformedCode = await (async () => {
         if (!filterId(id)) return;
         if (id.includes(remoteEntryId)) {
           return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
         }
         if (id === virtualExposesId) {
+          await refreshExposeRemoteDependencies(this);
           return generateExposes(options, exposeRemoteDependencies, _command);
         }
         if (id.includes(getHostAutoInitPath())) {


### PR DESCRIPTION
Close #911

Refresh nested remote dependencies lazily when the dependency graph is invalidated, ensuring virtual exposes wait for transitive remotes while avoiding repeated filesystem scans during development and builds.