### PR TITLE
fix: bound SSR remote fetches

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -21,7 +21,7 @@ type FetchEntry = {
 };
 
 function makeFetchMock(responses: Record<string, FetchEntry>) {
-  return vi.fn(async (url: string, _options?: { method?: string }) => {
+  return vi.fn(async (url: string, _options?: { method?: string; signal?: AbortSignal }) => {
     const entry = responses[url] ?? { ok: false };
     return {
       ok: entry.ok,
@@ -32,6 +32,14 @@ function makeFetchMock(responses: Record<string, FetchEntry>) {
       headers: { get: (h: string) => entry.headers?.[h] ?? null },
     };
   });
+}
+
+function expectFetchCalled(fetch: ReturnType<typeof vi.fn>, url: string): void {
+  expect(fetch.mock.calls.some(([requestUrl]) => requestUrl === url)).toBe(true);
+}
+
+function expectFetchNotCalled(fetch: ReturnType<typeof vi.fn>, url: string): void {
+  expect(fetch.mock.calls.some(([requestUrl]) => requestUrl === url)).toBe(false);
 }
 
 async function freshLoaderModule() {
@@ -104,7 +112,7 @@ describe('ssrEntryLoaderPlugin — browser guard', () => {
     await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
     });
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/mf-manifest.json');
+    expectFetchCalled(fetch, 'http://localhost:5001/mf-manifest.json');
     delete (globalThis as Record<string, unknown>).window;
   });
 });
@@ -124,7 +132,7 @@ describe('ssrEntryLoaderPlugin — manifest URL derivation', () => {
     await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
     });
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/mf-manifest.json');
+    expectFetchCalled(fetch, 'http://localhost:5001/mf-manifest.json');
   });
 });
 
@@ -266,8 +274,8 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.ssr.js' },
     });
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/remoteEntry.ssr.js');
-    expect(fetch).not.toHaveBeenCalledWith('http://localhost:5001/mf-manifest.json');
+    expectFetchCalled(fetch, 'http://localhost:5001/remoteEntry.ssr.js');
+    expectFetchNotCalled(fetch, 'http://localhost:5001/mf-manifest.json');
   });
 
   it('fetches the manifest URL directly when entry is mf-manifest.json', async () => {
@@ -289,7 +297,7 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/mf-manifest.json' },
     });
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/mf-manifest.json');
+    expectFetchCalled(fetch, 'http://localhost:5001/mf-manifest.json');
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
     expect(heads.map((c) => c[0])).not.toContain(
       'http://localhost:5001/__mf_server__/mf-manifest.ssr.js'
@@ -388,7 +396,7 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     });
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
     expect(heads.map((c) => c[0])).toEqual([]);
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/remoteEntry.ssr.js');
+    expectFetchCalled(fetch, 'http://localhost:5001/remoteEntry.ssr.js');
   });
 
   it('falls back to convention using remoteEntry.name when __mf_server__ is absent', async () => {
@@ -483,6 +491,61 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     expect(manifestGets).toHaveLength(1);
   });
 
