### PR TITLE
fix: optimize shared singleton React in dev

### DIFF
--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -1,0 +1,324 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer as createNetServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { chromium } from '@playwright/test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer as createViteServer, version as viteVersion } from 'vite';
+import { federation } from '../src';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const FIXTURE_PARENT = path.join(REPO_ROOT, 'examples/vite-webpack-rspack/remote');
+const VITE_CLI = path.join(REPO_ROOT, 'node_modules/vite/bin/vite.js');
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+let fixtureRoot: string;
+
+beforeEach(async () => {
+  fixtureRoot = await mkdtemp(path.join(FIXTURE_PARENT, '.issue-913-'));
+  await mkdir(path.join(fixtureRoot, 'src'));
+  const pluginEntry = pathToFileURL(path.join(REPO_ROOT, 'src/index.ts')).href;
+  await Promise.all([
+    writeFile(
+      path.join(fixtureRoot, 'index.html'),
+      '<div id="root"></div>\n<script type="module" src="/src/main.js"></script>\n'
+    ),
+    writeFile(
+      path.join(fixtureRoot, 'src/main.js'),
+      `import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+window.__issue913HostReact = React;
+const { default: RemoteHookComponent } = await import('issue913Remote/HookComponent');
+createRoot(document.querySelector('#root')).render(
+  React.createElement(RemoteHookComponent, { hostReact: React })
+);
+`
+    ),
+    writeFile(
+      path.join(fixtureRoot, 'src/RemoteHookComponent.js'),
+      `import React, { useState } from 'react';
+
+window.__issue913RemoteReact = React;
+export default function RemoteHookComponent({ hostReact }) {
+  const [renderCount] = useState(1);
+  return React.createElement(
+    'div',
+    { id: 'singleton-result' },
+    \`${'${React.version}:${renderCount}:${String(hostReact === React)}'}\`
+  );
+}
+`
+    ),
+    writeFile(
+      path.join(fixtureRoot, 'vite.remote.config.js'),
+      `import { federation } from ${JSON.stringify(pluginEntry)};
+
+export default {
+  cacheDir: process.env.ISSUE_913_CACHE_DIR,
+  plugins: [federation({
+    name: 'issue913Remote',
+    hostInitInjectLocation: 'entry',
+    filename: 'remoteEntry.js',
+    exposes: { './HookComponent': './src/RemoteHookComponent.js' },
+    dts: false,
+    shared: {
+      react: { singleton: true },
+      'react-dom': { singleton: true },
+    },
+  })],
+};
+`
+    ),
+    writeFile(
+      path.join(fixtureRoot, 'vite.host.config.js'),
+      `import { federation } from ${JSON.stringify(pluginEntry)};
+
+export default {
+  cacheDir: process.env.ISSUE_913_CACHE_DIR,
+  plugins: [federation({
+    name: 'issue913Host',
+    remotes: {
+      issue913Remote: {
+        type: 'module',
+        name: 'issue913Remote',
+        entry: \`${'${process.env.ISSUE_913_REMOTE_ORIGIN}'}/remoteEntry.js\`,
+      },
+    },
+    dts: false,
+    shared: {
+      react: { singleton: true },
+      'react-dom': { singleton: true },
+    },
+  })],
+};
+`
+    ),
+  ]);
+  cleanupTasks.push(() => rm(fixtureRoot, { recursive: true }));
+});
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupTasks
+      .splice(0)
+      .reverse()
+      .map((cleanup) => cleanup())
+  );
+});
+
+async function createDevServer(
+  name: string,
+  options: Parameters<typeof federation>[0]
+): Promise<{ origin: string }> {
+  const cacheDir = await mkdtemp(path.join(tmpdir(), `mf-vite-${name}-`));
+  const viteServer = await createViteServer({
+    root: fixtureRoot,
+    cacheDir,
+    logLevel: 'silent',
+    plugins: [federation(options)],
+    server: {
+      cors: true,
+      host: '127.0.0.1',
+      port: 0,
+    },
+  });
+  await viteServer.listen();
+  const address = viteServer.httpServer?.address();
+  if (!address || typeof address === 'string') throw new Error('Vite HTTP server did not bind');
+  const origin = `http://127.0.0.1:${address.port}`;
+  cleanupTasks.push(async () => {
+    await viteServer.close();
+    await rm(cacheDir, { recursive: true });
+  });
+  return { origin };
+}
+
+async function getAvailablePort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Port probe did not bind');
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([once(child, 'exit'), new Promise((resolve) => setTimeout(resolve, 5_000))]);
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+}
+
+async function startCliServer(
+  configFile: string,
+  extraEnv: NodeJS.ProcessEnv = {}
+): Promise<{ origin: string }> {
+  const port = await getAvailablePort();
+  const cacheDir = await mkdtemp(path.join(tmpdir(), 'mf-vite-issue-913-cli-'));
+  const output: string[] = [];
+  const child = spawn(
+    process.execPath,
+    [
+      VITE_CLI,
+      '--config',
+      configFile,
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(port),
+      '--strictPort',
+    ],
+    {
+      cwd: fixtureRoot,
+      env: { ...process.env, ...extraEnv, ISSUE_913_CACHE_DIR: cacheDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  child.stdout?.on('data', (chunk) => output.push(String(chunk)));
+  child.stderr?.on('data', (chunk) => output.push(String(chunk)));
+  cleanupTasks.push(async () => {
+    await stopChild(child);
+    await rm(cacheDir, { recursive: true });
+  });
+
+  const origin = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Vite child exited with ${child.exitCode}:\n${output.join('')}`);
+    }
+    try {
+      const response = await fetch(origin);
+      if (response.ok) return { origin };
+    } catch {
+      // The CLI has not started listening yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Vite child did not become ready:\n${output.join('')}`);
+}
+
+async function fetchModuleGraph(origin: string, entry: string): Promise<Map<string, string>> {
+  const modules = new Map<string, string>();
+  const pending = [entry];
+
+  while (pending.length > 0 && modules.size < 150) {
+    const moduleUrl = pending.shift()!;
+    if (modules.has(moduleUrl)) continue;
+
+    const response = await fetch(new URL(moduleUrl, origin));
+    expect(response.status, moduleUrl).toBe(200);
+    const source = await response.text();
+    modules.set(moduleUrl, source);
+
+    const imports = [
+      ...source.matchAll(/(?:import|export)\s+(?:[^'";]*?\s+from\s*)?["']([^"']+)["']/g),
+      ...source.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g),
+    ];
+    for (const match of imports) {
+      const specifier = match[1];
+      if (specifier.startsWith('/') && !modules.has(specifier)) pending.push(specifier);
+    }
+  }
+
+  return modules;
+}
+
+describe(`singleton React dev fallback (Vite ${viteVersion})`, () => {
+  it('serves an optimized ESM React provider', async () => {
+    const { origin } = await createDevServer('issue-913-provider', {
+      name: 'issue913Provider',
+      filename: 'remoteEntry.js',
+      dts: false,
+      shared: {
+        react: { singleton: true },
+      },
+    });
+
+    const modules = await fetchModuleGraph(origin, '/src/RemoteHookComponent.js');
+    const urls = [...modules.keys()];
+    const sources = [...modules.values()];
+    const reactPrebuild = [...modules].find(([url]) => url.includes('__prebuild__react__prebuild'));
+    const optimizedReactUrl = urls.find((url) => /\/deps\/react\.js(?:\?|$)/.test(url));
+
+    expect(sources.some((source) => source.includes('loadShare'))).toBe(true);
+    expect(reactPrebuild).toBeDefined();
+    expect(reactPrebuild?.[1]).toMatch(/\/deps\/react\.js(?:\?|["'])/);
+    expect(urls.some((url) => /\/react\/index\.js(?:\?|$)/.test(url))).toBe(false);
+    expect(optimizedReactUrl, JSON.stringify(urls, null, 2)).toBeDefined();
+  });
+
+  it('keeps one React instance while rendering a remote hook component', async () => {
+    const remote = await startCliServer('vite.remote.config.js');
+    const host = await startCliServer('vite.host.config.js', {
+      ISSUE_913_REMOTE_ORIGIN: remote.origin,
+    });
+
+    const browser = await chromium.launch({ channel: 'chrome', headless: true });
+    cleanupTasks.push(() => browser.close());
+    const page = await browser.newPage();
+    const pageErrors = new Set<string>();
+    const consoleErrors = new Set<string>();
+    const requestFailures = new Set<string>();
+    const errorResponses = new Set<string>();
+    const requests = new Set<string>();
+    page.on('pageerror', (error) => pageErrors.add(error.message));
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.add(message.text());
+    });
+    page.on('requestfailed', (request) => {
+      requestFailures.add(`${request.url()}: ${request.failure()?.errorText}`);
+    });
+    page.on('response', (response) => {
+      if (response.status() >= 400) errorResponses.add(`${response.status()} ${response.url()}`);
+    });
+    page.on('request', (request) => requests.add(request.url()));
+    await page.goto(host.origin, { waitUntil: 'domcontentloaded' });
+
+    try {
+      await page.locator('#singleton-result').waitFor({ timeout: 15_000 });
+    } catch (error) {
+      throw new Error(
+        JSON.stringify(
+          {
+            cause: String(error),
+            pageErrors: [...pageErrors],
+            consoleErrors: [...consoleErrors],
+            requestFailures: [...requestFailures],
+            errorResponses: [...errorResponses],
+            requests: [...requests],
+            content: await page.content(),
+          },
+          null,
+          2
+        )
+      );
+    }
+    await expect(page.locator('#singleton-result').textContent()).resolves.toMatch(
+      /^\d+\.\d+\.\d+:1:true$/
+    );
+    await expect(
+      page.evaluate(() => window.__issue913HostReact === window.__issue913RemoteReact)
+    ).resolves.toBe(true);
+    expect([...pageErrors]).toEqual([]);
+    expect(
+      [...consoleErrors].filter((error) => /invalid hook call|module is not defined/i.test(error))
+    ).toEqual([]);
+  }, 60_000);
+});
+
+declare global {
+  interface Window {
+    __issue913HostReact?: unknown;
+    __issue913RemoteReact?: unknown;
+  }
+}

--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -4,7 +4,6 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer as createNetServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import { chromium } from '@playwright/test';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServer as createViteServer, version as viteVersion } from 'vite';
@@ -20,7 +19,8 @@ let fixtureRoot: string;
 beforeEach(async () => {
   fixtureRoot = await mkdtemp(path.join(FIXTURE_PARENT, '.issue-913-'));
   await mkdir(path.join(fixtureRoot, 'src'));
-  const pluginEntry = pathToFileURL(path.join(REPO_ROOT, 'src/index.ts')).href;
+  const pluginEntry = path.join(REPO_ROOT, 'src/index.ts');
+  const ssrEntryLoaderEntry = path.join(REPO_ROOT, 'src/utils/ssrEntryLoader.ts');
   await Promise.all([
     writeFile(
       path.join(fixtureRoot, 'index.html'),
@@ -59,6 +59,11 @@ export default function RemoteHookComponent({ hostReact }) {
 
 export default {
   cacheDir: process.env.ISSUE_913_CACHE_DIR,
+  resolve: {
+    alias: {
+      '@module-federation/vite/ssrEntryLoader': ${JSON.stringify(ssrEntryLoaderEntry)},
+    },
+  },
   plugins: [federation({
     name: 'issue913Remote',
     hostInitInjectLocation: 'entry',
@@ -79,6 +84,11 @@ export default {
 
 export default {
   cacheDir: process.env.ISSUE_913_CACHE_DIR,
+  resolve: {
+    alias: {
+      '@module-federation/vite/ssrEntryLoader': ${JSON.stringify(ssrEntryLoaderEntry)},
+    },
+  },
   plugins: [federation({
     name: 'issue913Host',
     remotes: {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1431,7 +1431,7 @@ describe('vite:module-federation-early-init', () => {
     expect(optimizeDeps).toContain('zustand/react');
   });
 
-  it('excludes shared react from dev optimizeDeps when react-redux is installed', () => {
+  it('includes shared react in dev optimizeDeps when react-redux is installed', () => {
     hasPackageDependencyMock.mockImplementation(
       (dependency: string): boolean => dependency === 'react-redux'
     );
@@ -1449,11 +1449,11 @@ describe('vite:module-federation-early-init', () => {
       mode: 'test',
     });
 
-    expect(config.optimizeDeps.exclude).toContain('react');
-    expect(config.optimizeDeps.include).not.toContain('react');
+    expect(config.optimizeDeps.include).toContain('react');
+    expect(config.optimizeDeps.exclude).not.toContain('react');
   });
 
-  it('excludes shared singleton react from dev optimizeDeps without react-redux', () => {
+  it('includes shared singleton react in dev optimizeDeps without react-redux', () => {
     hasPackageDependencyMock.mockReturnValue(false);
     const plugin = getEarlyInitPluginWithReactShared();
     const config: any = {
@@ -1469,8 +1469,8 @@ describe('vite:module-federation-early-init', () => {
       mode: 'test',
     });
 
-    expect(config.optimizeDeps.exclude).toContain('react');
-    expect(config.optimizeDeps.include).not.toContain('react');
+    expect(config.optimizeDeps.include).toContain('react');
+    expect(config.optimizeDeps.exclude).not.toContain('react');
   });
 
   it('keeps included shared react out of dev optimizeDeps exclude when react-redux is installed', () => {
@@ -1493,6 +1493,35 @@ describe('vite:module-federation-early-init', () => {
 
     expect(config.optimizeDeps.include).toContain('react');
     expect(config.optimizeDeps.exclude).not.toContain('react');
+  });
+
+  it('keeps Lit outside dev dependency optimization', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        shared: {
+          lit: { singleton: true },
+        },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+        exclude: [],
+      },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps.exclude).toContain('lit');
+    expect(config.optimizeDeps.include).not.toContain('lit');
   });
 
   it('removes deps from optimizeDeps exclude when another plugin includes them later', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -458,12 +458,13 @@ export default __mfShared.default ?? __mfShared;`,
             const optimizeDeps = (config.optimizeDeps ??= {});
             optimizeDeps.include ??= [];
             optimizeDeps.exclude ??= [];
-            // Some packages must stay outside dependency optimization because
-            // their submodules rely on parent initialization order. Other
-            // shared deps should remain optimizable so Vite can apply CJS
-            // interop for transitive dependencies used by prebuild fallbacks.
-            const shouldBypassOptimizeDep =
-              isLitShare(key) || (key === 'react' && shareItem.shareConfig?.singleton === true);
+            // Lit must stay outside dependency optimization because its
+            // submodules rely on parent initialization order. Other shared
+            // deps, including singleton React, must remain optimizable so
+            // local prebuild fallbacks receive Vite's CJS-to-ESM interop.
+            // Singleton identity is enforced by the federation share cache
+            // and loadShare proxy, independently from dependency optimization.
+            const shouldBypassOptimizeDep = isLitShare(key);
             if (optimizeDeps.include.includes(key)) {
               optimizeDeps.exclude = optimizeDeps.exclude.filter((dep) => dep !== key);
             } else if (shouldBypassOptimizeDep) {


### PR DESCRIPTION
Fixes #913

Follow-up to #861 and #862

## Summary

This restores Vite dependency optimization for shared singleton React in dev mode.

#861 excluded every shared singleton React entry from `optimizeDeps` to prevent a remote-local React copy from bypassing Module Federation singleton sharing. However, local shared-provider fallbacks still need Vite's dependency optimizer to convert React's CommonJS package entry into browser-compatible ESM.

Without that conversion, the generated React prebuild module imports the raw package entry:

```txt
/node_modules/react/index.js
```

The browser then evaluates React's CommonJS `module.exports` code directly and fails with:

```txt
ReferenceError: module is not defined
```

This change keeps singleton identity in the federation `loadShare` and shared-cache layers introduced by the #862 follow-up, while allowing Vite to handle CommonJS-to-ESM interop.

## Problem

The fix in #861 used `optimizeDeps.exclude` as a singleton identity boundary:

```ts
isLitShare(key) ||
  (key === 'react' && shareItem.shareConfig?.singleton === true)
```

That avoids Vite pre-bundling React, but it also prevents Vite from generating its CommonJS interoperability wrapper.

As a result, the local React provider changes from:

```txt
/node_modules/.vite/deps/react.js
```

to:

```txt
/node_modules/react/index.js
```

The latter is raw CommonJS and cannot execute directly in the browser.

Explicitly adding React to `optimizeDeps.include` confirms the interop issue, but the complete fix must also preserve the singleton behavior that #861 intended to protect.

Singleton selection and dependency representation are separate responsibilities:

- Vite dependency optimization provides CommonJS-to-ESM interop.
- Module Federation's `loadShare` and shared cache preserve singleton identity.

## Changes

- Removed the singleton React exception from the dev `optimizeDeps` bypass condition.
- Kept the existing Lit optimization bypass unchanged.
- Allowed shared singleton React to use Vite's optimized ESM provider.
- Preserved the existing include-wins normalization behavior.
- Updated the React `optimizeDeps` unit tests for:
  - `react-redux` installed,
  - `react-redux` absent,
  - explicit React inclusion.
- Added explicit coverage ensuring Lit remains excluded.
- Added a dev integration regression test that:
  - verifies the React prebuild provider imports optimized `/deps/react.js`,
  - verifies raw `/react/index.js` is not exposed,
  - starts host and remote Vite servers in separate processes and cache directories,
  - renders a remote React hook component with the host's `react-dom`,
  - verifies host and remote React objects have strict identity,
  - verifies no `Invalid hook call`, `module is not defined`, or browser `pageerror` occurs.
- Generates the integration fixture in a temporary directory during the test so no permanent example files are required.

## Tests

Added coverage in `src/__tests__/index.test.ts` for:

- shared singleton React with `react-redux`,
- shared singleton React without `react-redux`,
- explicit React optimization precedence,
- the existing Lit optimization exception.

Added `integration/dev-singleton-react.test.ts` coverage for:

- optimized React provider generation,
- raw CommonJS React entry prevention,
- host/remote singleton identity,
- remote `useState` hook rendering through host `react-dom`,
- browser runtime errors.

The integration test uses the root Vite installation, so the existing integration CI matrix exercises the same test with Vite 5, 6, 7, and 8.