+  it('aborts stalled requests and retries them instead of caching the timeout', async () => {
+    const manifestUrl = 'http://localhost:5001/mf-manifest.json';
+    let manifestAttempts = 0;
+    const fetch = vi.fn(
+      async (url: string, options?: { method?: string; signal?: AbortSignal }) => {
+        if (url === manifestUrl) {
+          manifestAttempts++;
+          if (manifestAttempts === 1) {
+            return new Promise<never>((_resolve, reject) => {
+              options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+                once: true,
+              });
+            });
+          }
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({
+              metaData: {
+                ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '', type: 'module' },
+              },
+            }),
+            text: async () => '',
+            headers: { get: (_header: string): string | null => 'application/json' },
+          };
+        }
+
+        const isEntry = url === 'http://localhost:5001/remoteEntry.ssr.js' && !options?.method;
+        return {
+          ok: isEntry,
+          status: isEntry ? 200 : 404,
+          statusText: isEntry ? 'OK' : 'Not Found',
+          json: async () => ({}),
+          text: async () =>
+            isEntry ? 'export async function init() {} export async function get() {}' : '',
+          headers: {
+            get: (_header: string): string | null => (isEntry ? 'application/javascript' : null),
+          },
+        };
+      }
+    );
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+    const plugin = factory({ fetchTimeoutMs: 5 });
+    const remoteInfo = { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' };
+
+    await plugin.loadEntry!({ remoteInfo });
+    await plugin.loadEntry!({ remoteInfo });
+
+    expect(manifestAttempts).toBe(2);
+    const firstManifestRequest = fetch.mock.calls.find(([url]) => url === manifestUrl);
+    expect(firstManifestRequest?.[1]?.signal?.aborted).toBe(true);
+  });
+
   it('dedupes manifest fetches across js and manifest entry URLs', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
@@ -541,8 +604,8 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/dist/custom-manifest.json' },
     });
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/dist/custom-manifest.json');
-    expect(fetch).not.toHaveBeenCalledWith('http://localhost:5001/dist/mf-manifest.json');
+    expectFetchCalled(fetch, 'http://localhost:5001/dist/custom-manifest.json');
+    expectFetchNotCalled(fetch, 'http://localhost:5001/dist/mf-manifest.json');
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
     expect(heads.map((c) => c[0])).not.toContain(
       'http://localhost:5001/dist/__mf_server__/custom-manifest.ssr.js'
@@ -560,8 +623,8 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     await factory().loadEntry!({
       remoteInfo: { name: 'r', entry: 'http://localhost:5001/dist/remoteEntry.js' },
     });
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/dist/mf-manifest.json');
-    expect(fetch).not.toHaveBeenCalledWith('http://localhost:5001/dist/custom-manifest.json');
+    expectFetchCalled(fetch, 'http://localhost:5001/dist/mf-manifest.json');
+    expectFetchNotCalled(fetch, 'http://localhost:5001/dist/custom-manifest.json');
   });
 });
 
@@ -597,7 +660,7 @@ describe('ssrEntryLoaderPlugin — manifest SSR entry resolution', () => {
     expect(heads.map((c) => c[0])).toEqual([
       'http://localhost:5001/__mf_server__/remoteEntry.ssr.js',
     ]);
-    expect(fetch).toHaveBeenCalledWith('http://localhost:5001/remoteEntry.ssr.js');
+    expectFetchCalled(fetch, 'http://localhost:5001/remoteEntry.ssr.js');
   });
 
   it('resolves SSR entry URL with path prefix from manifest', async () => {
@@ -667,6 +730,42 @@ describe('ssrEntryLoaderPlugin — manifest SSR entry resolution', () => {
 // ---------------------------------------------------------------------------
 
 describe('ssrEntryLoaderPlugin — code transformation', () => {
+  it('evicts a timed-out module fetch so the next load can retry it', async () => {
+    const fsMock = await import('fs');
+    (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    const entryUrl = 'http://localhost:5001/remoteEntry.ssr.js';
+    let attempts = 0;
+    const fetch = vi.fn(async (_url: string, options?: { signal?: AbortSignal }) => {
+      attempts++;
+      if (attempts === 1) {
+        return new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+            once: true,
+          });
+        });
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({}),
+        text: async () => 'export async function init() {} export async function get() {}',
+        headers: { get: () => 'application/javascript' },
+      };
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+    const plugin = factory({ fetchTimeoutMs: 5 });
+    const remoteInfo = { name: 'r', entry: entryUrl };
+
+    await plugin.loadEntry!({ remoteInfo });
+    await plugin.loadEntry!({ remoteInfo });
+
+    expect(attempts).toBe(2);
+    expect(fsMock.writeFileSync).toHaveBeenCalled();
+  });
+
   it('throws HTTP status details instead of importing a non-ok SSR entry response', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
@@ -1010,7 +1109,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
       });
 
       expect(result).toBeUndefined();
-      expect(fetch).not.toHaveBeenCalledWith('http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js');
+      expectFetchNotCalled(fetch, 'http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js');
     } finally {
       if (previousNodeEnv === undefined) {
         delete process.env.NODE_ENV;
@@ -1068,7 +1167,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
       });
 
       expect(result).toBeUndefined();
-      expect(fetch).not.toHaveBeenCalledWith('http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js');
+      expectFetchNotCalled(fetch, 'http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js');
     } finally {
       if (previousNodeEnv === undefined) {
         delete process.env.NODE_ENV;
@@ -1115,7 +1214,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
 
       expect(typeof result?.init).toBe('function');
       expect(typeof result?.get).toBe('function');
-      expect(fetch).toHaveBeenCalledWith('http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js');
+      expectFetchCalled(fetch, 'http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js');
     } finally {
       if (previousNodeEnv === undefined) {
         delete process.env.NODE_ENV;

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -546,6 +546,65 @@ describe('ssrEntryLoaderPlugin — manifest-as-entry', () => {
     expect(firstManifestRequest?.[1]?.signal?.aborted).toBe(true);
   });
 
+  it('does not share in-flight caches between different fetch timeouts', async () => {
+    const manifestUrl = 'http://localhost:5001/mf-manifest.json';
+    let manifestAttempts = 0;
+    const fetch = vi.fn(
+      async (url: string, options?: { method?: string; signal?: AbortSignal }) => {
+        if (url === manifestUrl) {
+          manifestAttempts++;
+          if (options?.signal) {
+            return new Promise<never>((_resolve, reject) => {
+              options.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+                once: true,
+              });
+            });
+          }
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({
+              metaData: {
+                ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '', type: 'module' },
+              },
+            }),
+            text: async () => '',
+            headers: { get: (_header: string): string | null => 'application/json' },
+          };
+        }
+
+        const isEntry = url === 'http://localhost:5001/remoteEntry.ssr.js' && !options?.method;
+        return {
+          ok: isEntry,
+          status: isEntry ? 200 : 404,
+          statusText: isEntry ? 'OK' : 'Not Found',
+          json: async () => ({}),
+          text: async () =>
+            isEntry ? 'export async function init() {} export async function get() {}' : '',
+          headers: {
+            get: (_header: string): string | null => (isEntry ? 'application/javascript' : null),
+          },
+        };
+      }
+    );
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+    const remoteInfo = { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' };
+    const timedOutPlugin = factory({ fetchTimeoutMs: 5 });
+    const unboundedPlugin = factory({ fetchTimeoutMs: 0 });
+
+    await Promise.all([
+      timedOutPlugin.loadEntry!({ remoteInfo }),
+      unboundedPlugin.loadEntry!({ remoteInfo }),
+    ]);
+
+    expect(manifestAttempts).toBe(2);
+    expect(fetch.mock.calls.some(([url, options]) => url === manifestUrl && !options?.signal)).toBe(
+      true
+    );
+  });
+
   it('dedupes manifest fetches across js and manifest entry URLs', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_SSR_FETCH_TIMEOUT_MS = 10_000;
+
+/** Fetch with a bounded wait. Set timeoutMs to 0 to disable the timeout. */
+export function fetchWithTimeout(
+  input: Parameters<typeof fetch>[0],
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS
+): Promise<Response> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return fetch(input, init);
+
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal;
+  return fetch(input, { ...init, signal });
+}

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -26,6 +26,8 @@
  * generated runtimePlugins list in virtualRemotes.ts.
  */
 
+import { DEFAULT_SSR_FETCH_TIMEOUT_MS, fetchWithTimeout } from './fetchWithTimeout';
+
 // No static Node.js imports — this module is safe to import in the browser.
 // Node APIs are loaded on demand via dynamic import() which is tree-shaken
 // away when the caller is guarded by a Node environment check.
@@ -91,8 +93,9 @@ async function getModuleRunnerModule(): Promise<{
  * This is Vite 8+ only — older versions don't expose `vite/module-runner` or
  * the `/__mf_runner__` proxy endpoint.
  */
-async function getOrCreateRunner(remoteOrigin: string): Promise<unknown> {
-  if (runnerCache.has(remoteOrigin)) return runnerCache.get(remoteOrigin)!;
+async function getOrCreateRunner(remoteOrigin: string, fetchTimeoutMs: number): Promise<unknown> {
+  const cacheKey = `${fetchTimeoutMs}::${remoteOrigin}`;
+  if (runnerCache.has(cacheKey)) return runnerCache.get(cacheKey)!;
   const promise = (async () => {
     const viteRunner = await getModuleRunnerModule();
     if (!viteRunner) return null;
@@ -106,11 +109,15 @@ async function getOrCreateRunner(remoteOrigin: string): Promise<unknown> {
           hmr: false,
           transport: {
             async invoke(payload) {
-              const res = await fetch(runnerEndpoint, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-              });
+              const res = await fetchWithTimeout(
+                runnerEndpoint,
+                {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(payload),
+                },
+                fetchTimeoutMs
+              );
               return (await res.json()) as { result: unknown } | { error: { message: string } };
             },
           },
@@ -122,7 +129,7 @@ async function getOrCreateRunner(remoteOrigin: string): Promise<unknown> {
       return null;
     }
   })();
-  runnerCache.set(remoteOrigin, promise);
+  runnerCache.set(cacheKey, promise);
   return promise;
 }
 
@@ -227,9 +234,12 @@ function isSsrEntryHttpError(error: unknown): error is SsrEntryHttpError {
   return error instanceof SsrEntryHttpError;
 }
 
-async function fetchManifest(manifestUrl: string): Promise<Manifest | null> {
+async function fetchManifest(
+  manifestUrl: string,
+  fetchTimeoutMs: number
+): Promise<Manifest | null> {
   try {
-    const res = await fetch(manifestUrl);
+    const res = await fetchWithTimeout(manifestUrl, {}, fetchTimeoutMs);
     if (!res.ok) return null;
     return (await res.json()) as Manifest;
   } catch {
@@ -237,9 +247,18 @@ async function fetchManifest(manifestUrl: string): Promise<Manifest | null> {
   }
 }
 
-async function fetchManifestCached(manifestUrl: string): Promise<Manifest | null> {
+async function fetchManifestCached(
+  manifestUrl: string,
+  fetchTimeoutMs: number
+): Promise<Manifest | null> {
   if (!manifestFetchCache.has(manifestUrl)) {
-    manifestFetchCache.set(manifestUrl, fetchManifest(manifestUrl));
+    const promise = fetchManifest(manifestUrl, fetchTimeoutMs);
+    manifestFetchCache.set(manifestUrl, promise);
+    void promise.then((manifest) => {
+      if (!manifest && manifestFetchCache.get(manifestUrl) === promise) {
+        manifestFetchCache.delete(manifestUrl);
+      }
+    });
   }
   return manifestFetchCache.get(manifestUrl)!;
 }
@@ -298,9 +317,12 @@ function resolveSSREntryUrl(manifest: Manifest, manifestUrl: string): SsrEntryCa
  * remoteEntry.js → /__mf_ssr__/remoteEntry.ssr.js (dev middleware)
  * Returns the first URL that responds with a 200.
  */
-async function headCheckSsrEntry(candidate: SsrEntryCandidate): Promise<SsrEntryCandidate | null> {
+async function headCheckSsrEntry(
+  candidate: SsrEntryCandidate,
+  fetchTimeoutMs: number
+): Promise<SsrEntryCandidate | null> {
   try {
-    const res = await fetch(candidate.url, { method: 'HEAD' });
+    const res = await fetchWithTimeout(candidate.url, { method: 'HEAD' }, fetchTimeoutMs);
     const ct = res.headers.get('content-type') ?? '';
     // Reject SPA index.html fallbacks — only accept JS/text responses.
     if (res.ok && !ct.includes('text/html')) return candidate;
@@ -321,9 +343,9 @@ function resolveAssetBaseUrl(
   return new URL('remoteEntry.js', manifestUrl.replace(/\/[^/]+$/, '/')).href;
 }
 
-async function buildEntryContext(entryUrl: string): Promise<EntryContext> {
+async function buildEntryContext(entryUrl: string, fetchTimeoutMs: number): Promise<EntryContext> {
   const manifestUrl = getManifestUrl(entryUrl);
-  const manifest = await fetchManifestCached(manifestUrl);
+  const manifest = await fetchManifestCached(manifestUrl, fetchTimeoutMs);
   const assetBaseUrl = resolveAssetBaseUrl(entryUrl, manifest, manifestUrl);
   const filename = getEntryFilename(assetBaseUrl);
   const remoteOrigin = assetBaseUrl.replace(/\/[^/]+$/, '');
@@ -360,16 +382,20 @@ function buildSsrEntryCandidates(
 }
 
 async function resolveFirstReachableCandidate(
-  candidates: SsrEntryCandidate[]
+  candidates: SsrEntryCandidate[],
+  fetchTimeoutMs: number
 ): Promise<SsrEntryCandidate | null> {
   for (const candidate of candidates) {
-    const hit = await headCheckSsrEntry(candidate);
+    const hit = await headCheckSsrEntry(candidate, fetchTimeoutMs);
     if (hit) return hit;
   }
   return null;
 }
 
-async function resolveSSREntryImpl(remoteEntryUrl: string): Promise<SsrEntryCandidate | null> {
+async function resolveSSREntryImpl(
+  remoteEntryUrl: string,
+  fetchTimeoutMs: number
+): Promise<SsrEntryCandidate | null> {
   if (isSsrEntry(remoteEntryUrl)) {
     return { url: remoteEntryUrl, type: 'module', versionKey: UNVERSIONED };
   }
@@ -378,39 +404,48 @@ async function resolveSSREntryImpl(remoteEntryUrl: string): Promise<SsrEntryCand
   if (!isManifestEntry(remoteEntryUrl)) {
     const filename = getEntryFilename(remoteEntryUrl);
     const remoteOrigin = remoteEntryUrl.replace(/\/[^/]+$/, '');
-    const fromServerBuild = await headCheckSsrEntry({
-      url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
-      type: 'module',
-      versionKey: UNVERSIONED,
-    });
+    const fromServerBuild = await headCheckSsrEntry(
+      {
+        url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
+        type: 'module',
+        versionKey: UNVERSIONED,
+      },
+      fetchTimeoutMs
+    );
     if (fromServerBuild) return fromServerBuild;
   }
 
-  const ctx = await buildEntryContext(remoteEntryUrl);
+  const ctx = await buildEntryContext(remoteEntryUrl, fetchTimeoutMs);
   if (ctx.manifest) {
     const fromManifest = resolveSSREntryUrl(ctx.manifest, ctx.manifestUrl);
     if (fromManifest) return fromManifest;
   }
   return resolveFirstReachableCandidate(
-    buildSsrEntryCandidates(ctx, { skipServerBuild: !isManifestEntry(remoteEntryUrl) })
+    buildSsrEntryCandidates(ctx, { skipServerBuild: !isManifestEntry(remoteEntryUrl) }),
+    fetchTimeoutMs
   );
 }
 
-function setSsrEntryCache(remoteEntryUrl: string): SsrEntryCacheRecord {
+function setSsrEntryCache(remoteEntryUrl: string, fetchTimeoutMs: number): SsrEntryCacheRecord {
   const record: SsrEntryCacheRecord = {
-    promise: resolveSSREntryImpl(remoteEntryUrl),
+    promise: resolveSSREntryImpl(remoteEntryUrl, fetchTimeoutMs),
     resolvedAt: Date.now(),
   };
   ssrEntryCache.set(remoteEntryUrl, record);
+  void record.promise.then((entry) => {
+    if (!entry && ssrEntryCache.get(remoteEntryUrl) === record)
+      ssrEntryCache.delete(remoteEntryUrl);
+  });
   return record;
 }
 
 async function getSSREntry(
   remoteEntryUrl: string,
-  maxAgeMs?: number
+  maxAgeMs: number | undefined,
+  fetchTimeoutMs: number
 ): Promise<SsrEntryCandidate | null> {
   const cached = ssrEntryCache.get(remoteEntryUrl);
-  if (!cached) return setSsrEntryCache(remoteEntryUrl).promise;
+  if (!cached) return setSsrEntryCache(remoteEntryUrl, fetchTimeoutMs).promise;
 
   const isStale =
     typeof maxAgeMs === 'number' && maxAgeMs >= 0 && Date.now() - cached.resolvedAt >= maxAgeMs;
@@ -421,7 +456,7 @@ async function getSSREntry(
   // names, so the fresh entry is imported instead of Node's cached module.
   const previous = await cached.promise.catch(() => null);
   manifestFetchCache.delete(getManifestUrl(remoteEntryUrl));
-  const record = setSsrEntryCache(remoteEntryUrl);
+  const record = setSsrEntryCache(remoteEntryUrl, fetchTimeoutMs);
   const next = await record.promise.catch(() => null);
 
   if (previous && next && previous.versionKey !== next.versionKey) {
@@ -596,14 +631,15 @@ async function fetchEsmToTempFile(
   tmpDir: string,
   visited: Map<string, string>,
   sharedPkgMap?: Map<string, string>,
-  versionKey: string = UNVERSIONED
+  versionKey: string = UNVERSIONED,
+  fetchTimeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS
 ): Promise<string> {
   const cacheKey = `${versionKey}::${url}`;
   if (visited.has(url)) return visited.get(url)!;
   if (tempFileCache.has(cacheKey)) return tempFileCache.get(cacheKey)!;
 
   const promise = (async () => {
-    const res = await fetch(url);
+    const res = await fetchWithTimeout(url, {}, fetchTimeoutMs);
     let code = await res.text();
     if (!res.ok) {
       throw new SsrEntryHttpError(url, res.status, res.statusText, getBodyPreview(code));
@@ -631,7 +667,14 @@ async function fetchEsmToTempFile(
       [...new Set(relImports)]
         .filter((u) => u.startsWith('http://') || u.startsWith('https://'))
         .map(async (u) => {
-          const tmpPath = await fetchEsmToTempFile(u, tmpDir, visited, sharedPkgMap, versionKey);
+          const tmpPath = await fetchEsmToTempFile(
+            u,
+            tmpDir,
+            visited,
+            sharedPkgMap,
+            versionKey,
+            fetchTimeoutMs
+          );
           subMap.set(u, `file://${tmpPath}`);
         })
     );
@@ -654,7 +697,10 @@ async function fetchEsmToTempFile(
   })();
 
   tempFileCache.set(cacheKey, promise);
-  return promise;
+  return promise.catch((error) => {
+    if (tempFileCache.get(cacheKey) === promise) tempFileCache.delete(cacheKey);
+    throw error;
+  });
 }
 
 async function importTempModule(
@@ -690,6 +736,7 @@ async function tryVmStrategy(
     resolvedShared: options.resolvedShared,
     shareScopeName: options.shareScopeName,
     versionKey: ssrEntry.versionKey,
+    fetchTimeoutMs: options.fetchTimeoutMs,
   })) as { init: unknown; get: unknown } | null;
 }
 
@@ -727,7 +774,7 @@ async function loadSSRRemoteEntry(
       // virtual SSR entry ID, so `runner.import()` traverses the full Vite
       // plugin pipeline and returns real, fully-transformed module source.
       const remoteOrigin = urlObj.origin;
-      const runner = await getOrCreateRunner(remoteOrigin);
+      const runner = await getOrCreateRunner(remoteOrigin, options.fetchTimeoutMs);
       if (!runner) {
         if (process.env.NODE_ENV !== 'production') return null;
       } else {
@@ -775,7 +822,14 @@ async function loadSSRRemoteEntry(
     const sharedPkgMap = new Map(Object.entries(resolvedShared));
 
     try {
-      const tmpFile = await fetchEsmToTempFile(url, cacheDir, new Map(), sharedPkgMap, versionKey);
+      const tmpFile = await fetchEsmToTempFile(
+        url,
+        cacheDir,
+        new Map(),
+        sharedPkgMap,
+        versionKey,
+        options.fetchTimeoutMs
+      );
       return await importTempModule(tmpFile, versionKey);
     } catch (error) {
       if (isSsrEntryHttpError(error)) throw error;
@@ -835,6 +889,11 @@ interface SsrEntryLoaderOptions {
    * source.
    */
   maxAgeMs?: number;
+  /**
+   * Maximum time in milliseconds for each SSR network request. Defaults to
+   * 10 seconds. Set to `0` to disable the timeout.
+   */
+  fetchTimeoutMs?: number;
 }
 
 interface ResolvedLoaderOptions {
@@ -842,6 +901,7 @@ interface ResolvedLoaderOptions {
   strategy: 'temp-file' | 'vm';
   shareScopeName: string;
   maxAgeMs?: number;
+  fetchTimeoutMs: number;
 }
 
 // Default export so the module can be referenced as a runtimePlugin path string.
@@ -851,6 +911,7 @@ export default function ssrEntryLoaderPlugin(options: SsrEntryLoaderOptions = {}
     strategy: options.strategy ?? 'temp-file',
     shareScopeName: options.shareScopeName ?? 'default',
     maxAgeMs: options.maxAgeMs,
+    fetchTimeoutMs: options.fetchTimeoutMs ?? DEFAULT_SSR_FETCH_TIMEOUT_MS,
   };
   return {
     name: 'mf-vite:ssr-entry-loader',
@@ -858,7 +919,11 @@ export default function ssrEntryLoaderPlugin(options: SsrEntryLoaderOptions = {}
       // Only intercept on the server — browser should use the normal path.
       if (!isNodeServer()) return;
 
-      const ssrEntry = await getSSREntry(remoteInfo.entry, resolved.maxAgeMs);
+      const ssrEntry = await getSSREntry(
+        remoteInfo.entry,
+        resolved.maxAgeMs,
+        resolved.fetchTimeoutMs
+      );
       if (!ssrEntry) return;
 
       const mod = await loadSSRRemoteEntry(ssrEntry, resolved);

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -196,6 +196,10 @@ const ssrEntryCache = new Map<string, SsrEntryCacheRecord>();
 // Dedupe manifest fetches when multiple entry URLs resolve to the same manifest.
 const manifestFetchCache = new Map<string, Promise<Manifest | null>>();
 
+function makeUrlCacheKey(url: string, fetchTimeoutMs: number): string {
+  return `${fetchTimeoutMs}::${url}`;
+}
+
 interface EntryContext {
   entryUrl: string;
   manifestUrl: string;
@@ -251,16 +255,17 @@ async function fetchManifestCached(
   manifestUrl: string,
   fetchTimeoutMs: number
 ): Promise<Manifest | null> {
-  if (!manifestFetchCache.has(manifestUrl)) {
+  const cacheKey = makeUrlCacheKey(manifestUrl, fetchTimeoutMs);
+  if (!manifestFetchCache.has(cacheKey)) {
     const promise = fetchManifest(manifestUrl, fetchTimeoutMs);
-    manifestFetchCache.set(manifestUrl, promise);
+    manifestFetchCache.set(cacheKey, promise);
     void promise.then((manifest) => {
-      if (!manifest && manifestFetchCache.get(manifestUrl) === promise) {
-        manifestFetchCache.delete(manifestUrl);
+      if (!manifest && manifestFetchCache.get(cacheKey) === promise) {
+        manifestFetchCache.delete(cacheKey);
       }
     });
   }
-  return manifestFetchCache.get(manifestUrl)!;
+  return manifestFetchCache.get(cacheKey)!;
 }
 
 /** True when the host configured a manifest URL as the remote entry (any .json name). */
@@ -427,14 +432,14 @@ async function resolveSSREntryImpl(
 }
 
 function setSsrEntryCache(remoteEntryUrl: string, fetchTimeoutMs: number): SsrEntryCacheRecord {
+  const cacheKey = makeUrlCacheKey(remoteEntryUrl, fetchTimeoutMs);
   const record: SsrEntryCacheRecord = {
     promise: resolveSSREntryImpl(remoteEntryUrl, fetchTimeoutMs),
     resolvedAt: Date.now(),
   };
-  ssrEntryCache.set(remoteEntryUrl, record);
+  ssrEntryCache.set(cacheKey, record);
   void record.promise.then((entry) => {
-    if (!entry && ssrEntryCache.get(remoteEntryUrl) === record)
-      ssrEntryCache.delete(remoteEntryUrl);
+    if (!entry && ssrEntryCache.get(cacheKey) === record) ssrEntryCache.delete(cacheKey);
   });
   return record;
 }
@@ -444,7 +449,8 @@ async function getSSREntry(
   maxAgeMs: number | undefined,
   fetchTimeoutMs: number
 ): Promise<SsrEntryCandidate | null> {
-  const cached = ssrEntryCache.get(remoteEntryUrl);
+  const cacheKey = makeUrlCacheKey(remoteEntryUrl, fetchTimeoutMs);
+  const cached = ssrEntryCache.get(cacheKey);
   if (!cached) return setSsrEntryCache(remoteEntryUrl, fetchTimeoutMs).promise;
 
   const isStale =
@@ -455,7 +461,7 @@ async function getSSREntry(
   // (remote redeployed at the same URL), the new key flows into temp-file
   // names, so the fresh entry is imported instead of Node's cached module.
   const previous = await cached.promise.catch(() => null);
-  manifestFetchCache.delete(getManifestUrl(remoteEntryUrl));
+  manifestFetchCache.delete(makeUrlCacheKey(getManifestUrl(remoteEntryUrl), fetchTimeoutMs));
   const record = setSsrEntryCache(remoteEntryUrl, fetchTimeoutMs);
   const next = await record.promise.catch(() => null);
 
@@ -477,8 +483,8 @@ function dropRemoteCaches(remoteEntryUrl: string): void {
   } catch {
     return;
   }
-  for (const key of tempFileCache.keys()) {
-    const url = key.slice(key.indexOf('::') + 2);
+  for (const [key] of tempFileCache) {
+    const url = JSON.parse(key)[2] as string;
     if (url.startsWith(origin)) tempFileCache.delete(key);
   }
 }
@@ -495,8 +501,13 @@ function dropRemoteCaches(remoteEntryUrl: string): void {
  */
 export function revalidate(remoteEntryUrl?: string): void {
   if (remoteEntryUrl) {
-    ssrEntryCache.delete(remoteEntryUrl);
-    manifestFetchCache.delete(getManifestUrl(remoteEntryUrl));
+    for (const key of ssrEntryCache.keys()) {
+      if (key.endsWith(`::${remoteEntryUrl}`)) ssrEntryCache.delete(key);
+    }
+    const manifestUrl = getManifestUrl(remoteEntryUrl);
+    for (const key of manifestFetchCache.keys()) {
+      if (key.endsWith(`::${manifestUrl}`)) manifestFetchCache.delete(key);
+    }
     dropRemoteCaches(remoteEntryUrl);
   } else {
     ssrEntryCache.clear();
@@ -634,7 +645,7 @@ async function fetchEsmToTempFile(
   versionKey: string = UNVERSIONED,
   fetchTimeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS
 ): Promise<string> {
-  const cacheKey = `${versionKey}::${url}`;
+  const cacheKey = JSON.stringify([fetchTimeoutMs, versionKey, url]);
   if (visited.has(url)) return visited.get(url)!;
   if (tempFileCache.has(cacheKey)) return tempFileCache.get(cacheKey)!;
 

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -19,7 +19,7 @@
  * API is missing.
  */
 import { neutralizeBrowserPreloadHelpers, SsrEntryHttpError } from './ssrEntryLoader';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { DEFAULT_SSR_FETCH_TIMEOUT_MS, fetchWithTimeout } from './fetchWithTimeout';
 
 interface VmStrategyOptions {
   resolvedShared: Record<string, string>;
@@ -190,7 +190,11 @@ function resolveSpecifierUrl(specifier: string, referencerUrl: string): string |
 }
 
 function getHttpModule(vm: VmApi, url: string, options: VmStrategyOptions): Promise<VmModule> {
-  const cacheKey = `${options.versionKey}::${url}`;
+  const cacheKey = JSON.stringify([
+    options.fetchTimeoutMs ?? DEFAULT_SSR_FETCH_TIMEOUT_MS,
+    options.versionKey,
+    url,
+  ]);
   if (!httpModuleCache.has(cacheKey)) {
     httpModuleCache.set(
       cacheKey,

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -19,11 +19,13 @@
  * API is missing.
  */
 import { neutralizeBrowserPreloadHelpers, SsrEntryHttpError } from './ssrEntryLoader';
+import { fetchWithTimeout } from './fetchWithTimeout';
 
 interface VmStrategyOptions {
   resolvedShared: Record<string, string>;
   shareScopeName: string;
   versionKey: string;
+  fetchTimeoutMs?: number;
 }
 
 // Minimal structural typings for the experimental vm module APIs so this file
@@ -165,8 +167,8 @@ function getBodyPreview(body: string): string {
   return body.slice(0, 240).replace(/\s+/g, ' ').trim();
 }
 
-async function fetchModuleSource(url: string): Promise<string> {
-  const res = await fetch(url);
+async function fetchModuleSource(url: string, fetchTimeoutMs?: number): Promise<string> {
+  const res = await fetchWithTimeout(url, {}, fetchTimeoutMs);
   const text = await res.text();
   if (!res.ok) {
     throw new SsrEntryHttpError(url, res.status, res.statusText, getBodyPreview(text));
@@ -193,7 +195,7 @@ function getHttpModule(vm: VmApi, url: string, options: VmStrategyOptions): Prom
     httpModuleCache.set(
       cacheKey,
       (async () => {
-        const code = await fetchModuleSource(url);
+        const code = await fetchModuleSource(url, options.fetchTimeoutMs);
         return new vm.SourceTextModule(code, {
           identifier: url,
           initializeImportMeta(meta) {


### PR DESCRIPTION
## Summary

- abort SSR manifest, candidate probe, module graph, VM-strategy, and ModuleRunner transport requests after a configurable timeout
- default each request to a 10-second limit while allowing `fetchTimeoutMs: 0` to opt out
- evict failed manifest, entry-resolution, and temp-module cache records so a transient timeout can be retried

## Why

A remote that accepts a connection but never completes its response can currently leave server rendering pending indefinitely. The pending promise is also cached in several paths, so later renders remain stuck even after the remote recovers.

## Verification

- `pnpm vitest run src/utils/__tests__/ssrEntryLoader.test.ts src/utils/__tests__/ssrVmStrategy.test.ts`
- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm test` (747 passed, 1 skipped)
- `pnpm build`
