### PR TITLE
fix: resolve lazy shared providers

### DIFF
--- a/e2e/vite-runtime-register/runtime-register.spec.ts
+++ b/e2e/vite-runtime-register/runtime-register.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+test('uses a runtime host get-only React singleton', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'registerRemotes()' }).click();
+  await page.getByRole('button', { name: 'loadRemote() component' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Remote component mounted' })).toBeVisible();
+
+  const counter = page.getByTestId('runtime-remote-counter');
+  await expect(counter).toHaveText('count: 0');
+  await counter.click();
+  await expect(counter).toHaveText('count: 1');
+  const shareHooks = await page.evaluate(() => {
+    const runtimeGlobal = globalThis as typeof globalThis & {
+      __runtimeRegisterShareHooks?: string[];
+    };
+    return runtimeGlobal.__runtimeRegisterShareHooks ?? [];
+  });
+  expect(shareHooks).toEqual(
+    expect.arrayContaining(['beforeLoadShare', 'resolveShare', 'afterLoadShare'])
+  );
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/vite-runtime-register/runtime-register.spec.ts
+++ b/e2e/vite-runtime-register/runtime-register.spec.ts
@@ -45,8 +45,11 @@ test('uses a runtime host get-only React singleton', async ({ page }) => {
     };
     return runtimeGlobal.__runtimeRegisterShareHooks ?? [];
   });
-  expect(shareHooks).toEqual(
-    expect.arrayContaining(['beforeLoadShare', 'resolveShare', 'afterLoadShare'])
-  );
+  const beforeLoadShareIndex = shareHooks.indexOf('beforeLoadShare');
+  const resolveShareIndex = shareHooks.indexOf('resolveShare');
+  const afterLoadShareIndex = shareHooks.indexOf('afterLoadShare');
+  expect(beforeLoadShareIndex).toBeGreaterThanOrEqual(0);
+  expect(beforeLoadShareIndex).toBeLessThan(resolveShareIndex);
+  expect(resolveShareIndex).toBeLessThan(afterLoadShareIndex);
   expect(pageErrors).toEqual([]);
 });

--- a/e2e/vite-runtime-register/runtime-register.spec.ts
+++ b/e2e/vite-runtime-register/runtime-register.spec.ts
@@ -5,10 +5,35 @@ test('uses a runtime host get-only React singleton', async ({ page }) => {
   page.on('pageerror', (error) => pageErrors.push(error));
 
   await page.goto('/');
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __runtimeRegisterReactGetCalls?: number;
+            }
+          ).__runtimeRegisterReactGetCalls ?? -1
+      )
+    )
+    .toBe(0);
   await page.getByRole('button', { name: 'registerRemotes()' }).click();
   await page.getByRole('button', { name: 'loadRemote() component' }).click();
 
   await expect(page.getByRole('heading', { name: 'Remote component mounted' })).toBeVisible();
+  await expect(page.getByTestId('runtime-react-identity')).toHaveText('host React identity');
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __runtimeRegisterReactGetCalls?: number;
+            }
+          ).__runtimeRegisterReactGetCalls ?? 0
+      )
+    )
+    .toBeGreaterThan(0);
 
   const counter = page.getByTestId('runtime-remote-counter');
   await expect(counter).toHaveText('count: 0');

--- a/examples/vite-runtime-register/README.md
+++ b/examples/vite-runtime-register/README.md
@@ -5,7 +5,7 @@ Pure runtime host + Vite remote.
 What it shows:
 
 - host creates a Module Federation runtime instance
-- host registers React shared deps at runtime
+- host registers lazy, get-only React shared deps at runtime
 - host registers a remote with `registerRemotes()`
 - host loads exposed modules with `loadRemote()`
 

--- a/examples/vite-runtime-register/vite-host/src/runtime.js
+++ b/examples/vite-runtime-register/vite-host/src/runtime.js
@@ -3,8 +3,7 @@ import ReactDOM from 'react-dom';
 import { createInstance } from '@module-federation/enhanced/runtime';
 
 const remoteEntryUrl =
-  import.meta.env.VITE_REMOTE_ENTRY_URL ??
-  'http://localhost:4176/mf-manifest.json';
+  import.meta.env.VITE_REMOTE_ENTRY_URL ?? 'http://localhost:4176/mf-manifest.json';
 
 const mf = createInstance({
   name: 'viteRuntimeRegisterHost',
@@ -15,7 +14,7 @@ mf.registerShared({
   react: {
     version: React.version,
     scope: 'default',
-    lib: () => React,
+    get: async () => () => React,
     shareConfig: {
       singleton: true,
       requiredVersion: `^${React.version}`,
@@ -24,7 +23,7 @@ mf.registerShared({
   'react-dom': {
     version: ReactDOM.version || React.version,
     scope: 'default',
-    lib: () => ReactDOM,
+    get: async () => () => ReactDOM,
     shareConfig: {
       singleton: true,
       requiredVersion: `^${ReactDOM.version || React.version}`,

--- a/examples/vite-runtime-register/vite-host/src/runtime.js
+++ b/examples/vite-runtime-register/vite-host/src/runtime.js
@@ -10,11 +10,17 @@ const mf = createInstance({
   remotes: [],
 });
 
+globalThis.__runtimeRegisterHostReactUseState = React.useState;
+globalThis.__runtimeRegisterReactGetCalls = 0;
+
 mf.registerShared({
   react: {
     version: React.version,
     scope: 'default',
-    get: async () => () => React,
+    get: async () => {
+      globalThis.__runtimeRegisterReactGetCalls += 1;
+      return () => React;
+    },
     shareConfig: {
       singleton: true,
       requiredVersion: `^${React.version}`,

--- a/examples/vite-runtime-register/vite-remote/src/MessageCard.jsx
+++ b/examples/vite-runtime-register/vite-remote/src/MessageCard.jsx
@@ -3,6 +3,7 @@ import './index.css';
 
 export default function MessageCard() {
   const [count, setCount] = useState(0);
+  const usesHostReact = useState === globalThis.__runtimeRegisterHostReactUseState;
 
   return (
     <article className="card">
@@ -11,6 +12,9 @@ export default function MessageCard() {
       <p>
         Built with <code>@module-federation/vite</code>, discovered through the runtime manifest,
         rendered inside the host app.
+      </p>
+      <p data-testid="runtime-react-identity">
+        {usesHostReact ? 'host React identity' : 'different React identity'}
       </p>
       <button data-testid="runtime-remote-counter" onClick={() => setCount((value) => value + 1)}>
         count: {count}

--- a/examples/vite-runtime-register/vite-remote/src/MessageCard.jsx
+++ b/examples/vite-runtime-register/vite-remote/src/MessageCard.jsx
@@ -1,14 +1,20 @@
+import { useState } from 'react';
 import './index.css';
 
 export default function MessageCard() {
+  const [count, setCount] = useState(0);
+
   return (
     <article className="card">
       <p className="tag">runtimeRemote/MessageCard</p>
       <h3>Remote component mounted</h3>
       <p>
-        Built with <code>@module-federation/vite</code>, discovered through the
-        runtime manifest, rendered inside the host app.
+        Built with <code>@module-federation/vite</code>, discovered through the runtime manifest,
+        rendered inside the host app.
       </p>
+      <button data-testid="runtime-remote-counter" onClick={() => setCount((value) => value + 1)}>
+        count: {count}
+      </button>
     </article>
   );
 }

--- a/examples/vite-runtime-register/vite-remote/src/runtimePlugin.js
+++ b/examples/vite-runtime-register/vite-remote/src/runtimePlugin.js
@@ -1,0 +1,21 @@
+const recordShareHook = (name, pkgName) => {
+  if (pkgName !== 'react') return;
+  (globalThis.__runtimeRegisterShareHooks ||= []).push(name);
+};
+
+export default function runtimeRegisterSharePlugin() {
+  return {
+    name: 'runtime-register-share-hooks',
+    beforeLoadShare(args) {
+      recordShareHook('beforeLoadShare', args.pkgName);
+      return args;
+    },
+    resolveShare(args) {
+      recordShareHook('resolveShare', args.pkgName);
+      return args;
+    },
+    afterLoadShare(args) {
+      recordShareHook('afterLoadShare', args.pkgName);
+    },
+  };
+}

--- a/examples/vite-runtime-register/vite-remote/vite.config.js
+++ b/examples/vite-runtime-register/vite-remote/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
         './MessageCard': './src/MessageCard.jsx',
         './message': './src/message.js',
       },
+      runtimePlugins: ['./src/runtimePlugin.js'],
       shared: {
         react: {
           singleton: true,

--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -108,7 +108,7 @@ describe('shared dependencies', () => {
     expect(allCode).not.toContain('versions[Object.keys(versions)[0]]');
     expect(allCode).toContain('__mfReadSharedCache(__mfModuleCache.share');
     expect(allCode).toContain('__mfWriteSharedCache(__mfModuleCache.share');
-    expect(allCode).not.toContain('initRes.loadShare(pkg');
+    expect(allCode).toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');
     expect(loadShare!.code).toContain('pendingShareLoads');
     expect(loadShare!.code).toContain('default:mock-shared-dep');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,18 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
+    {
+      command: 'pnpm --filter examples-vite-runtime-register-host run preview',
+      url: 'http://localhost:4175',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: 'pnpm --filter examples-vite-runtime-register-remote run preview',
+      url: 'http://localhost:4176',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
   ],
   use: {
     trace: 'retain-on-failure',
@@ -50,6 +62,14 @@ export default defineConfig({
       testMatch: 'remote-preview.spec.ts',
       use: {
         baseURL: 'http://localhost:5176',
+        browserName: 'chromium',
+      },
+    },
+    {
+      name: 'vite-runtime-register',
+      testDir: 'e2e/vite-runtime-register',
+      use: {
+        baseURL: 'http://localhost:4175',
         browserName: 'chromium',
       },
     },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -190,6 +190,23 @@ function getModuleFederationVitePlugin(): FederationPlugin {
   return plugin;
 }
 
+function getModuleFederationVitePluginWithShared(): FederationPlugin {
+  const plugin = (
+    federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      shared: {
+        react: {
+          singleton: true,
+        },
+      },
+    }) as Plugin[]
+  ).find((entry) => entry.name === 'module-federation-vite');
+
+  if (!plugin) throw new Error('module-federation-vite plugin not found');
+  return plugin;
+}
+
 function getModuleFederationVitePluginWithImportFalse(implementation?: string): FederationPlugin {
   const plugin = (
     federation({
@@ -1774,6 +1791,34 @@ describe('vite:module-federation-early-init', () => {
     );
     expect(config.optimizeDeps.include).toContain('@module-federation/runtime');
     expect(config.optimizeDeps.include).not.toContain('@module-federation/runtime/helpers');
+  });
+
+  it('aliases and prebundles runtime helpers for normal shared dependencies', () => {
+    const plugin = getModuleFederationVitePluginWithShared();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: [],
+      },
+      resolve: {
+        alias: [],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const runtimeHelpersAlias = config.resolve.alias.find(
+      (alias: { find: string | RegExp }) =>
+        alias.find instanceof RegExp && alias.find.test('@module-federation/runtime/helpers')
+    );
+
+    expect(runtimeHelpersAlias.replacement).toEqual(
+      expect.stringMatching(/@module-federation\/runtime\/dist\/helpers\.js$/)
+    );
+    expect(config.optimizeDeps.include).toContain('@module-federation/runtime/helpers');
   });
 
   it('aliases runtime helpers to the same runtime package for import:false provider selection', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,10 +186,6 @@ function appendResolveAlias(config: UserConfig, alias: ResolveAliasEntry): void 
   ];
 }
 
-function hasImportFalseShared(options: NormalizedModuleFederationOptions): boolean {
-  return Object.values(options.shared ?? {}).some((share) => share?.shareConfig?.import === false);
-}
-
 function getRuntimeHelpersImplementation(runtimeImplementation: string): string {
   const indexEntryMatch = runtimeImplementation.match(/^(.*[\\/])index(\.[cm]?js)$/);
   if (indexEntryMatch) {
@@ -1133,10 +1129,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       config(config: UserConfig, { command: _command }: { command: string }) {
         const isRolldown = getIsRolldown(this);
         isSsrBuild = _command === 'build' && config.build?.ssr === true;
-        const needsSharedProviderSelectionHelper = hasImportFalseShared(options);
-        const needsRuntimeHelpers =
-          needsSharedProviderSelectionHelper ||
-          Object.values(options.shared ?? {}).some((share) => !!share?.shareConfig.treeShaking);
+        const needsRuntimeHelpers = Object.keys(options.shared ?? {}).length > 0;
 
         if (needsRuntimeHelpers) {
           appendResolveAlias(config, {

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -19,6 +19,7 @@
  * build time.  Use explicit named re-exports instead.
  */
 import type { Plugin } from 'vite';
+import { createCodePositionMap } from '../utils/codePositionMap';
 import { CodeRewriter, type SourceMapLike } from '../utils/codeRewriter';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { LOAD_REMOTE_TAG, LOAD_SHARE_TAG } from '../virtualModules';
@@ -498,58 +499,6 @@ function collectFromRegex(
   }
 
   return result.length > 0 ? result : undefined;
-}
-
-function createCodePositionMap(code: string): boolean[] {
-  const positions = Array(code.length).fill(true);
-
-  function mask(start: number, end: number): void {
-    for (let i = start; i < end; i++) positions[i] = false;
-  }
-
-  for (let i = 0; i < code.length; ) {
-    const char = code[i];
-    const next = code[i + 1];
-
-    if (char === '/' && next === '/') {
-      const start = i;
-      i += 2;
-      while (i < code.length && code[i] !== '\n' && code[i] !== '\r') i++;
-      mask(start, i);
-      continue;
-    }
-
-    if (char === '/' && next === '*') {
-      const start = i;
-      i += 2;
-      while (i < code.length && !(code[i] === '*' && code[i + 1] === '/')) i++;
-      i = Math.min(code.length, i + 2);
-      mask(start, i);
-      continue;
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      const quote = char;
-      const start = i++;
-      while (i < code.length) {
-        if (code[i] === '\\') {
-          i += 2;
-          continue;
-        }
-        if (code[i] === quote) {
-          i++;
-          break;
-        }
-        i++;
-      }
-      mask(start, i);
-      continue;
-    }
-
-    i++;
-  }
-
-  return positions;
 }
 
 // ── Plugin factory ────────────────────────────────────────────────

--- a/src/utils/__tests__/codePositionMap.test.ts
+++ b/src/utils/__tests__/codePositionMap.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createCodePositionMap } from '../codePositionMap';
+
+describe('createCodePositionMap', () => {
+  it('keeps exports after one-line JSX closing tags in code', () => {
+    const source =
+      'export function A(){return <div></div>} export function B(){return <span></span>}';
+    const positions = createCodePositionMap(source);
+
+    expect(positions[source.indexOf('export')]).toBe(true);
+    expect(positions[source.lastIndexOf('export')]).toBe(true);
+  });
+
+  it('masks export-like text in comments, strings, and regular expressions', () => {
+    const source =
+      '// export const commentValue = 1\nconst text = "export const stringValue = 1"; const matcher = /export const regexValue/;';
+    const positions = createCodePositionMap(source);
+
+    expect(positions[source.indexOf('export')]).toBe(false);
+    expect(positions[source.indexOf('export', source.indexOf('"'))]).toBe(false);
+    expect(positions[source.lastIndexOf('export')]).toBe(false);
+  });
+
+  it('does not confuse a less-than comparison followed by a regex with JSX', () => {
+    const source = 'const matches = value < /export const phantom/; export const real = 1;';
+    const positions = createCodePositionMap(source);
+
+    expect(positions[source.indexOf('export')]).toBe(false);
+    expect(positions[source.lastIndexOf('export')]).toBe(true);
+  });
+});

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import * as path from 'node:path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { normalizePathForImport } from '../buildPaths';
 import {
   getInstalledPackageEntry,
@@ -365,6 +365,146 @@ describe('getSharedCacheKey', () => {
 
     expect(cache['default:react']).toBe(react);
     expect(cache.react).toBe(react);
+  });
+
+  it('treats reserved aliases as own properties without reading or mutating prototypes', () => {
+    const runtime = new Function(
+      `${sharedCacheHelperCode}
+      return { read: __mfReadSharedCache, write: __mfWriteSharedCache };`
+    )() as {
+      read: (
+        cache: Record<PropertyKey, unknown>,
+        descriptor: { canonical: string; aliases?: string[] }
+      ) => unknown;
+      write: (
+        cache: Record<PropertyKey, unknown>,
+        descriptor: { canonical: string; aliases?: string[] },
+        value: unknown
+      ) => unknown;
+    };
+    const cache: Record<PropertyKey, unknown> = {};
+    const originalPrototype = Object.getPrototypeOf(cache);
+
+    expect(
+      runtime.read(cache, {
+        canonical: 'default:constructor',
+        aliases: ['constructor'],
+      })
+    ).toBeUndefined();
+    expect(
+      runtime.read(cache, {
+        canonical: 'default:__proto__',
+        aliases: ['__proto__'],
+      })
+    ).toBeUndefined();
+
+    const constructorValue = { marker: 'constructor-share' };
+    runtime.write(
+      cache,
+      {
+        canonical: 'default:constructor',
+        aliases: ['constructor'],
+      },
+      constructorValue
+    );
+    expect(Object.prototype.hasOwnProperty.call(cache, 'constructor')).toBe(true);
+    expect(cache.constructor).toBe(constructorValue);
+    expect(Object.getPrototypeOf(cache)).toBe(originalPrototype);
+
+    const protoValue = { marker: 'proto-share' };
+    runtime.write(
+      cache,
+      {
+        canonical: 'default:__proto__',
+        aliases: ['__proto__'],
+      },
+      protoValue
+    );
+    expect(Object.prototype.hasOwnProperty.call(cache, '__proto__')).toBe(true);
+    expect(cache.__proto__).toBe(protoValue);
+    expect(Object.getPrototypeOf(cache)).toBe(originalPrototype);
+  });
+
+  it('synchronizes aliases and notifies canonical subscribers when cache values change', () => {
+    const runtime = new Function(
+      `${sharedCacheHelperCode}
+      return {
+        subscribe: __mfSubscribeSharedCache,
+        write: __mfWriteSharedCache
+      };`
+    )() as {
+      subscribe: (
+        cache: Record<PropertyKey, unknown>,
+        descriptor: { canonical: string; aliases?: string[] },
+        listener: (value: unknown) => void
+      ) => void;
+      write: (
+        cache: Record<PropertyKey, unknown>,
+        descriptor: { canonical: string; aliases?: string[] },
+        value: unknown
+      ) => unknown;
+    };
+    const localReact = { marker: 'local-react' };
+    const hostReact = { marker: 'host-react' };
+    const cache: Record<PropertyKey, unknown> = {
+      'default:react': localReact,
+      react: localReact,
+    };
+    const descriptor = {
+      canonical: 'default:react',
+      aliases: ['react'],
+    };
+    const listener = vi.fn();
+
+    runtime.subscribe(cache, descriptor, listener);
+    expect(runtime.write(cache, descriptor, hostReact)).toBe(hostReact);
+
+    expect(cache['default:react']).toBe(hostReact);
+    expect(cache.react).toBe(hostReact);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(hostReact);
+  });
+
+  it('sets, overwrites, and clears shared cache ownership', () => {
+    const runtime = new Function(
+      `${sharedCacheHelperCode}
+      return {
+        readOwner: __mfReadSharedCacheOwner,
+        write: __mfWriteSharedCache
+      };`
+    )() as {
+      readOwner: (
+        cache: Record<PropertyKey, unknown>,
+        descriptor: { canonical: string; aliases?: string[] }
+      ) => unknown;
+      write: (
+        cache: Record<PropertyKey, unknown>,
+        descriptor: { canonical: string; aliases?: string[] },
+        value: unknown,
+        owner?: string
+      ) => unknown;
+    };
+    const cache: Record<PropertyKey, unknown> = {};
+    const descriptor = {
+      canonical: 'default:react',
+      aliases: ['react'],
+    };
+    const provisionalReact = { marker: 'remote-react' };
+    const hostReact = { marker: 'host-react' };
+    const unownedReact = { marker: 'unowned-react' };
+
+    runtime.write(cache, descriptor, provisionalReact, 'remote');
+    expect(runtime.readOwner(cache, descriptor)).toBe('remote');
+
+    runtime.write(cache, descriptor, hostReact, 'host');
+    expect(runtime.readOwner(cache, descriptor)).toBe('host');
+    expect(cache['default:react']).toBe(hostReact);
+    expect(cache.react).toBe(hostReact);
+
+    runtime.write(cache, descriptor, unownedReact);
+    expect(runtime.readOwner(cache, descriptor)).toBeUndefined();
+    expect(cache['default:react']).toBe(unownedReact);
+    expect(cache.react).toBe(unownedReact);
   });
 
   it('keeps partial modules coverage-aware without poisoning the full-module cache', () => {

--- a/src/utils/codePositionMap.ts
+++ b/src/utils/codePositionMap.ts
@@ -1,0 +1,148 @@
+const REGEX_PREFIX_KEYWORDS = new Set([
+  'await',
+  'case',
+  'delete',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'throw',
+  'typeof',
+  'void',
+  'yield',
+]);
+
+function isJsxClosingTagSlash(code: string, slashIndex: number): boolean {
+  if (code[slashIndex - 1] !== '<') return false;
+
+  let cursor = slashIndex + 1;
+  while (/\s/.test(code[cursor] || '')) cursor++;
+  if (code[cursor] === '>') return true;
+
+  const tagStart = cursor;
+  while (/[-:.$_\u200C\u200D\p{ID_Continue}]/u.test(code[cursor] || '')) cursor++;
+  if (cursor === tagStart) return false;
+  while (/\s/.test(code[cursor] || '')) cursor++;
+
+  return code[cursor] === '>';
+}
+
+/** Mark comments, string/template literals, and regular expressions as non-code. */
+export function createCodePositionMap(code: string): boolean[] {
+  const positions = Array<boolean>(code.length).fill(true);
+  const mask = (start: number, end: number) => {
+    for (let index = start; index < end; index++) positions[index] = false;
+  };
+  let canStartRegex = true;
+
+  for (let index = 0; index < code.length; ) {
+    const char = code[index];
+    const next = code[index + 1];
+
+    if (/\s/.test(char)) {
+      index++;
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      const start = index;
+      index += 2;
+      while (index < code.length && code[index] !== '\n' && code[index] !== '\r') index++;
+      mask(start, index);
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      const start = index;
+      index += 2;
+      while (index < code.length && !(code[index] === '*' && code[index + 1] === '/')) index++;
+      index = Math.min(code.length, index + 2);
+      mask(start, index);
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      const start = index++;
+      while (index < code.length) {
+        if (code[index] === '\\') {
+          index += 2;
+          continue;
+        }
+        if (code[index] === quote) {
+          index++;
+          break;
+        }
+        index++;
+      }
+      mask(start, index);
+      canStartRegex = false;
+      continue;
+    }
+    const closesJsxTag = isJsxClosingTagSlash(code, index);
+    if (char === '/' && canStartRegex && !closesJsxTag) {
+      const start = index;
+      let cursor = index + 1;
+      let escaped = false;
+      let inCharacterClass = false;
+      let closed = false;
+      for (; cursor < code.length; cursor++) {
+        const regexChar = code[cursor];
+        if (regexChar === '\n' || regexChar === '\r') break;
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (regexChar === '\\') {
+          escaped = true;
+          continue;
+        }
+        if (regexChar === '[') {
+          inCharacterClass = true;
+          continue;
+        }
+        if (regexChar === ']' && inCharacterClass) {
+          inCharacterClass = false;
+          continue;
+        }
+        if (regexChar === '/' && !inCharacterClass) {
+          cursor++;
+          while (/[$_\p{ID_Continue}]/u.test(code[cursor] || '')) cursor++;
+          closed = true;
+          break;
+        }
+      }
+      if (closed) {
+        mask(start, cursor);
+        index = cursor;
+        canStartRegex = false;
+        continue;
+      }
+    }
+    if (/[$_\p{ID_Start}]/u.test(char)) {
+      const start = index++;
+      while (/[$_\u200C\u200D\p{ID_Continue}]/u.test(code[index] || '')) index++;
+      canStartRegex = REGEX_PREFIX_KEYWORDS.has(code.slice(start, index));
+      continue;
+    }
+    if (/\d/.test(char)) {
+      index++;
+      while (/[\w.]/.test(code[index] || '')) index++;
+      canStartRegex = false;
+      continue;
+    }
+    if ((char === '+' || char === '-') && next === char) {
+      index += 2;
+      continue;
+    }
+    if (char === '!' && next !== '=') {
+      index++;
+      continue;
+    }
+    if (char === ')' || char === ']' || char === '}') {
+      canStartRegex = false;
+    } else if (char !== '.') {
+      canStartRegex = true;
+    }
+    index++;
+  }
+
+  return positions;
+}

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -252,6 +252,7 @@ export const sharedCacheHelperCode = `const __mfGetSharedCacheDescriptor = (pkg,
             if (value !== undefined) return value;
             const aliases = descriptor.aliases || [];
             for (const alias of aliases) {
+              if (!Object.prototype.hasOwnProperty.call(cache, alias)) continue;
               const aliasValue = cache[alias];
               if (aliasValue !== undefined) {
                 cache[descriptor.canonical] = aliasValue;
@@ -260,11 +261,60 @@ export const sharedCacheHelperCode = `const __mfGetSharedCacheDescriptor = (pkg,
             }
             return undefined;
           };
-          const __mfWriteSharedCache = (cache, descriptor, value) => {
+          const __mfSharedCacheListenersKey = Symbol.for("module-federation.shared-cache-listeners");
+          const __mfGetSharedCacheListeners = (cache) => {
+            let listeners = cache[__mfSharedCacheListenersKey];
+            if (listeners === undefined) {
+              listeners = Object.create(null);
+              Object.defineProperty(cache, __mfSharedCacheListenersKey, {
+                value: listeners,
+                enumerable: false,
+                configurable: false,
+                writable: false
+              });
+            }
+            return listeners;
+          };
+          const __mfSubscribeSharedCache = (cache, descriptor, listener) => {
+            const listeners = __mfGetSharedCacheListeners(cache);
+            (listeners[descriptor.canonical] ||= new Set()).add(listener);
+          };
+          const __mfSharedCacheOwnersKey = Symbol.for("module-federation.shared-cache-owners");
+          const __mfGetSharedCacheOwners = (cache) => {
+            let owners = cache[__mfSharedCacheOwnersKey];
+            if (owners === undefined) {
+              owners = Object.create(null);
+              Object.defineProperty(cache, __mfSharedCacheOwnersKey, {
+                value: owners,
+                enumerable: false,
+                configurable: false,
+                writable: false
+              });
+            }
+            return owners;
+          };
+          const __mfReadSharedCacheOwner = (cache, descriptor) =>
+            cache[__mfSharedCacheOwnersKey]?.[descriptor.canonical];
+          const __mfWriteSharedCache = (cache, descriptor, value, owner) => {
             cache[descriptor.canonical] = value;
             const aliases = descriptor.aliases || [];
             for (const alias of aliases) {
-              if (cache[alias] === undefined) cache[alias] = value;
+              Object.defineProperty(cache, alias, {
+                value,
+                enumerable: true,
+                configurable: true,
+                writable: true
+              });
+            }
+            const owners = cache[__mfSharedCacheOwnersKey];
+            if (owner === undefined) {
+              if (owners) delete owners[descriptor.canonical];
+            } else {
+              __mfGetSharedCacheOwners(cache)[descriptor.canonical] = owner;
+            }
+            const listeners = cache[__mfSharedCacheListenersKey]?.[descriptor.canonical];
+            if (listeners) {
+              for (const listener of listeners) listener(value);
             }
             return value;
           };

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2725,7 +2725,7 @@ describe('virtualRemoteEntry', () => {
     ).toBeUndefined();
   });
 
-  it('exposes the pre-pin provider without changing the default runtime selection', async () => {
+  it('preserves the default provider through a passthrough resolveShare wrapper', async () => {
     const rootFactory = () => ({ marker: 'root-react' });
     const laterFactory = () => ({ marker: 'later-react' });
     const rootProvider: RuntimeBridgeProvider = {
@@ -2747,7 +2747,11 @@ describe('virtualRemoteEntry', () => {
     const inspectResolveShare = vi.fn((args: RuntimeResolveShareArgs) => {
       lifecycle.push('resolveShare');
       expect(args.shareScopeMap?.default.react['18.3.1']).toBe(laterProvider);
-      return args;
+      const defaultResolver = args.resolver;
+      return {
+        ...args,
+        resolver: (...resolverArgs: unknown[]) => defaultResolver(...resolverArgs),
+      };
     });
     let recordSelection!: (
       provider: RuntimeBridgeProvider,

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -53,6 +53,213 @@ async function getSharedProviderSelector() {
   )(runtimeShare) as SharedProviderSelector;
 }
 
+async function getSharedProviderEntryResolver() {
+  const mod = await import('../virtualRemoteEntry');
+
+  return new Function(
+    `${mod.sharedProviderSelectionHelperCode}; return __mfFindSharedProviderEntry;`
+  )() as (
+    versions: Record<string, unknown> | undefined,
+    provider: unknown
+  ) => { version: string; provider: unknown; registered: boolean } | undefined;
+}
+
+async function getExternalSharedProviderSelector() {
+  const [mod, { share: runtimeShare }] = await Promise.all([
+    import('../virtualRemoteEntry'),
+    import('@module-federation/runtime/helpers'),
+  ]);
+
+  return new Function(
+    'runtimeShare',
+    `${mod.sharedProviderSelectionHelperCode}\n${mod.externalSharedProviderSelectionHelperCode}; return __mfSelectExternalSharedProvider;`
+  )(runtimeShare) as (
+    versions: Record<string, unknown> | undefined,
+    pkg: string,
+    localShare: Parameters<SharedProviderSelector>[2] & {
+      version: string;
+      loaded?: boolean | number;
+      lib?: () => unknown;
+      loading?: Promise<unknown>;
+      get?: () => unknown;
+    },
+    strategy: 'version-first' | 'loaded-first',
+    resolveShareHook?: {
+      emit: (params: any) => any;
+    },
+    selectionState?: { resolveShareHookUsed?: boolean }
+  ) => unknown;
+}
+
+async function getScopeRootProviderResolver() {
+  const mod = await import('../virtualRemoteEntry');
+
+  return new Function(
+    `${mod.externalSharedProviderSelectionHelperCode}; return __mfGetScopeRootProvider;`
+  )() as (
+    instances: unknown[],
+    scopeRoot: unknown,
+    shared: unknown,
+    scopeName: string,
+    pkg: string,
+    version: string,
+    provider: unknown,
+    passedProvider: unknown,
+    strategy: 'version-first' | 'loaded-first',
+    resolveShareHookUsed?: boolean
+  ) => unknown;
+}
+
+async function getExternalSharedProviderResolver() {
+  const mod = await import('../virtualRemoteEntry');
+
+  return new Function(
+    `${mod.externalSharedProviderSelectionHelperCode}; return __mfResolveExternalSharedProvider;`
+  )() as (
+    instances: unknown[],
+    scopeRoot: unknown,
+    shared: unknown,
+    scopeName: string,
+    pkg: string,
+    providerEntry: { version: string; provider: unknown; registered: boolean },
+    selectedExternalProvider: unknown,
+    passedProvider: unknown,
+    strategy: 'version-first' | 'loaded-first',
+    resolveShareHookUsed?: boolean
+  ) => { provider: unknown; scopeRootProvider: unknown } | undefined;
+}
+
+type RuntimeBridgeProvider = {
+  from: string;
+  version?: string;
+  scope?: string | string[];
+  get?: () => Promise<() => unknown> | (() => unknown);
+  lib?: () => unknown;
+  loaded?: boolean;
+  loading?: Promise<() => unknown>;
+  strategy?: string;
+};
+
+async function getRuntimeBridgeLoader(initRes: {
+  loadShare: (pkg: string, options: unknown) => Promise<unknown>;
+}) {
+  const mod = await import('../virtualRemoteEntry');
+  const code = mod.generateRemoteEntry(
+    {
+      internalName: '__mfe_internal__remote',
+      name: 'remote',
+      filename: 'remoteEntry.js',
+      exposes: {},
+      remotes: {},
+      shared: {},
+      runtimePlugins: [],
+      shareScope: 'default',
+      shareStrategy: 'version-first',
+    } as any,
+    'virtual:exposes',
+    'serve'
+  );
+  const helperCode = code.slice(
+    code.indexOf('const __mfRuntimeProviderOrigins ='),
+    code.indexOf('const bridgedProviders =')
+  );
+
+  let recordSelection = (
+    _provider: RuntimeBridgeProvider,
+    _shareInfo?: Record<string, unknown>
+  ) => {};
+  const runtimeResolveShareHook = {
+    on(
+      listener: (args: {
+        shareInfo?: Record<string, unknown>;
+        resolver: () => { shared: RuntimeBridgeProvider };
+      }) => {
+        resolver: () => { shared: RuntimeBridgeProvider };
+      }
+    ) {
+      recordSelection = (provider, shareInfo) => {
+        const args = { shareInfo, resolver: () => ({ shared: provider }) };
+        (listener(args) || args).resolver();
+      };
+    },
+  };
+  const loadPinnedShare = new Function(
+    'initRes',
+    'runtimeResolveShareHook',
+    '__mfTransparentResolverKey',
+    `${helperCode}; return __mfLoadPinnedRuntimeShare;`
+  )(
+    initRes,
+    runtimeResolveShareHook,
+    Symbol.for('module-federation.vite.transparent-resolver')
+  ) as ((
+    pkg: string,
+    shareConfig: Record<string, unknown>,
+    versionMap: Record<string, RuntimeBridgeProvider>,
+    version: string,
+    currentProvider: RuntimeBridgeProvider | undefined,
+    provider: RuntimeBridgeProvider,
+    providerRegistered?: boolean
+  ) => Promise<
+    | {
+        provider: RuntimeBridgeProvider;
+        selection: {
+          provider: RuntimeBridgeProvider;
+          version: string;
+          from: string;
+          registered: boolean;
+        };
+        resolved: unknown;
+      }
+    | undefined
+  >) & {
+    recordSelection(provider: RuntimeBridgeProvider, shareInfo?: Record<string, unknown>): void;
+  };
+  loadPinnedShare.recordSelection = (provider, shareInfo) => recordSelection(provider, shareInfo);
+  return loadPinnedShare;
+}
+
+function createRuntimeShareLoader(versionMap: Record<string, RuntimeBridgeProvider>) {
+  return async (
+    _pkg: string,
+    options: { customShareInfo?: { shareConfig?: { requiredVersion?: string } } }
+  ) => {
+    const version = options.customShareInfo?.shareConfig?.requiredVersion;
+    if (!version) return false;
+    const provider = versionMap[version];
+    if (provider.lib) return provider.lib;
+    if (provider.loading && !provider.loaded) {
+      const factory = await provider.loading;
+      provider.lib ??= factory;
+      provider.loaded = true;
+      return factory;
+    }
+    if (!provider.get) return false;
+    const loading = Promise.resolve(provider.get());
+    provider.loading = loading;
+    const factory = await loading;
+    provider.lib = factory;
+    provider.loaded = true;
+    return factory;
+  };
+}
+
+function getRuntimeSeedCode(code: string) {
+  const start = code.indexOf('const __mfSeedOrder =');
+  const endMarker = 'await __mfSeedLocalShared(__mfImmediateSeedKeys);';
+  const end = code.indexOf(endMarker, start);
+  if (start === -1 || end === -1) throw new Error('runtime seed code not found');
+  return code.slice(start, end + endMarker.length);
+}
+
+function getRuntimeDeferredResolutionCode(code: string) {
+  const start = code.indexOf('for (const pkg of __mfDeferredSeedKeys) {');
+  const endMarker = 'await __mfSeedLocalShared([pkg]);\n    }';
+  const end = code.indexOf(endMarker, start);
+  if (start === -1 || end === -1) throw new Error('runtime deferred resolution code not found');
+  return code.slice(start, end + endMarker.length);
+}
+
 vi.mock('../../utils/VirtualModule', () => {
   return {
     default: class MockVirtualModule {
@@ -112,6 +319,7 @@ vi.mock('../../utils/packageUtils', () => {
             if (value !== undefined) return value;
             const aliases = descriptor.aliases || [];
             for (const alias of aliases) {
+              if (!Object.prototype.hasOwnProperty.call(cache, alias)) continue;
               const aliasValue = cache[alias];
               if (aliasValue !== undefined) {
                 cache[descriptor.canonical] = aliasValue;
@@ -120,11 +328,60 @@ vi.mock('../../utils/packageUtils', () => {
             }
             return undefined;
           };
-          const __mfWriteSharedCache = (cache, descriptor, value) => {
+          const __mfSharedCacheListenersKey = Symbol.for("module-federation.shared-cache-listeners");
+          const __mfGetSharedCacheListeners = (cache) => {
+            let listeners = cache[__mfSharedCacheListenersKey];
+            if (listeners === undefined) {
+              listeners = Object.create(null);
+              Object.defineProperty(cache, __mfSharedCacheListenersKey, {
+                value: listeners,
+                enumerable: false,
+                configurable: false,
+                writable: false
+              });
+            }
+            return listeners;
+          };
+          const __mfSubscribeSharedCache = (cache, descriptor, listener) => {
+            const listeners = __mfGetSharedCacheListeners(cache);
+            (listeners[descriptor.canonical] ||= new Set()).add(listener);
+          };
+          const __mfSharedCacheOwnersKey = Symbol.for("module-federation.shared-cache-owners");
+          const __mfGetSharedCacheOwners = (cache) => {
+            let owners = cache[__mfSharedCacheOwnersKey];
+            if (owners === undefined) {
+              owners = Object.create(null);
+              Object.defineProperty(cache, __mfSharedCacheOwnersKey, {
+                value: owners,
+                enumerable: false,
+                configurable: false,
+                writable: false
+              });
+            }
+            return owners;
+          };
+          const __mfReadSharedCacheOwner = (cache, descriptor) =>
+            cache[__mfSharedCacheOwnersKey]?.[descriptor.canonical];
+          const __mfWriteSharedCache = (cache, descriptor, value, owner) => {
             cache[descriptor.canonical] = value;
             const aliases = descriptor.aliases || [];
             for (const alias of aliases) {
-              if (cache[alias] === undefined) cache[alias] = value;
+              Object.defineProperty(cache, alias, {
+                value,
+                enumerable: true,
+                configurable: true,
+                writable: true
+              });
+            }
+            const owners = cache[__mfSharedCacheOwnersKey];
+            if (owner === undefined) {
+              if (owners) delete owners[descriptor.canonical];
+            } else {
+              __mfGetSharedCacheOwners(cache)[descriptor.canonical] = owner;
+            }
+            const listeners = cache[__mfSharedCacheListenersKey]?.[descriptor.canonical];
+            if (listeners) {
+              for (const listener of listeners) listener(value);
             }
             return value;
           };`,
@@ -193,16 +450,18 @@ vi.mock('../../utils/normalizeModuleFederationOptions', () => {
       scope: 'default',
       shareConfig: {
         import:
-          pkg === 'custom-import'
-            ? '/abs/custom-import.js'
-            : pkg === 'tree-shared' && optionsMock.treeSharedImportFalse
-              ? false
-              : undefined,
-        singleton: true,
+          pkg === 'host-only'
+            ? false
+            : pkg === 'custom-import'
+              ? '/abs/custom-import.js'
+              : pkg === 'tree-shared' && optionsMock.treeSharedImportFalse
+                ? false
+                : undefined,
+        singleton: pkg !== 'non-singleton',
         requiredVersion: pkg === 'unconstrained' ? false : '^19.2.4',
         strictVersion: false,
         eager: pkg === 'eager-shared',
-        ...(pkg === 'tree-shared'
+        ...(pkg === 'tree-shared' || pkg === 'unknown-tree-shared'
           ? { treeShaking: { mode: 'runtime-infer', usedExports: ['Button'] } }
           : {}),
       },
@@ -220,6 +479,12 @@ vi.mock('../virtualShared_preBuild', () => {
   return {
     getPreBuildLibImportId: (pkg: string) => `virtual:prebuild:${pkg}`,
     getTreeShakingSharedProviderImportId: (pkg: string) => `virtual:tree-provider:${pkg}`,
+    getSharedNamedExports: (pkg: string) =>
+      pkg === 'named-singleton'
+        ? ['namedExport']
+        : pkg === 'unknown-exports-singleton' || pkg === 'unknown-tree-shared'
+          ? undefined
+          : [],
     hasTreeShakingSharedProvider: (pkg: string) =>
       pkg === 'tree-shared' && optionsMock.treeSharedProvider,
     getConcreteSharedImportSource: (
@@ -334,6 +599,47 @@ describe('virtualRemoteEntry', () => {
 
     expect(code).toContain('let pkg = await import("/abs/custom-import.js");');
     expect(code).not.toContain('virtual:prebuild:custom-import');
+  });
+
+  it('marks only export-complete shared proxies as rebindable', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    for (const pkg of [
+      'host-only',
+      'non-singleton',
+      'named-singleton',
+      'default-only-singleton',
+      'unknown-exports-singleton',
+    ]) {
+      mod.addUsedShares(pkg);
+    }
+
+    const code = mod.generateLocalSharedImportMap();
+    const canLiveRebind = (pkg: string) =>
+      code.match(
+        new RegExp(`${JSON.stringify(pkg)}: \\{[\\s\\S]*?canLiveRebind: (true|false),`)
+      )?.[1];
+
+    expect(canLiveRebind('host-only')).toBe('true');
+    expect(canLiveRebind('non-singleton')).toBe('true');
+    expect(canLiveRebind('named-singleton')).toBe('true');
+    expect(canLiveRebind('default-only-singleton')).toBe('true');
+    expect(canLiveRebind('unknown-exports-singleton')).toBe('false');
+  });
+
+  it('disables runtime tree selection when export coverage is unknown', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('unknown-tree-shared');
+
+    const code = mod.generateLocalSharedImportMap();
+
+    expect(code).toContain('"unknown-tree-shared": {');
+    expect(code).toContain('canLiveRebind: false');
+    expect(code).not.toContain('treeShaking: {');
+    expect(code).not.toContain('virtual:tree-provider:unknown-tree-shared');
   });
 
   it('statically imports eager shared providers and emits eager runtime metadata', async () => {
@@ -462,6 +768,18 @@ describe('virtualRemoteEntry', () => {
     });
 
     expect(args.resolver()).toBe(originalResult);
+  });
+
+  it('does not wrap the resolver for a non-tree-shaking consumer', async () => {
+    const { treeShakingResolveShareBodyCode } = await import('../virtualRemoteEntry');
+    const applyResolveShare = new Function('args', treeShakingResolveShareBodyCode) as (
+      args: any
+    ) => any;
+    const resolver = vi.fn(() => ({ shared: {}, useTreesShaking: false }));
+
+    const args = applyResolveShare({ shareInfo: {}, resolver });
+
+    expect(args.resolver).toBe(resolver);
   });
 
   it('orders React before shared packages that evaluate React APIs', async () => {
@@ -690,11 +1008,11 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('const mfName = "host"');
     expect(code).toContain('await Promise.all(__mfModuleCache.pendingShareLoads)');
     expect(code).toContain('share.shareConfig?.import !== false');
-    expect(code).toContain('const versions = shared?.[pkg]');
+    expect(code).toContain('const versionMap = shared?.[pkg]');
     expect(code.indexOf('share.shareConfig?.import !== false')).toBeLessThan(
       code.indexOf('initResolve(initRes)')
     );
-    expect(code).not.toContain('initRes.loadShare(pkg');
+    expect(code).toContain('const factory = await initRes.loadShare(pkg');
     expect(code).not.toContain('import exposesMap from');
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
   });
@@ -774,11 +1092,129 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('if (typeof fullFallbackGet === "function") return fullFallbackGet();');
     expect(code).toContain('__mfWriteTreeShakingSharedCache(');
     expect(code).toContain('treeShaking.providedExports');
-    expect(code).toContain('if (!treeShaking) continue;');
+    expect(code).toContain('if (!treeShaking) return;');
     expect(code).not.toContain('treeShaking.providedExports.length === 0) continue;');
     expect(code).toContain('const hasPartialProvider =');
-    expect(code).toContain('Boolean(share.treeShaking)');
+    expect(code).toContain(
+      'const providedExports = treeShaking.providedExports ?? treeShaking.usedExports ?? [];'
+    );
+    expect(code).not.toContain('treeShaking.providedExports.length > 0');
+    expect(code).toContain('if (share.treeShaking || share.shareConfig?.import === false)');
+    const materializedBridgeCall = code.indexOf(
+      'await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);'
+    );
+    const materializedPreSeedLoop = code.lastIndexOf(
+      'for (const [pkg, usedShare] of Object.entries(usedShared))',
+      materializedBridgeCall
+    );
+    expect(code.slice(materializedPreSeedLoop, materializedBridgeCall)).toContain(
+      'if (usedShare.treeShaking) continue;'
+    );
+    const aliasCacheLoop = code.indexOf(
+      'for (const [pkg, share] of Object.entries(usedShared))',
+      materializedBridgeCall
+    );
+    expect(code.slice(aliasCacheLoop, code.indexOf('const __mfSeedOrder ='))).toContain(
+      'if (share.treeShaking) continue;'
+    );
     expect(code).toContain('plugins: [__mfTreeShakingSnapshotPlugin(),');
+  });
+
+  it('coverage-caches runtime-infer partials even when provider coverage is empty', async () => {
+    const treeShare = {
+      name: 'tree-shared',
+      from: '',
+      version: '19.2.4',
+      scope: 'default',
+      shareConfig: {
+        singleton: false,
+        import: false,
+        requiredVersion: '^19.2.4',
+        strictVersion: false,
+        treeShaking: { mode: 'runtime-infer', usedExports: [] },
+      },
+    };
+    normalizedSharedMock.mockReturnValue({ 'tree-shared': treeShare });
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+    const treeResolutionStart = code.indexOf('// Resolve tree-enabled shares through the Runtime');
+    const treeResolutionEnd = code.indexOf(
+      'const __mfResolveImportFalseShared =',
+      treeResolutionStart
+    );
+    const treeResolutionCode = code.slice(treeResolutionStart, treeResolutionEnd);
+    const genericWrite = vi.fn();
+    const treeWrite = vi.fn();
+    const selectionWrite = vi.fn();
+    const partial = { Button: 'partial' };
+
+    await new Function(
+      'initRes',
+      'usedShared',
+      '__mfModuleCache',
+      '__mfGetSharedCacheDescriptor',
+      '__mfWriteSharedCache',
+      '__mfWriteTreeShakingSharedCache',
+      '__mfWriteTreeShakingSharedSelection',
+      'mfName',
+      `return (async () => {
+        ${treeResolutionCode}
+        await __mfResolveTreeShakingShared('tree-shared', usedShared['tree-shared']);
+      })();`
+    )(
+      { loadShare: async () => () => partial },
+      {
+        'tree-shared': {
+          ...treeShare,
+          scope: ['default'],
+          treeShaking: {
+            mode: 'runtime-infer',
+            status: 1,
+            usedExports: [],
+            providedExports: [],
+          },
+        },
+      },
+      { share: {} },
+      () => ({ canonical: 'default:tree-shared@19.2.4' }),
+      genericWrite,
+      treeWrite,
+      selectionWrite,
+      'remote'
+    );
+
+    expect(genericWrite).not.toHaveBeenCalled();
+    expect(treeWrite).toHaveBeenCalledWith(
+      {},
+      { canonical: 'default:tree-shared@19.2.4' },
+      [],
+      partial
+    );
+    expect(selectionWrite).toHaveBeenCalledWith(
+      {},
+      { canonical: 'default:tree-shared@19.2.4' },
+      'remote',
+      partial
+    );
+    const importFalseFallback = code.slice(treeResolutionEnd, code.indexOf('initResolve(initRes)'));
+    expect(importFalseFallback).toContain('if (share.treeShaking) {');
+    expect(importFalseFallback).toContain('__mfWriteTreeShakingSharedCache(');
+    expect(importFalseFallback).toContain('__mfWriteTreeShakingSharedSelection(');
   });
 
   it('includes remote aliases in version-first remoteEntry initialization', async () => {
@@ -931,6 +1367,491 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('for (const pkg of Object.keys(usedShared))');
   });
 
+  it('defers consumers of tree-enabled shares until the tree selection is cached', async () => {
+    const shareItem = (name: string, treeShaking = false) => ({
+      name,
+      from: '',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^1.0.0',
+        strictVersion: false,
+        ...(treeShaking
+          ? { treeShaking: { mode: 'runtime-infer' as const, usedExports: ['value'] } }
+          : {}),
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      '@repro/core': shareItem('@repro/core'),
+      '@repro/shared-lib': shareItem('@repro/shared-lib', true),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/core');
+    mod.addUsedShares('@repro/shared-lib');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const seedCode = getRuntimeSeedCode(code);
+    const deferredResolutionCode = getRuntimeDeferredResolutionCode(code);
+    const calls: string[] = [];
+    const state = { treeReady: false };
+    const usedShared = {
+      '@repro/shared-lib': {
+        name: '@repro/shared-lib',
+        version: '1.0.0',
+        scope: ['default'],
+        shareConfig: { singleton: true },
+        treeShaking: { mode: 'runtime-infer', status: 1, usedExports: ['value'] },
+        get: async () => {
+          throw new Error('tree share must be resolved by the Runtime');
+        },
+      },
+      '@repro/core': {
+        name: '@repro/core',
+        version: '1.0.0',
+        scope: ['default'],
+        shareConfig: { singleton: true },
+        get: async () => {
+          if (!state.treeReady) throw new Error('tree dependency was not ready');
+          calls.push('@repro/core');
+          return () => ({ value: 'core' });
+        },
+      },
+    };
+
+    await new Function(
+      'usedShared',
+      'state',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        const mfName = 'host';
+        const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
+          const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
+          const id = singleton || !version ? pkg : pkg + '@' + version;
+          return { canonical: scopeName + ':' + id };
+        };
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const treeSelections = Object.create(null);
+        const __mfReadTreeShakingSharedSelection = (_cache, descriptor, consumer) =>
+          treeSelections[descriptor.canonical + ':' + consumer];
+        const __mfResolveTreeShakingShared = async () => {
+          throw new Error('ready tree share should not resolve again');
+        };
+        const __mfResolveImportFalseShared = async () => {};
+        ${seedCode}
+        state.treeReady = true;
+        treeSelections['default:@repro/shared-lib:host'] = { value: 'tree' };
+        ${deferredResolutionCode}
+      })();`
+    )(usedShared, state);
+
+    expect(calls).toEqual(['@repro/core']);
+  });
+
+  it('seeds tree dependents when a complete provider is in the generic cache', async () => {
+    const shareItem = (name: string, treeShaking = false) => ({
+      name,
+      from: 'remote',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^1.0.0',
+        strictVersion: false,
+        ...(treeShaking
+          ? { treeShaking: { mode: 'runtime-infer' as const, usedExports: ['value'] } }
+          : {}),
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      '@repro/core': shareItem('@repro/core'),
+      '@repro/shared-lib': shareItem('@repro/shared-lib', true),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/core');
+    mod.addUsedShares('@repro/shared-lib');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const seedCode = getRuntimeSeedCode(code);
+    const deferredResolutionCode = getRuntimeDeferredResolutionCode(code);
+    const state = { consumerLoads: 0, treeResolutions: 0 };
+    const usedShared = {
+      '@repro/shared-lib': {
+        ...shareItem('@repro/shared-lib', true),
+        scope: ['default'],
+        treeShaking: { mode: 'runtime-infer', status: 0, usedExports: ['value'] },
+        get: async () => {
+          throw new Error('complete tree provider should already be cached');
+        },
+      },
+      '@repro/core': {
+        ...shareItem('@repro/core'),
+        scope: ['default'],
+        get: async () => {
+          state.consumerLoads++;
+          return () => ({ value: 'core' });
+        },
+      },
+    };
+
+    await new Function(
+      'usedShared',
+      'state',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        const mfName = 'remote';
+        const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
+          const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
+          const id = singleton || !version ? pkg : pkg + '@' + version;
+          return { canonical: scopeName + ':' + id };
+        };
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const __mfReadTreeShakingSharedSelection = () => undefined;
+        const __mfResolveTreeShakingShared = async () => {
+          state.treeResolutions++;
+        };
+        const __mfResolveImportFalseShared = async () => {};
+        ${seedCode}
+        __mfModuleCache.share['default:@repro/shared-lib'] = { value: 'complete-tree' };
+        ${deferredResolutionCode}
+      })();`
+    )(usedShared, state);
+
+    expect(state.treeResolutions).toBe(0);
+    expect(state.consumerLoads).toBe(1);
+  });
+
+  it('resolves import:false dependencies before tree providers that consume them', async () => {
+    const shareItem = (name: string, options: { importFalse?: boolean; tree?: boolean } = {}) => ({
+      name,
+      from: 'remote',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^1.0.0',
+        strictVersion: false,
+        ...(options.importFalse ? { import: false } : {}),
+        ...(options.tree
+          ? { treeShaking: { mode: 'runtime-infer' as const, usedExports: ['value'] } }
+          : {}),
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      '@repro/core': shareItem('@repro/core', { tree: true }),
+      '@repro/shared-lib': shareItem('@repro/shared-lib', { importFalse: true }),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/core');
+    mod.addUsedShares('@repro/shared-lib');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const seedCode = getRuntimeSeedCode(code);
+    const deferredResolutionCode = getRuntimeDeferredResolutionCode(code);
+    const order: string[] = [];
+    const usedShared = {
+      '@repro/shared-lib': {
+        ...shareItem('@repro/shared-lib', { importFalse: true }),
+        scope: ['default'],
+      },
+      '@repro/core': {
+        ...shareItem('@repro/core', { tree: true }),
+        scope: ['default'],
+        treeShaking: { mode: 'runtime-infer', status: 1, usedExports: ['value'] },
+      },
+    };
+
+    await new Function(
+      'usedShared',
+      'order',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        const treeSelections = Object.create(null);
+        const mfName = 'remote';
+        const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
+          const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
+          const id = singleton || !version ? pkg : pkg + '@' + version;
+          return { canonical: scopeName + ':' + id };
+        };
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const __mfReadTreeShakingSharedSelection = (_cache, descriptor, consumer) =>
+          treeSelections[descriptor.canonical + ':' + consumer];
+        const __mfResolveImportFalseShared = async (pkg) => {
+          order.push(pkg);
+          __mfModuleCache.share['default:' + pkg] = { value: 'host-only' };
+        };
+        const __mfResolveTreeShakingShared = async (pkg) => {
+          if (!__mfModuleCache.share['default:@repro/shared-lib']) {
+            throw new Error('tree provider evaluated before its import:false dependency');
+          }
+          order.push(pkg);
+          treeSelections['default:' + pkg + ':remote'] = { value: 'partial-tree' };
+        };
+        ${seedCode}
+        ${deferredResolutionCode}
+      })();`
+    )(usedShared, order);
+
+    expect(order).toEqual(['@repro/shared-lib', '@repro/core']);
+  });
+
+  it('bridges a lazy singleton before evaluating shared modules that capture it', async () => {
+    const shareItem = (name: string) => ({
+      name,
+      from: 'remote',
+      version: '18.3.1',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        strictVersion: false,
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      react: shareItem('react'),
+      'react-dom': shareItem('react-dom'),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+    mod.addUsedShares('react-dom');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const seedCode = getRuntimeSeedCode(code);
+    const deferredResolutionCode = getRuntimeDeferredResolutionCode(code);
+    const state: {
+      cache?: Record<string, unknown>;
+      capturedReact?: unknown;
+      localReactLoads: number;
+    } = {
+      localReactLoads: 0,
+    };
+    const hostReact = { marker: 'host-react' };
+    const usedShared = {
+      react: {
+        ...shareItem('react'),
+        scope: ['default'],
+        get: async () => {
+          state.localReactLoads++;
+          return () => ({ marker: 'local-react' });
+        },
+      },
+      'react-dom': {
+        ...shareItem('react-dom'),
+        scope: ['default'],
+        get: async () => {
+          state.capturedReact = state.cache?.['default:react'];
+          return () => ({ marker: 'react-dom' });
+        },
+      },
+    };
+
+    await new Function(
+      'usedShared',
+      'state',
+      'hostReact',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        state.cache = __mfModuleCache.share;
+        const mfName = 'remote';
+        const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
+          const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
+          const id = singleton || !version ? pkg : pkg + '@' + version;
+          return { canonical: scopeName + ':' + id };
+        };
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const __mfReadTreeShakingSharedSelection = () => undefined;
+        const __mfResolveTreeShakingShared = async () => {};
+        const __mfResolveImportFalseShared = async () => {};
+        const initialShared = {
+          react: { '18.3.1': { from: 'host' } },
+          'react-dom': { '18.3.1': { from: 'host' } },
+        };
+        const runtimeResolveShareHook = {};
+        const __mfSelectExternalSharedProvider = (versions) =>
+          versions && Object.values(versions)[0];
+        ${seedCode}
+        if (state.localReactLoads !== 0 || state.capturedReact !== undefined) {
+          throw new Error('shared modules evaluated before Runtime selection');
+        }
+        __mfModuleCache.share['default:react'] = hostReact;
+        ${deferredResolutionCode}
+      })();`
+    )(usedShared, state, hostReact);
+
+    expect(state.localReactLoads).toBe(0);
+    expect(state.capturedReact).toBe(hostReact);
+    const globalBridgeEnd = code.indexOf(
+      "console.error('[Module Federation] Failed to bridge external shared modules'"
+    );
+    const orderedRuntimeSeed = code.indexOf(
+      'for (const pkg of __mfDeferredSeedKeys)',
+      globalBridgeEnd
+    );
+    expect(orderedRuntimeSeed).toBeGreaterThan(globalBridgeEnd);
+  });
+
+  it('seeds a root host singleton before version-first remote initialization', async () => {
+    const hostReactShare = {
+      name: 'react',
+      from: 'host',
+      version: '18.3.1',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        strictVersion: false,
+      },
+    };
+    normalizedSharedMock.mockReturnValue({ react: hostReactShare });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {
+          remote: {
+            entryGlobalName: 'remote',
+            name: 'remote',
+            type: 'module',
+            entry: 'http://localhost:4174/remoteEntry.js',
+          },
+        },
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const seedCode = getRuntimeSeedCode(code);
+    const state = { localReactLoads: 0, cachedReact: undefined as unknown };
+    const usedShared = {
+      react: {
+        ...hostReactShare,
+        scope: ['default'],
+        get: async () => {
+          state.localReactLoads++;
+          return () => ({ marker: 'host-react' });
+        },
+      },
+    };
+
+    await new Function(
+      'usedShared',
+      'state',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        const mfName = 'host';
+        const initialShared = {};
+        const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
+          const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
+          const id = singleton || !version ? pkg : pkg + '@' + version;
+          return { canonical: scopeName + ':' + id };
+        };
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const __mfReadTreeShakingSharedSelection = () => undefined;
+        const runtimeResolveShareHook = {};
+        const __mfSelectExternalSharedProvider = () => undefined;
+        ${seedCode}
+        state.cachedReact = __mfModuleCache.share['default:react'];
+      })();`
+    )(usedShared, state);
+
+    expect(state.localReactLoads).toBe(1);
+    expect(state.cachedReact).toMatchObject({ marker: 'host-react' });
+  });
+
   it('orders package subpath shares discovered after remoteEntry codegen before their package root', async () => {
     const shareItem = (name: string) => ({
       name,
@@ -971,9 +1892,7 @@ describe('virtualRemoteEntry', () => {
     expect(seedOrderMatch).not.toBeNull();
     expect(JSON.parse(seedOrderMatch![1]) as string[]).toEqual(['@repro/shared-lib']);
 
-    const seedCodeMatch = code.match(/const __mfSeedOrder = [\s\S]*?\n\s+const __browserPlugins =/);
-    expect(seedCodeMatch).not.toBeNull();
-    const seedCode = seedCodeMatch![0].replace(/\n\s+const __browserPlugins =$/, '');
+    const seedCode = getRuntimeSeedCode(code);
     const calls: string[] = [];
     const usedShared = {
       '@repro/shared-lib': {
@@ -1003,16 +1922,19 @@ describe('virtualRemoteEntry', () => {
       `
         return (async () => {
           const __mfModuleCache = { share: {} };
+          const mfName = 'host';
           const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => {
             const scopeName = Array.isArray(scope) ? scope[0] : scope || 'default';
             const id = singleton || !version ? pkg : pkg + '@' + version;
             return { canonical: scopeName + ':' + id };
           };
           const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
-          const __mfWriteSharedCache = (cache, descriptor, value) => {
+          const __mfReadSharedCacheOwner = () => undefined;
+          const __mfWriteSharedCache = (cache, descriptor, value, owner) => {
             cache[descriptor.canonical] = value;
           };
           ${seedCode}
+          await __mfSeedLocalShared(__mfDeferredSeedKeys);
         })();
       `
     )(usedShared);
@@ -1121,6 +2043,138 @@ describe('virtualRemoteEntry', () => {
 
     expect(code).toContain('remotes: []');
     expect(code).not.toContain('remotes: usedRemotes');
+    expect(code).not.toContain('const deferredRemotes =');
+    expect(code).not.toContain('initRes.options.remotes.push(...deferredRemotes);');
+    const materializedBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeMaterializedProvider ='),
+      code.indexOf('const __mfBridgeExternalSharedProvider =')
+    );
+    expect(materializedBridgeCode).toContain(
+      "if (singleton && 'loaded-first' !== 'loaded-first') return;"
+    );
+    expect(materializedBridgeCode).toContain('if (usedShare.canLiveRebind === false) return;');
+  });
+
+  it('keeps the remote registry intact while pre-seeding version-first shares', async () => {
+    optionsMock.shareStrategy = 'version-first';
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {
+          remote: {
+            entryGlobalName: 'remote',
+            name: 'remote',
+            type: 'module',
+            entry: 'http://localhost:4174/remoteEntry.js',
+          },
+        },
+        shared: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    const runtimeInitCall = code.indexOf('const initRes = runtimeInit({');
+    const initShareScopeMapCall = code.indexOf("initRes.initShareScopeMap('default', shared);");
+    const materializedBridgeCall = code.indexOf(
+      'await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);'
+    );
+    const initializeSharingCall = code.indexOf(
+      `await Promise.all(await initRes.initializeSharing('default'`
+    );
+
+    expect(code).toContain('remotes: usedRemotes');
+    expect(runtimeInitCall).toBeGreaterThan(-1);
+    expect(initShareScopeMapCall).toBeGreaterThan(runtimeInitCall);
+    expect(materializedBridgeCall).toBeGreaterThan(initShareScopeMapCall);
+    expect(initializeSharingCall).toBeGreaterThan(materializedBridgeCall);
+    expect(code).not.toContain('initRes.options.remotes.splice(0)');
+    expect(code).not.toContain('initRes.options.remotes.push(...deferredRemotes)');
+  });
+
+  it('pre-seeds a loaded-first default-only singleton before local proxy evaluation', async () => {
+    optionsMock.shareStrategy = 'loaded-first';
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('default-only-singleton');
+
+    const localSharedCode = mod.generateLocalSharedImportMap();
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'loaded-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const materializedBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeMaterializedProvider ='),
+      code.indexOf('const __mfBridgeExternalSharedProvider =')
+    );
+    const lateBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeExternalSharedProvider ='),
+      code.indexOf('for (const [pkg, usedShare] of Object.entries(usedShared))')
+    );
+
+    expect(localSharedCode).toContain('canLiveRebind: true');
+    expect(materializedBridgeCode).toContain('if (usedShare.canLiveRebind === false) return;');
+    expect(lateBridgeCode).toContain('if (usedShare.canLiveRebind === false) return;');
+  });
+
+  it('late-bridges a version-first default-only singleton after runtime selection', async () => {
+    optionsMock.shareStrategy = 'version-first';
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('default-only-singleton');
+
+    const localSharedCode = mod.generateLocalSharedImportMap();
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const materializedBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeMaterializedProvider ='),
+      code.indexOf('const __mfBridgeExternalSharedProvider =')
+    );
+    const initializeSharingCall = code.indexOf(
+      `await Promise.all(await initRes.initializeSharing('default'`
+    );
+    const lateBridgeCall = code.indexOf('await __mfBridgeExternalSharedProvider(\n        pkg');
+
+    expect(localSharedCode).toContain('canLiveRebind: true');
+    expect(materializedBridgeCode).toContain(
+      "if (singleton && 'version-first' !== 'loaded-first') return;"
+    );
+    expect(initializeSharingCall).toBeGreaterThan(-1);
+    expect(lateBridgeCall).toBeGreaterThan(initializeSharingCall);
   });
 
   it('seeds import:false shared modules in hostAutoInit during serve', async () => {
@@ -1175,11 +2229,13 @@ describe('virtualRemoteEntry', () => {
 
     expect(code).toContain('const __mfGetSharedCacheDescriptor =');
     expect(code).toContain('__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor)');
-    expect(code).toContain('__mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor');
+    expect(code).toMatch(
+      /__mfWriteSharedCache\(\s*__mfModuleCache\.share,\s*cacheDescriptor,\s*__mfNormalizeRuntimeShare\(resolved\),\s*"host"\s*\)/
+    );
     expect(code).not.toContain('__mfModuleCache.share[cacheKey]');
   });
 
-  it('aliases external singleton providers to the remote share cache key', async () => {
+  it('bridges materialized shares without losing singleton cache semantics', async () => {
     normalizedSharedMock.mockReturnValue({
       react: {
         name: 'react',
@@ -1187,7 +2243,7 @@ describe('virtualRemoteEntry', () => {
         version: '18.3.1',
         scope: 'default',
         shareConfig: {
-          singleton: false,
+          singleton: true,
           requiredVersion: '^18.3.1',
           strictVersion: false,
         },
@@ -1215,11 +2271,743 @@ describe('virtualRemoteEntry', () => {
     );
 
     expect(code).toContain('const usedShare = usedShared?.[pkg];');
-    expect(code).toContain('if (provider.shareConfig?.singleton && usedShare) {');
-    expect(code).toContain(
-      '__mfWriteSharedCache(__mfModuleCache.share, usedCacheDescriptor, normalized);'
+    expect(code).toContain('const initialShared = Object.create(null);');
+    expect(code).toContain('const initialVersions = initialShared[pkg] = Object.create(null);');
+    expect(code).toContain('for (const [version, provider] of Object.entries(versions))');
+    expect(code).toContain('initialVersions[version] = Object.assign({}, provider);');
+    expect(code).not.toContain(
+      'initialShared[pkg] = Object.assign(Object.create(null), versions);'
     );
+    expect(code.indexOf('const initialShared =')).toBeLessThan(
+      code.indexOf('await getLocalSharedImportMap()')
+    );
+    expect(code).toContain(
+      'const federationInstances = globalThis.__FEDERATION__?.__INSTANCES__ || [];'
+    );
+    expect(code).toContain('const initRootName = initScope.find((token) => token?.from)?.from;');
+    expect(code).toContain('const scopeRoot = federationInstances.find');
+    expect(code).toContain("instance?.shareScopeMap?.['default'] === shared");
+    expect(code).toContain('const usedCacheDescriptor = __mfGetSharedCacheDescriptor');
+    expect(code).toContain(
+      '__mfWriteSharedCache(\n          __mfModuleCache.share,\n          usedCacheDescriptor,\n          normalized,\n          actualSelection.from'
+    );
+    const preSeedBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeMaterializedProvider ='),
+      code.indexOf('const __mfBridgeExternalSharedProvider =')
+    );
+    expect(preSeedBridgeCode).toContain(
+      "if (singleton && 'version-first' !== 'loaded-first') return;"
+    );
+    expect(preSeedBridgeCode).toContain('if (usedShare.canLiveRebind === false) return;');
+    expect(preSeedBridgeCode).toContain('const provider = __mfSelectExternalSharedProvider(');
+    expect(preSeedBridgeCode).toContain('if (!singleton && version !== usedShare.version) return;');
+    expect(preSeedBridgeCode).toContain("!(provider.loaded && typeof provider.get === 'function')");
+    expect(preSeedBridgeCode).toContain('directFactory = await provider.get();');
+    expect(preSeedBridgeCode).toMatch(
+      /__mfGetSharedCacheDescriptor\(\s*pkg,\s*singleton,\s*usedShare\.version/
+    );
+    expect(preSeedBridgeCode).toContain("'version-first',\n          runtimeResolveShareHook");
+    expect(preSeedBridgeCode).not.toContain('__mfLoadPinnedRuntimeShare(');
+    expect(preSeedBridgeCode).toContain(
+      'if (providerEntry.registered && !__mfMatchesSharedProvider(liveProvider, provider)) return;'
+    );
+    expect(preSeedBridgeCode).toContain('const actualSelection = loadedShare?.selection;');
+    expect(preSeedBridgeCode).toContain('if (!actualSelection) return;');
+    expect(preSeedBridgeCode).not.toContain(
+      '__mfMatchesSharedProvider({ from: actualSelection?.from }, provider)'
+    );
+    expect(preSeedBridgeCode).toContain('providerEntry.registered &&');
+    expect(preSeedBridgeCode).toContain(
+      'liveVersionMap?.[actualSelection.version] !== actualProvider'
+    );
+    expect(preSeedBridgeCode).toContain(
+      '__mfWriteSharedCache(\n          __mfModuleCache.share,\n          usedCacheDescriptor,'
+    );
+    const preSeedBridgeCall = code.indexOf(
+      'await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);'
+    );
+    expect(preSeedBridgeCall).toBeGreaterThan(-1);
+    expect(preSeedBridgeCall).toBeLessThan(code.indexOf('const __mfSeedOrder ='));
+    const bridgeHelperCode = code.slice(
+      code.indexOf('const __mfBridgeExternalSharedProvider ='),
+      code.indexOf('for (const [pkg, usedShare] of Object.entries(usedShared))')
+    );
+    expect(code).toContain('const bridgeSelections = new Map();');
+    expect(bridgeHelperCode).toContain('passedVersionMap,');
+    expect(bridgeHelperCode).toContain(
+      'const selectedExternalProvider = __mfSelectExternalSharedProvider'
+    );
+    expect(bridgeHelperCode).toContain(
+      'const selectedRuntimeProvider = selectedExternalProvider ||'
+    );
+    expect(bridgeHelperCode).toContain(
+      "__mfSelectSharedProvider(versionMap, pkg, usedShare, 'version-first', runtimeResolveShareHook)"
+    );
+    expect(bridgeHelperCode).toContain('const passedProvider = passedVersionMap?.[version];');
+    expect(bridgeHelperCode).toContain('const externalProviderSelection = {};');
+    expect(bridgeHelperCode).toContain(
+      'const resolvedExternalProvider = __mfResolveExternalSharedProvider('
+    );
+    expect(bridgeHelperCode).toContain('externalProviderSelection.resolveShareHookUsed');
+    expect(bridgeHelperCode).toContain(
+      'const { provider, scopeRootProvider } = resolvedExternalProvider;'
+    );
+    expect(bridgeHelperCode).toContain('providerEntry.registered &&');
+    expect(bridgeHelperCode).toContain('!__mfMatchesSharedProvider(liveProvider, provider)');
+    expect(bridgeHelperCode).toContain('if (!resolvedExternalProvider) return;');
+    expect(bridgeHelperCode).toContain('bridgeSelections.set(pkg, {');
+    expect(bridgeHelperCode).toContain('const loadedShare = await __mfLoadPinnedRuntimeShare(');
+    expect(bridgeHelperCode).toContain('if (!actualSelection) return;');
+    expect(bridgeHelperCode).not.toContain(
+      '__mfMatchesSharedProvider({ from: actualSelection?.from }, provider)'
+    );
+    expect(bridgeHelperCode).toContain(
+      'const cachedShareOwner = __mfReadSharedCacheOwner(__mfModuleCache.share, usedCacheDescriptor);'
+    );
+    expect(bridgeHelperCode).toContain(
+      'if (cachedShare !== undefined && cachedShareOwner !== mfName) return;'
+    );
+    expect(bridgeHelperCode).toContain(
+      'const latestCachedShareOwner = __mfReadSharedCacheOwner(__mfModuleCache.share, usedCacheDescriptor);'
+    );
+    expect(bridgeHelperCode).toContain(
+      'if (latestCachedShare !== undefined && latestCachedShareOwner !== mfName) return;'
+    );
+    expect(bridgeHelperCode).toContain(
+      'actualSelection.registered &&\n          liveVersionMap?.[actualSelection.version] !== actualProvider'
+    );
+    const liveProviderRead = bridgeHelperCode.indexOf(
+      'const liveProvider = liveVersionMap?.[version]'
+    );
+    const providerLoad = bridgeHelperCode.indexOf(
+      'const loadedShare = await __mfLoadPinnedRuntimeShare('
+    );
+    const latestOwnerRead = bridgeHelperCode.indexOf('const latestCachedShareOwner =');
+    const bridgedCacheWrite = bridgeHelperCode.indexOf(
+      '__mfWriteSharedCache(\n          __mfModuleCache.share,\n          usedCacheDescriptor,\n          normalized,\n          actualSelection.from'
+    );
+    expect(providerLoad).toBeGreaterThan(-1);
+    expect(liveProviderRead).toBeLessThan(providerLoad);
+    expect(providerLoad).toBeLessThan(latestOwnerRead);
+    expect(latestOwnerRead).toBeLessThan(bridgedCacheWrite);
+    expect(bridgeHelperCode).toContain('if (!usedShare.shareConfig?.singleton) return;');
+    expect(bridgeHelperCode.indexOf('if (!usedShare.shareConfig?.singleton) return;')).toBeLessThan(
+      providerLoad
+    );
+    expect(bridgeHelperCode).toContain('if (usedShare.canLiveRebind === false) return;');
+    expect(bridgeHelperCode.indexOf('if (usedShare.canLiveRebind === false) return;')).toBeLessThan(
+      providerLoad
+    );
+    expect(bridgeHelperCode).toContain(
+      '__mfWriteSharedCache(\n          __mfModuleCache.share,\n          usedCacheDescriptor,\n          normalized,\n          actualSelection.from'
+    );
+    expect(bridgeHelperCode).not.toContain('const cacheDescriptor =');
+    expect(bridgeHelperCode.match(/__mfWriteSharedCache\(/g)).toHaveLength(1);
+    expect(bridgeHelperCode).toContain("Failed to bridge external shared module \"' + pkg + '\"'");
+    const exactBridgeCall = code.indexOf('await __mfBridgeExternalSharedProvider(\n        pkg');
+    expect(code.indexOf('if (initScope.indexOf(initToken) >= 0) return;')).toBeLessThan(
+      exactBridgeCall
+    );
+    const initializeSharingCall = code.indexOf(
+      `await Promise.all(await initRes.initializeSharing('default'`
+    );
+    expect(initializeSharingCall).toBeGreaterThan(-1);
+    expect(initializeSharingCall).toBeLessThan(exactBridgeCall);
+    const exactBridgeCode = code.slice(exactBridgeCall, code.indexOf('const allInstances ='));
+    expect(exactBridgeCode).toContain('shared[pkg]');
+    expect(exactBridgeCode).toContain('initialShared[pkg]');
+    expect(exactBridgeCode.indexOf('shared[pkg]')).toBeLessThan(
+      exactBridgeCode.indexOf('initialShared[pkg]')
+    );
+    expect(exactBridgeCode).toContain('undefined');
+    expect(code).not.toContain('const initFrom =');
+    expect(code).not.toContain('expectedFrom');
     expect(code).not.toContain('__mfModuleCache.share[usedCacheKey] = normalized;');
+  });
+
+  it('materializes only an originally passed root provider replaced by a later instance', async () => {
+    const getScopeRootProvider = await getScopeRootProviderResolver();
+    const shared = {};
+    const loading = Promise.resolve(() => ({ marker: 'host-react' }));
+    const lib = () => ({ marker: 'loaded-host-react' });
+    const rootProvider = { from: 'host', version: '18.3.1', loading, lib };
+    const configuredRootProvider = { from: 'host', version: '18.3.1' };
+    const root = {
+      options: {
+        name: 'host',
+        shared: { react: [configuredRootProvider] },
+      },
+      shareScopeMap: { default: shared },
+    };
+    const sibling = {
+      options: { name: 'rspack' },
+      shareScopeMap: { default: shared },
+    };
+
+    const selectedRootProvider = getScopeRootProvider(
+      [root, sibling],
+      root,
+      shared,
+      'default',
+      'react',
+      '18.3.1',
+      { from: 'rspack' },
+      rootProvider,
+      'version-first'
+    );
+    expect(selectedRootProvider).toBe(rootProvider);
+    expect(selectedRootProvider).toMatchObject({ loading, lib });
+    expect(
+      getScopeRootProvider(
+        [root, sibling],
+        root,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        { from: 'rspack' },
+        undefined,
+        'version-first'
+      )
+    ).toBeUndefined();
+    expect(
+      getScopeRootProvider(
+        [root, sibling],
+        root,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        { from: 'rspack' },
+        { from: 'other-host' },
+        'version-first'
+      )
+    ).toBeUndefined();
+    expect(
+      getScopeRootProvider(
+        [root, sibling],
+        root,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        { from: 'rspack' },
+        rootProvider,
+        'loaded-first'
+      )
+    ).toBeUndefined();
+
+    const staleConfiguredRoot = {
+      options: {
+        name: 'host',
+        shared: { react: [{ from: 'stale-host', version: '18.3.1' }] },
+      },
+      shareScopeMap: { default: shared },
+    };
+    expect(
+      getScopeRootProvider(
+        [staleConfiguredRoot, sibling],
+        staleConfiguredRoot,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        { from: 'rspack' },
+        rootProvider,
+        'version-first'
+      )
+    ).toBe(rootProvider);
+
+    const unconfiguredRoot = {
+      options: { name: 'host' },
+      shareScopeMap: { default: shared },
+    };
+    expect(
+      getScopeRootProvider(
+        [unconfiguredRoot, sibling],
+        unconfiguredRoot,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        { from: 'rspack' },
+        rootProvider,
+        'version-first'
+      )
+    ).toBe(rootProvider);
+    expect(
+      getScopeRootProvider(
+        [unconfiguredRoot, sibling],
+        unconfiguredRoot,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        { from: 'rspack' },
+        { from: 'other-host', version: '18.3.1' },
+        'version-first'
+      )
+    ).toBeUndefined();
+  });
+
+  it('preserves a later external provider explicitly selected by the resolveShare hook', async () => {
+    const [selectExternalProvider, resolveExternalProvider] = await Promise.all([
+      getExternalSharedProviderSelector(),
+      getExternalSharedProviderResolver(),
+    ]);
+    const rootProvider = { from: 'host', version: '18.3.1' };
+    const laterProvider = { from: 'rspack', version: '18.3.1' };
+    const shared = { react: { '18.3.1': laterProvider } };
+    const root = {
+      options: { name: 'host', shared: { react: [rootProvider] } },
+      shareScopeMap: { default: shared },
+    };
+    const sibling = {
+      options: { name: 'rspack' },
+      shareScopeMap: { default: shared },
+    };
+    const localProvider = {
+      from: 'remote',
+      version: '18.3.1',
+      shareConfig: { singleton: true, requiredVersion: '^18.0.0' },
+    };
+    const selectionState: { resolveShareHookUsed?: boolean } = {};
+    const resolveShareHook = {
+      emit: (params: any) => ({
+        ...params,
+        resolver: () => ({
+          shared: params.shareScopeMap.default.react['18.3.1'],
+          useTreesShaking: false,
+        }),
+      }),
+    };
+
+    const selectedProvider = selectExternalProvider(
+      shared.react,
+      'react',
+      localProvider,
+      'version-first',
+      resolveShareHook,
+      selectionState
+    );
+    const providerEntry = {
+      version: '18.3.1',
+      provider: selectedProvider,
+      registered: true,
+    };
+
+    expect(selectedProvider).toBe(laterProvider);
+    expect(selectionState.resolveShareHookUsed).toBe(true);
+    expect(
+      resolveExternalProvider(
+        [root, sibling],
+        root,
+        shared,
+        'default',
+        'react',
+        providerEntry,
+        selectedProvider,
+        rootProvider,
+        'version-first',
+        false
+      )
+    ).toEqual({ provider: rootProvider, scopeRootProvider: rootProvider });
+    expect(
+      resolveExternalProvider(
+        [root, sibling],
+        root,
+        shared,
+        'default',
+        'react',
+        providerEntry,
+        selectedProvider,
+        rootProvider,
+        'version-first',
+        selectionState.resolveShareHookUsed
+      )
+    ).toEqual({ provider: laterProvider, scopeRootProvider: undefined });
+  });
+
+  it('does not give parent authority to a provider registered after the initial snapshot', async () => {
+    const resolveExternalProvider = await getExternalSharedProviderResolver();
+    const laterProvider = { from: 'rspack', version: '19.0.0' };
+    const staleProvider = { from: 'stale', version: '19.0.0' };
+    const shared = { react: { '19.0.0': laterProvider } };
+
+    expect(
+      resolveExternalProvider(
+        [],
+        undefined,
+        shared,
+        'default',
+        'react',
+        { version: '19.0.0', provider: laterProvider, registered: true },
+        laterProvider,
+        undefined,
+        'version-first',
+        false
+      )
+    ).toBeUndefined();
+    expect(
+      resolveExternalProvider(
+        [],
+        undefined,
+        shared,
+        'default',
+        'react',
+        { version: '19.0.0', provider: staleProvider, registered: true },
+        staleProvider,
+        undefined,
+        'version-first',
+        false
+      )
+    ).toBeUndefined();
+  });
+
+  it('attributes concurrent runtime loads by factory identity', async () => {
+    let resolveOne!: (factory: () => unknown) => void;
+    let resolveTwo!: (factory: () => unknown) => void;
+    const one = new Promise<() => unknown>((resolve) => {
+      resolveOne = resolve;
+    });
+    const two = new Promise<() => unknown>((resolve) => {
+      resolveTwo = resolve;
+    });
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '1.0.0': { from: 'host-one', get: () => one },
+      '2.0.0': { from: 'host-two', get: () => two },
+    };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: createRuntimeShareLoader(versionMap) as (
+        pkg: string,
+        options: unknown
+      ) => Promise<unknown>,
+    });
+
+    const loadOne = loadPinnedShare(
+      'dep',
+      { requiredVersion: '1.0.0' },
+      versionMap,
+      '1.0.0',
+      versionMap['1.0.0'],
+      versionMap['1.0.0']
+    );
+    const loadTwo = loadPinnedShare(
+      'dep',
+      { requiredVersion: '2.0.0' },
+      versionMap,
+      '2.0.0',
+      versionMap['2.0.0'],
+      versionMap['2.0.0']
+    );
+
+    resolveTwo(() => ({ value: 2 }));
+    resolveOne(() => ({ value: 1 }));
+
+    await expect(loadOne).resolves.toMatchObject({
+      selection: { version: '1.0.0', from: 'host-one' },
+      resolved: { value: 1 },
+    });
+    await expect(loadTwo).resolves.toMatchObject({
+      selection: { version: '2.0.0', from: 'host-two' },
+      resolved: { value: 2 },
+    });
+  });
+
+  it('attributes a runtime-selected provider when compatible versions share a factory', async () => {
+    const sharedFactory = () => ({ marker: 'shared-react' });
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.2.0': {
+        from: 'host-react-18.2',
+        version: '18.2.0',
+        lib: sharedFactory,
+        loaded: true,
+      },
+      '18.3.1': {
+        from: 'host-react-18.3',
+        version: '18.3.1',
+        lib: sharedFactory,
+        loaded: true,
+      },
+    };
+    let recordSelection!: (
+      provider: RuntimeBridgeProvider,
+      shareInfo?: Record<string, unknown>
+    ) => void;
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async (_pkg, options) => {
+        recordSelection(
+          versionMap['18.3.1'],
+          (options as { customShareInfo?: Record<string, unknown> }).customShareInfo
+        );
+        return sharedFactory;
+      },
+    });
+    recordSelection = loadPinnedShare.recordSelection;
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        versionMap['18.3.1'],
+        versionMap['18.3.1']
+      )
+    ).resolves.toMatchObject({
+      selection: { version: '18.3.1', from: 'host-react-18.3' },
+      resolved: { marker: 'shared-react' },
+    });
+  });
+
+  it('attributes a provider registered while the runtime load is pending', async () => {
+    const selectedFactory = () => ({ marker: 'plugin-provider' });
+    const originalProvider: RuntimeBridgeProvider = {
+      from: 'original-host',
+      version: '1.0.0',
+      get: async () => () => ({ marker: 'original-provider' }),
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '1.0.0': originalProvider,
+    };
+    let recordSelection!: (provider: RuntimeBridgeProvider) => void;
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async () => {
+        const pluginProvider = (versionMap['2.0.0'] = {
+          from: 'plugin-host',
+          version: '2.0.0',
+          lib: selectedFactory,
+          loaded: true,
+        });
+        recordSelection(pluginProvider);
+        pluginProvider.from = 'remote';
+        return selectedFactory;
+      },
+    });
+    recordSelection = loadPinnedShare.recordSelection;
+
+    await expect(
+      loadPinnedShare(
+        'dep',
+        { requiredVersion: '*' },
+        versionMap,
+        '1.0.0',
+        originalProvider,
+        originalProvider
+      )
+    ).resolves.toMatchObject({
+      selection: { version: '2.0.0', from: 'plugin-host' },
+      resolved: { marker: 'plugin-provider' },
+    });
+    expect(versionMap['1.0.0']).toBe(originalProvider);
+    expect(versionMap['2.0.0'].from).toBe('plugin-host');
+  });
+
+  it('restores external provenance after the runtime tags a pinned load as local', async () => {
+    const factory = () => ({ marker: 'host-react' });
+    const provider: RuntimeBridgeProvider = {
+      from: 'host',
+      version: '18.3.1',
+      get: async () => factory,
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = { '18.3.1': provider };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async () => {
+        versionMap['18.3.1'].from = 'remote';
+        versionMap['18.3.1'].lib = factory;
+        versionMap['18.3.1'].loaded = true;
+        return factory;
+      },
+    });
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        provider,
+        provider
+      )
+    ).resolves.toMatchObject({
+      selection: { version: '18.3.1', from: 'host' },
+      resolved: { marker: 'host-react' },
+    });
+    expect(versionMap['18.3.1'].from).toBe('host');
+  });
+
+  it('loads a hook-selected provider that is not registered in the share map', async () => {
+    const factory = () => ({ marker: 'plugin-react' });
+    const registeredProvider: RuntimeBridgeProvider = {
+      from: 'registered-host',
+      version: '18.2.0',
+      get: async () => () => ({ marker: 'registered-react' }),
+    };
+    const pluginProvider: RuntimeBridgeProvider = {
+      from: 'plugin-host',
+      version: '18.3.1',
+      get: async () => factory,
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.2.0': registeredProvider,
+    };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async () => {
+        const pinnedProvider = versionMap['18.3.1'];
+        pinnedProvider.from = 'remote';
+        pinnedProvider.lib = factory;
+        pinnedProvider.loaded = true;
+        return factory;
+      },
+    });
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        undefined,
+        pluginProvider,
+        false
+      )
+    ).resolves.toMatchObject({
+      provider: pluginProvider,
+      selection: {
+        version: '18.3.1',
+        from: 'plugin-host',
+        registered: false,
+      },
+      resolved: { marker: 'plugin-react' },
+    });
+    expect(versionMap['18.3.1']).toBeUndefined();
+    expect(pluginProvider.from).toBe('plugin-host');
+    expect(pluginProvider.lib).toBeUndefined();
+  });
+
+  it('loads an unregistered hook provider whose factory was already materialized', async () => {
+    const factory = () => ({ marker: 'plugin-react' });
+    const pluginProvider: RuntimeBridgeProvider = {
+      from: 'plugin-host',
+      version: '18.3.1',
+      lib: factory,
+      loaded: true,
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {};
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async () => factory,
+    });
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        undefined,
+        pluginProvider,
+        false
+      )
+    ).resolves.toMatchObject({
+      provider: pluginProvider,
+      selection: {
+        version: '18.3.1',
+        from: 'plugin-host',
+        registered: false,
+      },
+      resolved: { marker: 'plugin-react' },
+    });
+    expect(versionMap['18.3.1']).toBeUndefined();
+  });
+
+  it('clears a rejected pinned runtime load so it can retry', async () => {
+    const get = vi
+      .fn<() => Promise<() => unknown>>()
+      .mockRejectedValueOnce(new Error('broken runtime provider'))
+      .mockResolvedValueOnce(() => ({ marker: 'host-react' }));
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.3.1': { from: 'host', get },
+    };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: createRuntimeShareLoader(versionMap) as (
+        pkg: string,
+        options: unknown
+      ) => Promise<unknown>,
+    });
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '18.3.1' },
+        versionMap,
+        '18.3.1',
+        versionMap['18.3.1'],
+        versionMap['18.3.1']
+      )
+    ).rejects.toThrow('broken runtime provider');
+    expect(versionMap['18.3.1'].loading).toBeUndefined();
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '18.3.1' },
+        versionMap,
+        '18.3.1',
+        versionMap['18.3.1'],
+        versionMap['18.3.1']
+      )
+    ).resolves.toMatchObject({
+      selection: { version: '18.3.1', from: 'host' },
+      resolved: { marker: 'host-react' },
+    });
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not resolve a provider replaced during an awaited runtime load', async () => {
+    let markStarted!: () => void;
+    let resolveFactory!: (factory: () => unknown) => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const pendingFactory = new Promise<() => unknown>((resolve) => {
+      resolveFactory = resolve;
+    });
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.3.1': {
+        from: 'host',
+        get: () => {
+          markStarted();
+          return pendingFactory;
+        },
+      },
+    };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: createRuntimeShareLoader(versionMap) as (
+        pkg: string,
+        options: unknown
+      ) => Promise<unknown>,
+    });
+    const load = loadPinnedShare(
+      'react',
+      { requiredVersion: '18.3.1' },
+      versionMap,
+      '18.3.1',
+      versionMap['18.3.1'],
+      versionMap['18.3.1']
+    );
+
+    await started;
+    expect(versionMap['18.3.1']).toMatchObject({
+      from: 'host',
+      version: '18.3.1',
+      scope: ['default'],
+    });
+    const replacement = { from: 'later-host', lib: () => ({ marker: 'later-react' }) };
+    versionMap['18.3.1'] = replacement;
+    resolveFactory(() => ({ marker: 'stale-react' }));
+
+    await expect(load).resolves.toBeUndefined();
+    expect(versionMap['18.3.1']).toBe(replacement);
   });
 
   it('reuses an already cached singleton for a versioned remote share key', async () => {
@@ -1261,10 +3049,10 @@ describe('virtualRemoteEntry', () => {
       'const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);'
     );
     expect(code).toContain(
-      '__mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, singletonModule);'
+      '__mfReadSharedCacheOwner(__mfModuleCache.share, singletonCacheDescriptor)'
     );
     expect(code.indexOf('const singletonCacheDescriptor')).toBeLessThan(
-      code.indexOf('const initRes = runtimeInit({')
+      code.indexOf(`await Promise.all(await initRes.initializeSharing('default'`)
     );
   });
 
@@ -1303,7 +3091,12 @@ describe('virtualRemoteEntry', () => {
       'serve'
     );
 
-    expect(code).not.toContain('initRes.loadShare(pkg');
+    const initializeSharingCall = code.indexOf(
+      `await Promise.all(await initRes.initializeSharing('default'`
+    );
+    const bridgeCall = code.indexOf('await __mfBridgeExternalSharedProvider(');
+    expect(initializeSharingCall).toBeGreaterThan(-1);
+    expect(bridgeCall).toBeGreaterThan(initializeSharingCall);
     expect(code).not.toContain(
       'const mod = await import("virtual:mf:remote__prebuild__react__prebuild__.js")'
     );
@@ -1355,6 +3148,169 @@ describe('virtualRemoteEntry', () => {
     ).toBe(loadedReact18);
   });
 
+  it('compares external and local singleton providers with version-first', async () => {
+    const selectExternalProvider = await getExternalSharedProviderSelector();
+    const hostGet = vi.fn();
+    const hostReact18 = { from: 'host-react-18', get: hostGet };
+    const localReact19 = {
+      version: '19.2.0',
+      from: 'remote-react-19',
+      scope: ['default'],
+      loaded: false,
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^19.0.0',
+        strictVersion: false,
+      },
+    };
+
+    expect(
+      selectExternalProvider({ '18.3.1': hostReact18 }, 'react', localReact19, 'version-first')
+    ).toBeUndefined();
+    expect(hostGet).not.toHaveBeenCalled();
+
+    const localReact17 = {
+      ...localReact19,
+      version: '17.0.2',
+      from: 'remote-react-17',
+      shareConfig: {
+        ...localReact19.shareConfig,
+        requiredVersion: '^17.0.2',
+      },
+    };
+    expect(
+      selectExternalProvider({ '18.3.1': hostReact18 }, 'react', localReact17, 'version-first')
+    ).toBe(hostReact18);
+    expect(
+      selectExternalProvider(
+        { '17.0.2': { ...localReact17, lib: () => ({ marker: 'local-clone' }) } },
+        'react',
+        localReact17,
+        'version-first'
+      )
+    ).toBeUndefined();
+    expect(hostGet).not.toHaveBeenCalled();
+  });
+
+  it('selects only active external providers with loaded-first', async () => {
+    const selectExternalProvider = await getExternalSharedProviderSelector();
+    const hostGet = vi.fn(async () => () => ({ marker: 'host-react' }));
+    const hostReact18 = { from: 'host-react-18', get: hostGet, loaded: 1 };
+    const localReact19 = {
+      version: '19.2.0',
+      from: 'remote-react-19',
+      scope: ['default'],
+      loaded: false,
+      shareConfig: {
+        singleton: true,
+        requiredVersion: false as const,
+        strictVersion: false,
+      },
+    };
+
+    expect(
+      selectExternalProvider({ '18.3.1': hostReact18 }, 'react', localReact19, 'loaded-first')
+    ).toBe(hostReact18);
+
+    expect(
+      selectExternalProvider(
+        { '18.3.1': { from: hostReact18.from, get: hostGet } },
+        'react',
+        localReact19,
+        'loaded-first'
+      )
+    ).toBeUndefined();
+    expect(hostGet).not.toHaveBeenCalled();
+  });
+
+  it('retains an unloaded same-version parent provider with loaded-first', async () => {
+    const selectExternalProvider = await getExternalSharedProviderSelector();
+    const hostGet = vi.fn(async () => () => ({ marker: 'host-react' }));
+    const hostReact = { from: 'host', get: hostGet };
+    const localReact = {
+      version: '18.3.1',
+      from: 'remote',
+      scope: ['default'],
+      loaded: false,
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^18.0.0',
+        strictVersion: false,
+      },
+    };
+
+    expect(
+      selectExternalProvider({ '18.3.1': hostReact }, 'react', localReact, 'loaded-first')
+    ).toBe(hostReact);
+    expect(hostGet).not.toHaveBeenCalled();
+  });
+
+  it('uses the runtime resolve hook for external provider selection', async () => {
+    const selectProvider = await getExternalSharedProviderSelector();
+    const pluginProvider = { from: 'plugin-provider', lib: () => ({ marker: 'plugin' }) };
+    const defaultProvider = { from: 'default-provider', lib: () => ({ marker: 'default' }) };
+    const localProvider = {
+      from: 'remote',
+      version: '3.0.0',
+      shareConfig: { singleton: true, requiredVersion: '*' },
+    };
+    const resolveShareHook = {
+      emit: (params: any) => ({
+        ...params,
+        resolver: () => ({
+          shared: params.shareScopeMap.default.react['1.0.0'],
+          useTreesShaking: false,
+        }),
+      }),
+    };
+
+    expect(
+      selectProvider(
+        {
+          '1.0.0': pluginProvider,
+          '2.0.0': defaultProvider,
+        },
+        'react',
+        localProvider,
+        'version-first',
+        resolveShareHook
+      )
+    ).toBe(pluginProvider);
+  });
+
+  it('tracks hook-selected providers that are not the registered map object', async () => {
+    const findProviderEntry = await getSharedProviderEntryResolver();
+    const registered = { from: 'registered-host', version: '1.0.0' };
+    const versions = { '1.0.0': registered };
+    const pluginProvider = { from: 'plugin-host', version: '2.0.0' };
+
+    expect(findProviderEntry(versions, registered)).toEqual({
+      version: '1.0.0',
+      provider: registered,
+      registered: true,
+    });
+    expect(findProviderEntry(versions, pluginProvider)).toEqual({
+      version: '2.0.0',
+      provider: pluginProvider,
+      registered: false,
+    });
+    const wrappedProvider = { from: 'registered-host' };
+    expect(findProviderEntry(versions, wrappedProvider)).toEqual({
+      version: '1.0.0',
+      provider: wrappedProvider,
+      registered: false,
+    });
+    expect(
+      findProviderEntry(
+        {
+          '1.0.0': registered,
+          '1.1.0': { from: 'registered-host' },
+        },
+        wrappedProvider
+      )
+    ).toBeUndefined();
+  });
+
   it('matches tilde major ranges when selecting import:false providers', async () => {
     const selectProvider = await getSharedProviderSelector();
     const react100 = { from: 'host-react-1.0.0' };
@@ -1403,7 +3359,7 @@ describe('virtualRemoteEntry', () => {
     ).toBe(dep123);
   });
 
-  it('does not import runtime share helpers when no import:false share is configured', async () => {
+  it('does not import runtime share helpers when no shared dependency is configured', async () => {
     const mod = await import('../virtualRemoteEntry');
 
     const code = mod.generateRemoteEntry(
@@ -1461,11 +3417,17 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain(
       'import {share as runtimeShare} from "@module-federation/runtime/helpers";'
     );
-    expect(code).toContain("__mfSelectSharedProvider(versions, pkg, share, 'version-first')");
+    expect(code).toContain('const loadedShare = await __mfLoadPinnedRuntimeShare(');
+    expect(code).toContain(
+      'if (__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) continue;'
+    );
+    expect(code).toContain(
+      'providerSelection.registered &&\n        versionMap?.[providerSelection.version] !== actualProvider'
+    );
     expect(code).not.toContain('versions[Object.keys(versions)[0]]');
   });
 
-  it('uses provider selection helper before seeding import:false shares from the global share scope', async () => {
+  it('aggregates materialized global providers before selecting a shared version', async () => {
     const mod = await import('../virtualRemoteEntry');
 
     const code = mod.generateRemoteEntry(
@@ -1496,10 +3458,71 @@ describe('virtualRemoteEntry', () => {
     );
 
     expect(code).toContain('const usedShare = usedShared?.[pkg];');
-    expect(code).toContain('const providerEntries = usedShare?.shareConfig?.import === false');
-    expect(code).toContain("__mfSelectSharedProvider(versionMap, pkg, usedShare, 'version-first')");
-    expect(code.indexOf('__mfSelectSharedProvider(versionMap')).toBeLessThan(
-      code.indexOf('for (const [version, provider] of providerEntries)')
+    expect(code).toContain('if (!usedShare) continue;');
+    const globalBridgeCode = code.slice(
+      code.indexOf('const allInstances ='),
+      code.indexOf("console.error('[Module Federation] Failed to bridge external shared modules'")
     );
+    expect(globalBridgeCode).toContain('const globalVersionsByPackage = Object.create(null);');
+    expect(globalBridgeCode).toContain('for (const [, scopes] of Object.entries(allInstances))');
+    expect(globalBridgeCode).toContain('if (!provider.lib) continue;');
+    expect(globalBridgeCode).toContain('const passedVersions = initialShared[pkg];');
+    expect(globalBridgeCode).toContain('const bridgeSelection = bridgeSelections.get(pkg);');
+    expect(globalBridgeCode).toContain('if (!passedVersions) continue;');
+    expect(globalBridgeCode).toContain('if (!bridgeSelection) continue;');
+    expect(globalBridgeCode).toContain('if (bridgeSelection.version !== version) continue;');
+    expect(globalBridgeCode).toContain(
+      'if (!__mfMatchesSharedProvider(provider, bridgeSelection.provider)) continue;'
+    );
+    expect(globalBridgeCode).toContain('const passedProvider = passedVersions[version];');
+    expect(globalBridgeCode).toContain('const matchesPassedProvider =');
+    expect(globalBridgeCode).toContain(
+      'passedProvider?.from && provider.from === passedProvider.from'
+    );
+    expect(globalBridgeCode).toContain(
+      'if (provider === usedShare || (usedShare.from && provider.from === usedShare.from)) continue;'
+    );
+    expect(globalBridgeCode).toContain(
+      'for (const [pkg, versionMap] of Object.entries(globalVersionsByPackage))'
+    );
+    expect(globalBridgeCode.indexOf('for (const [, scopes]')).toBeLessThan(
+      globalBridgeCode.indexOf('await __mfBridgeExternalSharedProvider(')
+    );
+    expect(globalBridgeCode).toMatch(
+      /await __mfBridgeExternalSharedProvider\(\s*pkg,\s*usedShared\[pkg\],\s*versionMap,\s*initialShared\[pkg\],\s*bridgeSelections\.get\(pkg\)\s*\)/
+    );
+  });
+
+  it('uses null-prototype aggregation maps for reserved shared package names', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: Object.fromEntries(
+          ['constructor', 'toString', '__proto__'].map((name) => [
+            name,
+            {
+              name,
+              version: '1.0.0',
+              scope: ['default'],
+              shareConfig: { singleton: true, requiredVersion: false },
+            },
+          ])
+        ),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    expect(code).toContain('const globalVersionsByPackage = Object.create(null);');
+    expect(code).toContain('globalVersionsByPackage[pkg] = Object.create(null)');
   });
 });

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2664,6 +2664,47 @@ describe('virtualRemoteEntry', () => {
     ).toBeUndefined();
   });
 
+  it('awaits and materializes a loading-only external provider', async () => {
+    let resolveFactory!: (factory: () => unknown) => void;
+    const exactExports = { marker: 'host-react', useState: vi.fn() };
+    const factory = vi.fn(() => exactExports);
+    const provider: RuntimeBridgeProvider = {
+      from: 'host',
+      version: '18.3.1',
+      loading: new Promise<() => unknown>((resolve) => {
+        resolveFactory = resolve;
+      }),
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.3.1': provider,
+    };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: createRuntimeShareLoader(versionMap) as (
+        pkg: string,
+        options: unknown
+      ) => Promise<unknown>,
+    });
+
+    const pending = loadPinnedShare(
+      'react',
+      { requiredVersion: '18.3.1' },
+      versionMap,
+      '18.3.1',
+      provider,
+      provider
+    );
+    expect(versionMap['18.3.1'].lib).toBeUndefined();
+
+    resolveFactory(factory);
+
+    await expect(pending).resolves.toMatchObject({
+      selection: { version: '18.3.1', from: 'host' },
+      resolved: exactExports,
+    });
+    expect(versionMap['18.3.1']).toMatchObject({ lib: factory, loaded: true });
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
   it('attributes concurrent runtime loads by factory identity', async () => {
     let resolveOne!: (factory: () => unknown) => void;
     let resolveTwo!: (factory: () => unknown) => void;
@@ -2920,13 +2961,14 @@ describe('virtualRemoteEntry', () => {
     expect(versionMap['18.3.1']).toBeUndefined();
   });
 
-  it('clears a rejected pinned runtime load so it can retry', async () => {
+  it('restores a rejected pinned runtime load so it can retry', async () => {
     const get = vi
       .fn<() => Promise<() => unknown>>()
       .mockRejectedValueOnce(new Error('broken runtime provider'))
       .mockResolvedValueOnce(() => ({ marker: 'host-react' }));
+    const currentProvider = { from: 'host', get };
     const versionMap: Record<string, RuntimeBridgeProvider> = {
-      '18.3.1': { from: 'host', get },
+      '18.3.1': currentProvider,
     };
     const loadPinnedShare = await getRuntimeBridgeLoader({
       loadShare: createRuntimeShareLoader(versionMap) as (
@@ -2945,7 +2987,7 @@ describe('virtualRemoteEntry', () => {
         versionMap['18.3.1']
       )
     ).rejects.toThrow('broken runtime provider');
-    expect(versionMap['18.3.1'].loading).toBeUndefined();
+    expect(versionMap['18.3.1']).toBe(currentProvider);
 
     await expect(
       loadPinnedShare(
@@ -2961,6 +3003,63 @@ describe('virtualRemoteEntry', () => {
       resolved: { marker: 'host-react' },
     });
     expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes an absent pinned provider when the runtime returns false', async () => {
+    const provider: RuntimeBridgeProvider = {
+      from: 'plugin-host',
+      version: '18.3.1',
+      get: async () => () => ({ marker: 'plugin-react' }),
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {};
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async () => false,
+    });
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        undefined,
+        provider,
+        false
+      )
+    ).resolves.toBeUndefined();
+    expect(versionMap['18.3.1']).toBeUndefined();
+  });
+
+  it('preserves a provider that replaces a pin before a rejected runtime load settles', async () => {
+    const currentProvider: RuntimeBridgeProvider = {
+      from: 'host',
+      get: async () => () => ({ marker: 'host-react' }),
+    };
+    const replacement: RuntimeBridgeProvider = {
+      from: 'later-host',
+      lib: () => ({ marker: 'later-react' }),
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.3.1': currentProvider,
+    };
+    const loadPinnedShare = await getRuntimeBridgeLoader({
+      loadShare: async () => {
+        versionMap['18.3.1'] = replacement;
+        throw new Error('broken runtime provider');
+      },
+    });
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        currentProvider,
+        currentProvider
+      )
+    ).rejects.toThrow('broken runtime provider');
+    expect(versionMap['18.3.1']).toBe(replacement);
   });
 
   it('does not resolve a provider replaced during an awaited runtime load', async () => {
@@ -3102,7 +3201,7 @@ describe('virtualRemoteEntry', () => {
     );
   });
 
-  it('selects the runtime provider for import:false singleton shares with version-first', async () => {
+  it('preserves loaded singleton precedence for version-first provider selection', async () => {
     const selectProvider = await getSharedProviderSelector();
     const react18 = { from: 'host-react-18', lib: () => ({ marker: 'react-18' }), loaded: true };
     const react19 = { from: 'host-react-19', lib: () => ({ marker: 'react-19' }) };
@@ -3122,7 +3221,7 @@ describe('virtualRemoteEntry', () => {
         },
         'version-first'
       )
-    ).toBe(react19);
+    ).toBe(react18);
   });
 
   it('prefers an already loaded provider for import:false shares with loaded-first', async () => {
@@ -3191,6 +3290,34 @@ describe('virtualRemoteEntry', () => {
     ).toBeUndefined();
     expect(hostGet).not.toHaveBeenCalled();
   });
+
+  it.each([false, true])(
+    'keeps a loaded host singleton ahead of a newer local fallback with version-first (local loaded: %s)',
+    async (localLoaded) => {
+      const selectExternalProvider = await getExternalSharedProviderSelector();
+      const hostReact18 = {
+        from: 'host-react-18',
+        lib: () => ({ marker: 'host-react' }),
+        loaded: true,
+      };
+      const localReact19 = {
+        version: '19.2.0',
+        from: 'remote-react-19',
+        scope: ['default'],
+        loaded: localLoaded,
+        ...(localLoaded ? { lib: () => ({ marker: 'local-react' }) } : {}),
+        shareConfig: {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+          strictVersion: false,
+        },
+      };
+
+      expect(
+        selectExternalProvider({ '18.3.1': hostReact18 }, 'react', localReact19, 'version-first')
+      ).toBe(hostReact18);
+    }
+  );
 
   it('selects only active external providers with loaded-first', async () => {
     const selectExternalProvider = await getExternalSharedProviderSelector();

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -83,11 +83,7 @@ async function getExternalSharedProviderSelector() {
       loading?: Promise<unknown>;
       get?: () => unknown;
     },
-    strategy: 'version-first' | 'loaded-first',
-    resolveShareHook?: {
-      emit: (params: any) => any;
-    },
-    selectionState?: { resolveShareHookUsed?: boolean }
+    strategy: 'version-first' | 'loaded-first'
   ) => unknown;
 }
 
@@ -105,8 +101,7 @@ async function getScopeRootProviderResolver() {
     version: string,
     provider: unknown,
     passedProvider: unknown,
-    strategy: 'version-first' | 'loaded-first',
-    resolveShareHookUsed?: boolean
+    strategy: 'version-first' | 'loaded-first'
   ) => unknown;
 }
 
@@ -124,8 +119,7 @@ async function getExternalSharedProviderResolver() {
     providerEntry: { version: string; provider: unknown; registered: boolean },
     selectedExternalProvider: unknown,
     passedProvider: unknown,
-    strategy: 'version-first' | 'loaded-first',
-    resolveShareHookUsed?: boolean
+    strategy: 'version-first' | 'loaded-first'
   ) => { provider: unknown; scopeRootProvider: unknown } | undefined;
 }
 
@@ -186,13 +180,8 @@ async function getRuntimeBridgeLoader(initRes: {
   const loadPinnedShare = new Function(
     'initRes',
     'runtimeResolveShareHook',
-    '__mfTransparentResolverKey',
     `${helperCode}; return __mfLoadPinnedRuntimeShare;`
-  )(
-    initRes,
-    runtimeResolveShareHook,
-    Symbol.for('module-federation.vite.transparent-resolver')
-  ) as ((
+  )(initRes, runtimeResolveShareHook) as ((
     pkg: string,
     shareConfig: Record<string, unknown>,
     versionMap: Record<string, RuntimeBridgeProvider>,
@@ -2306,7 +2295,7 @@ describe('virtualRemoteEntry', () => {
     expect(preSeedBridgeCode).toMatch(
       /__mfGetSharedCacheDescriptor\(\s*pkg,\s*singleton,\s*usedShare\.version/
     );
-    expect(preSeedBridgeCode).toContain("'version-first',\n          runtimeResolveShareHook");
+    expect(preSeedBridgeCode).not.toContain('runtimeResolveShareHook');
     expect(preSeedBridgeCode).not.toContain('__mfLoadPinnedRuntimeShare(');
     expect(preSeedBridgeCode).toContain(
       'if (providerEntry.registered && !__mfMatchesSharedProvider(liveProvider, provider)) return;'
@@ -2341,20 +2330,28 @@ describe('virtualRemoteEntry', () => {
       'const selectedRuntimeProvider = selectedExternalProvider ||'
     );
     expect(bridgeHelperCode).toContain(
-      "__mfSelectSharedProvider(versionMap, pkg, usedShare, 'version-first', runtimeResolveShareHook)"
+      "__mfSelectSharedProvider(versionMap, pkg, usedShare, 'version-first') ||\n          usedShare"
+    );
+    expect(bridgeHelperCode).toContain(
+      "__mfSelectSharedProvider(versionMap, pkg, usedShare, 'version-first')"
     );
     expect(bridgeHelperCode).toContain('const passedProvider = passedVersionMap?.[version];');
-    expect(bridgeHelperCode).toContain('const externalProviderSelection = {};');
+    expect(bridgeHelperCode).not.toContain('runtimeResolveShareHook');
+    expect(bridgeHelperCode).not.toContain('externalProviderSelection');
     expect(bridgeHelperCode).toContain(
       'const resolvedExternalProvider = __mfResolveExternalSharedProvider('
     );
-    expect(bridgeHelperCode).toContain('externalProviderSelection.resolveShareHookUsed');
     expect(bridgeHelperCode).toContain(
-      'const { provider, scopeRootProvider } = resolvedExternalProvider;'
+      'const { provider, scopeRootProvider } = resolvedExternalProvider || {'
     );
     expect(bridgeHelperCode).toContain('providerEntry.registered &&');
     expect(bridgeHelperCode).toContain('!__mfMatchesSharedProvider(liveProvider, provider)');
-    expect(bridgeHelperCode).toContain('if (!resolvedExternalProvider) return;');
+    expect(bridgeHelperCode).toContain(
+      'if (!resolvedExternalProvider && !selectedLocalProvider) return;'
+    );
+    expect(bridgeHelperCode).toContain(
+      'if (__mfMatchesSharedProvider(actualProvider, usedShare)) return;'
+    );
     expect(bridgeHelperCode).toContain('bridgeSelections.set(pkg, {');
     expect(bridgeHelperCode).toContain('const loadedShare = await __mfLoadPinnedRuntimeShare(');
     expect(bridgeHelperCode).toContain('if (!actualSelection) return;');
@@ -2423,6 +2420,7 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('const initFrom =');
     expect(code).not.toContain('expectedFrom');
     expect(code).not.toContain('__mfModuleCache.share[usedCacheKey] = normalized;');
+    expect(code.match(/runtimeResolveShareHook/g)).toHaveLength(2);
   });
 
   it('materializes only an originally passed root provider replaced by a later instance', async () => {
@@ -2550,7 +2548,53 @@ describe('virtualRemoteEntry', () => {
     ).toBeUndefined();
   });
 
-  it('preserves a later external provider explicitly selected by the resolveShare hook', async () => {
+  it('restores a plain host provider from the pre-init snapshot after remote registration', async () => {
+    const getScopeRootProvider = await getScopeRootProviderResolver();
+    const hostGet = vi.fn(async () => () => ({ marker: 'host-react' }));
+    const passedProvider = {
+      from: 'webpack-host',
+      version: '18.3.1',
+      get: hostGet,
+    };
+    const rewrittenProvider = {
+      ...passedProvider,
+      from: 'vite-remote',
+    };
+    const shared = { react: { '18.3.1': rewrittenProvider } };
+    const remote = {
+      options: { name: 'vite-remote' },
+      shareScopeMap: { default: shared },
+    };
+
+    expect(
+      getScopeRootProvider(
+        [remote],
+        undefined,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        rewrittenProvider,
+        passedProvider,
+        'version-first'
+      )
+    ).toBe(passedProvider);
+    expect(
+      getScopeRootProvider(
+        [],
+        undefined,
+        shared,
+        'default',
+        'react',
+        '18.3.1',
+        rewrittenProvider,
+        passedProvider,
+        'version-first'
+      )
+    ).toBeUndefined();
+  });
+
+  it('keeps speculative external selection outside the public resolveShare lifecycle', async () => {
     const [selectExternalProvider, resolveExternalProvider] = await Promise.all([
       getExternalSharedProviderSelector(),
       getExternalSharedProviderResolver(),
@@ -2571,24 +2615,18 @@ describe('virtualRemoteEntry', () => {
       version: '18.3.1',
       shareConfig: { singleton: true, requiredVersion: '^18.0.0' },
     };
-    const selectionState: { resolveShareHookUsed?: boolean } = {};
     const resolveShareHook = {
-      emit: (params: any) => ({
-        ...params,
-        resolver: () => ({
-          shared: params.shareScopeMap.default.react['18.3.1'],
-          useTreesShaking: false,
-        }),
+      emit: vi.fn(() => {
+        throw new Error('public resolveShare hook must not run during speculation');
       }),
     };
 
-    const selectedProvider = selectExternalProvider(
+    const selectedProvider = (selectExternalProvider as (...args: any[]) => unknown)(
       shared.react,
       'react',
       localProvider,
       'version-first',
-      resolveShareHook,
-      selectionState
+      resolveShareHook
     );
     const providerEntry = {
       version: '18.3.1',
@@ -2597,7 +2635,7 @@ describe('virtualRemoteEntry', () => {
     };
 
     expect(selectedProvider).toBe(laterProvider);
-    expect(selectionState.resolveShareHookUsed).toBe(true);
+    expect(resolveShareHook.emit).not.toHaveBeenCalled();
     expect(
       resolveExternalProvider(
         [root, sibling],
@@ -2608,24 +2646,9 @@ describe('virtualRemoteEntry', () => {
         providerEntry,
         selectedProvider,
         rootProvider,
-        'version-first',
-        false
+        'version-first'
       )
     ).toEqual({ provider: rootProvider, scopeRootProvider: rootProvider });
-    expect(
-      resolveExternalProvider(
-        [root, sibling],
-        root,
-        shared,
-        'default',
-        'react',
-        providerEntry,
-        selectedProvider,
-        rootProvider,
-        'version-first',
-        selectionState.resolveShareHookUsed
-      )
-    ).toEqual({ provider: laterProvider, scopeRootProvider: undefined });
   });
 
   it('does not give parent authority to a provider registered after the initial snapshot', async () => {
@@ -2644,8 +2667,7 @@ describe('virtualRemoteEntry', () => {
         { version: '19.0.0', provider: laterProvider, registered: true },
         laterProvider,
         undefined,
-        'version-first',
-        false
+        'version-first'
       )
     ).toBeUndefined();
     expect(
@@ -2658,8 +2680,7 @@ describe('virtualRemoteEntry', () => {
         { version: '19.0.0', provider: staleProvider, registered: true },
         staleProvider,
         undefined,
-        'version-first',
-        false
+        'version-first'
       )
     ).toBeUndefined();
   });
@@ -2892,25 +2913,30 @@ describe('virtualRemoteEntry', () => {
     const versionMap: Record<string, RuntimeBridgeProvider> = {
       '18.2.0': registeredProvider,
     };
+    let recordSelection!: (
+      provider: RuntimeBridgeProvider,
+      shareInfo?: Record<string, unknown>
+    ) => void;
     const loadPinnedShare = await getRuntimeBridgeLoader({
-      loadShare: async () => {
-        const pinnedProvider = versionMap['18.3.1'];
-        pinnedProvider.from = 'remote';
-        pinnedProvider.lib = factory;
-        pinnedProvider.loaded = true;
+      loadShare: async (_pkg, options) => {
+        recordSelection(
+          pluginProvider,
+          (options as { customShareInfo?: Record<string, unknown> }).customShareInfo
+        );
+        pluginProvider.from = 'remote';
         return factory;
       },
     });
+    recordSelection = loadPinnedShare.recordSelection;
 
     await expect(
       loadPinnedShare(
         'react',
         { requiredVersion: '^18.0.0' },
         versionMap,
-        '18.3.1',
-        undefined,
-        pluginProvider,
-        false
+        '18.2.0',
+        registeredProvider,
+        registeredProvider
       )
     ).resolves.toMatchObject({
       provider: pluginProvider,
@@ -2921,6 +2947,7 @@ describe('virtualRemoteEntry', () => {
       },
       resolved: { marker: 'plugin-react' },
     });
+    expect(versionMap['18.2.0']).toBe(registeredProvider);
     expect(versionMap['18.3.1']).toBeUndefined();
     expect(pluginProvider.from).toBe('plugin-host');
     expect(pluginProvider.lib).toBeUndefined();
@@ -3372,27 +3399,21 @@ describe('virtualRemoteEntry', () => {
     expect(hostGet).not.toHaveBeenCalled();
   });
 
-  it('uses the runtime resolve hook for external provider selection', async () => {
+  it('does not emit the public resolve hook during external provider speculation', async () => {
     const selectProvider = await getExternalSharedProviderSelector();
-    const pluginProvider = { from: 'plugin-provider', lib: () => ({ marker: 'plugin' }) };
-    const defaultProvider = { from: 'default-provider', lib: () => ({ marker: 'default' }) };
+    const pluginProvider = { from: 'plugin-provider', get: vi.fn() };
+    const defaultProvider = { from: 'default-provider', get: vi.fn() };
     const localProvider = {
       from: 'remote',
-      version: '3.0.0',
+      version: '0.5.0',
       shareConfig: { singleton: true, requiredVersion: '*' },
     };
     const resolveShareHook = {
-      emit: (params: any) => ({
-        ...params,
-        resolver: () => ({
-          shared: params.shareScopeMap.default.react['1.0.0'],
-          useTreesShaking: false,
-        }),
-      }),
+      emit: vi.fn(),
     };
 
     expect(
-      selectProvider(
+      (selectProvider as (...args: any[]) => unknown)(
         {
           '1.0.0': pluginProvider,
           '2.0.0': defaultProvider,
@@ -3402,7 +3423,8 @@ describe('virtualRemoteEntry', () => {
         'version-first',
         resolveShareHook
       )
-    ).toBe(pluginProvider);
+    ).toBe(defaultProvider);
+    expect(resolveShareHook.emit).not.toHaveBeenCalled();
   });
 
   it('tracks hook-selected providers that are not the registered map object', async () => {

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -134,9 +134,21 @@ type RuntimeBridgeProvider = {
   strategy?: string;
 };
 
-async function getRuntimeBridgeLoader(initRes: {
-  loadShare: (pkg: string, options: unknown) => Promise<unknown>;
-}) {
+type RuntimeResolveShareArgs = {
+  shareInfo?: Record<string, unknown>;
+  shareScopeMap?: Record<string, Record<string, Record<string, RuntimeBridgeProvider>>>;
+  resolver: (...args: unknown[]) => {
+    shared: RuntimeBridgeProvider;
+    useTreesShaking?: boolean;
+  };
+};
+
+async function getRuntimeBridgeLoader(
+  initRes: {
+    loadShare: (pkg: string, options: unknown) => Promise<unknown>;
+  },
+  resolveShare?: (args: RuntimeResolveShareArgs) => RuntimeResolveShareArgs | undefined
+) {
   const mod = await import('../virtualRemoteEntry');
   const code = mod.generateRemoteEntry(
     {
@@ -153,58 +165,84 @@ async function getRuntimeBridgeLoader(initRes: {
     'virtual:exposes',
     'serve'
   );
-  const helperCode = code.slice(
+  const lifecycleStateCode = code.slice(
+    code.indexOf('const __mfRuntimeShareLoadIdKey ='),
+    code.indexOf('const initRes = runtimeInit({')
+  );
+  const lifecyclePluginCode = code.slice(
+    code.indexOf('function __mfSharePinLifecyclePlugin()'),
+    code.indexOf('const runtimeResolveShareHook =')
+  );
+  const runtimeBridgeCode = code.slice(
     code.indexOf('const __mfRuntimeProviderOrigins ='),
     code.indexOf('const bridgedProviders =')
   );
+  const helperCode = `${lifecycleStateCode}\n${lifecyclePluginCode}\n${runtimeBridgeCode}`;
 
   let recordSelection = (
     _provider: RuntimeBridgeProvider,
-    _shareInfo?: Record<string, unknown>
+    _shareInfo?: Record<string, unknown>,
+    _shareScopeMap?: RuntimeResolveShareArgs['shareScopeMap']
   ) => {};
+  let runtimeResolveShareListener = (args: RuntimeResolveShareArgs) => args;
   const runtimeResolveShareHook = {
-    on(
-      listener: (args: {
-        shareInfo?: Record<string, unknown>;
-        resolver: () => { shared: RuntimeBridgeProvider };
-      }) => {
-        resolver: () => { shared: RuntimeBridgeProvider };
-      }
-    ) {
-      recordSelection = (provider, shareInfo) => {
-        const args = { shareInfo, resolver: () => ({ shared: provider }) };
-        (listener(args) || args).resolver();
-      };
+    on(listener: (args: RuntimeResolveShareArgs) => RuntimeResolveShareArgs) {
+      runtimeResolveShareListener = listener;
     },
   };
-  const loadPinnedShare = new Function(
+  const helpers = new Function(
     'initRes',
     'runtimeResolveShareHook',
-    `${helperCode}; return __mfLoadPinnedRuntimeShare;`
-  )(initRes, runtimeResolveShareHook) as ((
-    pkg: string,
-    shareConfig: Record<string, unknown>,
-    versionMap: Record<string, RuntimeBridgeProvider>,
-    version: string,
-    currentProvider: RuntimeBridgeProvider | undefined,
-    provider: RuntimeBridgeProvider,
-    providerRegistered?: boolean
-  ) => Promise<
-    | {
-        provider: RuntimeBridgeProvider;
-        selection: {
+    `${helperCode}; return {
+      loadPinnedShare: __mfLoadPinnedRuntimeShare,
+      pinLifecyclePlugin: __mfSharePinLifecyclePlugin()
+    };`
+  )(initRes, runtimeResolveShareHook) as {
+    loadPinnedShare: (
+      pkg: string,
+      shareConfig: Record<string, unknown>,
+      versionMap: Record<string, RuntimeBridgeProvider>,
+      version: string,
+      currentProvider: RuntimeBridgeProvider | undefined,
+      provider: RuntimeBridgeProvider,
+      providerRegistered?: boolean
+    ) => Promise<
+      | {
           provider: RuntimeBridgeProvider;
-          version: string;
-          from: string;
-          registered: boolean;
-        };
-        resolved: unknown;
-      }
-    | undefined
-  >) & {
-    recordSelection(provider: RuntimeBridgeProvider, shareInfo?: Record<string, unknown>): void;
+          selection: {
+            provider: RuntimeBridgeProvider;
+            version: string;
+            from: string;
+            registered: boolean;
+          };
+          resolved: unknown;
+        }
+      | undefined
+    >;
+    pinLifecyclePlugin: {
+      resolveShare: (args: RuntimeResolveShareArgs) => RuntimeResolveShareArgs;
+    };
   };
-  loadPinnedShare.recordSelection = (provider, shareInfo) => recordSelection(provider, shareInfo);
+  recordSelection = (provider, shareInfo, shareScopeMap) => {
+    let args: RuntimeResolveShareArgs = {
+      shareInfo,
+      shareScopeMap,
+      resolver: () => ({ shared: provider }),
+    };
+    args = helpers.pinLifecyclePlugin.resolveShare(args) || args;
+    args = resolveShare?.(args) || args;
+    args = runtimeResolveShareListener(args) || args;
+    args.resolver();
+  };
+  const loadPinnedShare = helpers.loadPinnedShare as typeof helpers.loadPinnedShare & {
+    recordSelection(
+      provider: RuntimeBridgeProvider,
+      shareInfo?: Record<string, unknown>,
+      shareScopeMap?: RuntimeResolveShareArgs['shareScopeMap']
+    ): void;
+  };
+  loadPinnedShare.recordSelection = (provider, shareInfo, shareScopeMap) =>
+    recordSelection(provider, shareInfo, shareScopeMap);
   return loadPinnedShare;
 }
 
@@ -1106,7 +1144,9 @@ describe('virtualRemoteEntry', () => {
     expect(code.slice(aliasCacheLoop, code.indexOf('const __mfSeedOrder ='))).toContain(
       'if (share.treeShaking) continue;'
     );
-    expect(code).toContain('plugins: [__mfTreeShakingSnapshotPlugin(),');
+    expect(code).toContain(
+      'plugins: [__mfSharePinLifecyclePlugin(), __mfTreeShakingSnapshotPlugin(),'
+    );
   });
 
   it('coverage-caches runtime-infer partials even when provider coverage is empty', async () => {
@@ -2683,6 +2723,144 @@ describe('virtualRemoteEntry', () => {
         'version-first'
       )
     ).toBeUndefined();
+  });
+
+  it('exposes the pre-pin provider without changing the default runtime selection', async () => {
+    const rootFactory = () => ({ marker: 'root-react' });
+    const laterFactory = () => ({ marker: 'later-react' });
+    const rootProvider: RuntimeBridgeProvider = {
+      from: 'host',
+      version: '18.3.1',
+      lib: rootFactory,
+      loaded: true,
+    };
+    const laterProvider: RuntimeBridgeProvider = {
+      from: 'rspack',
+      version: '18.3.1',
+      lib: laterFactory,
+      loaded: true,
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.3.1': laterProvider,
+    };
+    const lifecycle: string[] = [];
+    const inspectResolveShare = vi.fn((args: RuntimeResolveShareArgs) => {
+      lifecycle.push('resolveShare');
+      expect(args.shareScopeMap?.default.react['18.3.1']).toBe(laterProvider);
+      return args;
+    });
+    let recordSelection!: (
+      provider: RuntimeBridgeProvider,
+      shareInfo?: Record<string, unknown>,
+      shareScopeMap?: RuntimeResolveShareArgs['shareScopeMap']
+    ) => void;
+    const loadPinnedShare = await getRuntimeBridgeLoader(
+      {
+        loadShare: async (_pkg, options) => {
+          lifecycle.push('loadShare:start');
+          const pinnedProvider = versionMap['18.3.1'];
+          expect(pinnedProvider).not.toBe(laterProvider);
+          recordSelection(
+            pinnedProvider,
+            (options as { customShareInfo?: Record<string, unknown> }).customShareInfo,
+            { default: { react: versionMap } }
+          );
+          lifecycle.push('loadShare:end');
+          return rootFactory;
+        },
+      },
+      inspectResolveShare
+    );
+    recordSelection = loadPinnedShare.recordSelection;
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        laterProvider,
+        rootProvider
+      )
+    ).resolves.toMatchObject({
+      selection: { version: '18.3.1', from: 'host' },
+      resolved: { marker: 'root-react' },
+    });
+    expect(inspectResolveShare).toHaveBeenCalledOnce();
+    expect(lifecycle).toEqual(['loadShare:start', 'resolveShare', 'loadShare:end']);
+    expect(versionMap['18.3.1']).not.toBe(laterProvider);
+    expect(versionMap['18.3.1']).toMatchObject({ from: 'host', loaded: true });
+  });
+
+  it('lets resolveShare select the real pre-pin provider', async () => {
+    const rootFactory = () => ({ marker: 'root-react' });
+    const laterFactory = () => ({ marker: 'later-react' });
+    const rootProvider: RuntimeBridgeProvider = {
+      from: 'host',
+      version: '18.3.1',
+      lib: rootFactory,
+      loaded: true,
+    };
+    const laterProvider: RuntimeBridgeProvider = {
+      from: 'rspack',
+      version: '18.3.1',
+      lib: laterFactory,
+      loaded: true,
+    };
+    const versionMap: Record<string, RuntimeBridgeProvider> = {
+      '18.3.1': laterProvider,
+    };
+    const lifecycle: string[] = [];
+    const overrideResolveShare = vi.fn((args: RuntimeResolveShareArgs) => {
+      lifecycle.push('resolveShare');
+      const selectedProvider = args.shareScopeMap?.default.react['18.3.1'];
+      expect(selectedProvider).toBe(laterProvider);
+      return {
+        ...args,
+        resolver: () => ({ shared: selectedProvider! }),
+      };
+    });
+    let recordSelection!: (
+      provider: RuntimeBridgeProvider,
+      shareInfo?: Record<string, unknown>,
+      shareScopeMap?: RuntimeResolveShareArgs['shareScopeMap']
+    ) => void;
+    const loadPinnedShare = await getRuntimeBridgeLoader(
+      {
+        loadShare: async (_pkg, options) => {
+          lifecycle.push('loadShare:start');
+          const pinnedProvider = versionMap['18.3.1'];
+          expect(pinnedProvider).not.toBe(laterProvider);
+          recordSelection(
+            pinnedProvider,
+            (options as { customShareInfo?: Record<string, unknown> }).customShareInfo,
+            { default: { react: versionMap } }
+          );
+          lifecycle.push('loadShare:end');
+          return laterFactory;
+        },
+      },
+      overrideResolveShare
+    );
+    recordSelection = loadPinnedShare.recordSelection;
+
+    await expect(
+      loadPinnedShare(
+        'react',
+        { requiredVersion: '^18.0.0' },
+        versionMap,
+        '18.3.1',
+        laterProvider,
+        rootProvider
+      )
+    ).resolves.toMatchObject({
+      provider: laterProvider,
+      selection: { version: '18.3.1', from: 'rspack' },
+      resolved: { marker: 'later-react' },
+    });
+    expect(overrideResolveShare).toHaveBeenCalledOnce();
+    expect(lifecycle).toEqual(['loadShare:start', 'resolveShare', 'loadShare:end']);
+    expect(versionMap['18.3.1']).toBe(laterProvider);
   });
 
   it('awaits and materializes a loading-only external provider', async () => {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -30,6 +30,29 @@ type MockRequire = NodeJS.Require & {
   resolve: NodeJS.RequireResolve;
 };
 
+function expectLiveSingletonProxy(generatedCode: string, pkg: string, namedExports: string[]) {
+  const cacheDescriptor = JSON.stringify({
+    canonical: `default:${pkg}`,
+    aliases: [pkg],
+  });
+  const exportList = namedExports.map((name, index) => `__mf_${index} as ${name}`).join(', ');
+
+  expect(generatedCode).toContain('let __mfDefaultExport;');
+  namedExports.forEach((name, index) => {
+    expect(generatedCode).toContain(`let __mf_${index};`);
+    expect(generatedCode).toContain(`__mf_${index} = mod[${JSON.stringify(name)}];`);
+  });
+  expect(generatedCode).toContain('const __mfApplySharedExports = (mod) => {');
+  expect(generatedCode).toContain('__mfDefaultExport = (() => {');
+  expect(generatedCode).toContain(
+    `__mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplySharedExports);`
+  );
+  expect(generatedCode).toContain('__mfApplySharedExports(exportModule);');
+  expect(generatedCode).toContain('export { __mfDefaultExport as default };');
+  expect(generatedCode).toContain(`export { ${exportList} };`);
+  expect(generatedCode).not.toMatch(/const \{[^}]+\} = exportModule;/);
+}
+
 describe('tree-shaking graph ids', () => {
   it('adds, reads, replaces, and strips the graph token without losing other query data', () => {
     const tagged = addTreeShakingGraphQuery('/pkg/index.js?raw=true#fragment', '@scope/pkg');
@@ -82,6 +105,7 @@ vi.mock('../../utils/packageUtils', () => ({
             if (value !== undefined) return value;
             const aliases = descriptor.aliases || [];
             for (const alias of aliases) {
+              if (!Object.prototype.hasOwnProperty.call(cache, alias)) continue;
               const aliasValue = cache[alias];
               if (aliasValue !== undefined) {
                 cache[descriptor.canonical] = aliasValue;
@@ -90,11 +114,60 @@ vi.mock('../../utils/packageUtils', () => ({
             }
             return undefined;
           };
-          const __mfWriteSharedCache = (cache, descriptor, value) => {
+          const __mfSharedCacheListenersKey = Symbol.for("module-federation.shared-cache-listeners");
+          const __mfGetSharedCacheListeners = (cache) => {
+            let listeners = cache[__mfSharedCacheListenersKey];
+            if (listeners === undefined) {
+              listeners = Object.create(null);
+              Object.defineProperty(cache, __mfSharedCacheListenersKey, {
+                value: listeners,
+                enumerable: false,
+                configurable: false,
+                writable: false
+              });
+            }
+            return listeners;
+          };
+          const __mfSubscribeSharedCache = (cache, descriptor, listener) => {
+            const listeners = __mfGetSharedCacheListeners(cache);
+            (listeners[descriptor.canonical] ||= new Set()).add(listener);
+          };
+          const __mfSharedCacheOwnersKey = Symbol.for("module-federation.shared-cache-owners");
+          const __mfGetSharedCacheOwners = (cache) => {
+            let owners = cache[__mfSharedCacheOwnersKey];
+            if (owners === undefined) {
+              owners = Object.create(null);
+              Object.defineProperty(cache, __mfSharedCacheOwnersKey, {
+                value: owners,
+                enumerable: false,
+                configurable: false,
+                writable: false
+              });
+            }
+            return owners;
+          };
+          const __mfReadSharedCacheOwner = (cache, descriptor) =>
+            cache[__mfSharedCacheOwnersKey]?.[descriptor.canonical];
+          const __mfWriteSharedCache = (cache, descriptor, value, owner) => {
             cache[descriptor.canonical] = value;
             const aliases = descriptor.aliases || [];
             for (const alias of aliases) {
-              if (cache[alias] === undefined) cache[alias] = value;
+              Object.defineProperty(cache, alias, {
+                value,
+                enumerable: true,
+                configurable: true,
+                writable: true
+              });
+            }
+            const owners = cache[__mfSharedCacheOwnersKey];
+            if (owner === undefined) {
+              if (owners) delete owners[descriptor.canonical];
+            } else {
+              __mfGetSharedCacheOwners(cache)[descriptor.canonical] = owner;
+            }
+            const listeners = cache[__mfSharedCacheListenersKey]?.[descriptor.canonical];
+            if (listeners) {
+              for (const listener of listeners) listener(value);
             }
             return value;
           };`,
@@ -143,8 +216,17 @@ vi.mock('../../utils/packageUtils', () => ({
     ) {
       return '/repo/apps/remote/node_modules/mock-package-browser-conditional/dist/browser.js';
     }
+    if (pkg === 'mock-package-dual-shape') {
+      return '/repo/apps/remote/node_modules/mock-package-dual-shape/dist/browser.js';
+    }
+    if (pkg === 'mock-package-cjs-comment') {
+      return '/repo/apps/remote/node_modules/mock-package-cjs-comment/index.js';
+    }
     if (pkg === 'workspace-shared-lib') {
       return '/repo/packages/workspace-shared-lib/src/index.tsx';
+    }
+    if (pkg === 'workspace-unknown-exports') {
+      return '/repo/packages/workspace-unknown-exports/src/index.ts';
     }
     if (pkg === 'workspace-esm-symlink') {
       return '/repo/apps/remote/node_modules/workspace-esm-symlink/src/index.ts';
@@ -180,6 +262,13 @@ vi.mock('../../utils/packageUtils', () => ({
         path: '/repo/packages/workspace-shared-lib/package.json',
         dir: '/repo/packages/workspace-shared-lib',
         packageJson: { name: 'workspace-shared-lib' },
+      };
+    }
+    if (opts?.fromResolvedEntry?.includes('/repo/packages/workspace-unknown-exports/')) {
+      return {
+        path: '/repo/packages/workspace-unknown-exports/package.json',
+        dir: '/repo/packages/workspace-unknown-exports',
+        packageJson: { name: 'workspace-unknown-exports' },
       };
     }
     if (
@@ -321,7 +410,13 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-browser-conditional/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-browser-conditional/dist/server.js') ||
       filePath.endsWith('/mock-package-browser-conditional/dist/server.js') ||
+      filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js') ||
+      filePath.endsWith('/mock-package-dual-shape/dist/browser.js') ||
+      filePath.endsWith('node_modules/mock-package-cjs-comment/index.js') ||
+      filePath.endsWith('/mock-package-cjs-comment/index.js') ||
       filePath.endsWith('/repo/packages/workspace-shared-lib/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-unknown-exports/package.json') ||
+      filePath.endsWith('/repo/packages/workspace-unknown-exports/src/index.ts') ||
       filePath.endsWith('/repo/packages/workspace-name-mismatch/package.json') ||
       filePath.endsWith('/repo/packages/workspace-cycle-a/package.json') ||
       filePath.endsWith('/repo/packages/workspace-cycle-b/package.json') ||
@@ -331,13 +426,104 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/workspace-dual-format/package.json') ||
       filePath.endsWith('/repo/packages/workspace-dual-format/dist/index.js') ||
       filePath.endsWith('/repo/packages/mock-package-star-entry.js') ||
+      filePath.endsWith('/repo/packages/default-only.js') ||
+      filePath.endsWith('/repo/packages/default-only-cjs-lookalikes.js') ||
+      filePath.endsWith('/repo/packages/typescript-cjs-barrel.js') ||
+      filePath.endsWith('/repo/packages/babel-cjs-barrel.js') ||
+      filePath.endsWith('/repo/packages/default-with-unknown-star.js') ||
+      filePath.endsWith('/repo/packages/partial-with-unknown-star.js') ||
+      filePath.endsWith('/repo/packages/barrel-with-cjs-star.js') ||
+      filePath.endsWith('/repo/packages/hidden.cjs') ||
+      filePath.endsWith('/repo/packages/multi-declarator.js') ||
+      filePath.endsWith('/repo/packages/postfix-multi-declarator.js') ||
+      filePath.endsWith('/repo/packages/string-export-list.js') ||
+      filePath.endsWith('/repo/packages/string-namespace-export.js') ||
+      filePath.endsWith('/repo/packages/nested-destructuring.js') ||
+      filePath.endsWith('/repo/packages/defaulted-destructuring.js') ||
+      filePath.endsWith('/repo/packages/typed-destructuring.ts') ||
+      filePath.endsWith('/repo/packages/decorated-export.ts') ||
+      filePath.endsWith('/repo/packages/export-import-alias.ts') ||
       filePath.endsWith('/repo/packages/custom-shared-source/index.ts')
     );
   }),
   readFileSync: vi.fn((filePath: string) => {
     filePath = normalizePathForImport(filePath);
     if (filePath.endsWith('/repo/packages/mock-package-star-entry.js')) {
-      return "export * from 'mock-package-star-dependency'; export const directExport = 1;";
+      return `// docs: export * from './missing-comment';
+const snippet = "export * from './missing-string'";
+export * from 'mock-package-star-dependency'; export const directExport = 1;`;
+    }
+    if (filePath.endsWith('/repo/packages/default-only.js')) {
+      return `// docs: export * from './missing-comment';
+const snippet = "export const phantom = 1";
+const pattern = /export\\s+\\*\\s+from/;
+export default function createDefaultOnly() {}`;
+    }
+    if (filePath.endsWith('/repo/packages/default-only-cjs-lookalikes.js')) {
+      return `// Object.defineProperty(exports, "__esModule", { value: true });
+const typescriptSnippet = "__exportStar(require('./dependency'), exports)";
+const babelSnippet = 'Object.defineProperty(exports, "named", descriptor)';
+const assignmentSnippet = 'exports = module.exports';
+const markerPattern = /exports\\s*(?:[,)]|=(?!=|>))/;
+export default function createDefaultOnly() {}`;
+    }
+    if (filePath.endsWith('/repo/packages/typescript-cjs-barrel.js')) {
+      return `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./dependency"), exports);`;
+    }
+    if (filePath.endsWith('/repo/packages/babel-cjs-barrel.js')) {
+      return `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var dependency = require("./dependency");
+Object.keys(dependency).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () { return dependency[key]; }
+  });
+});`;
+    }
+    if (filePath.endsWith('/repo/packages/default-with-unknown-star.js')) {
+      return "export default {}; export * from 'unresolved-virtual-module';";
+    }
+    if (filePath.endsWith('/repo/packages/partial-with-unknown-star.js')) {
+      return "export const visible = 1; export * from 'unresolved-virtual-module';";
+    }
+    if (filePath.endsWith('/repo/packages/barrel-with-cjs-star.js')) {
+      return "export const visible = 1; export * from './hidden.cjs';";
+    }
+    if (filePath.endsWith('/repo/packages/hidden.cjs')) {
+      return "module['exports'] = { hidden: 1 };";
+    }
+    if (filePath.endsWith('/repo/packages/multi-declarator.js')) {
+      return `export const first =
+  /\\{;/,
+  second = 2;`;
+    }
+    if (filePath.endsWith('/repo/packages/postfix-multi-declarator.js')) {
+      return 'export let first = count++ / total, second = /x/;';
+    }
+    if (filePath.endsWith('/repo/packages/string-export-list.js')) {
+      return 'const foo = 1; export { foo as "a-b", foo as valid };';
+    }
+    if (filePath.endsWith('/repo/packages/string-namespace-export.js')) {
+      return `export const visible = 1; export * as "a-b" from './dependency.js';`;
+    }
+    if (filePath.endsWith('/repo/packages/nested-destructuring.js')) {
+      return 'export const visible = 1; export const { nested: { a, b } } = obj;';
+    }
+    if (filePath.endsWith('/repo/packages/defaulted-destructuring.js')) {
+      return 'export const visible = 1; export const { a = fn(1, fake), b } = obj;';
+    }
+    if (filePath.endsWith('/repo/packages/typed-destructuring.ts')) {
+      return 'export const visible = 1; export const { a, b }: Actions = obj;';
+    }
+    if (filePath.endsWith('/repo/packages/decorated-export.ts')) {
+      return 'export const visible = 1; export @dec class Foo {}';
+    }
+    if (filePath.endsWith('/repo/packages/export-import-alias.ts')) {
+      return 'export const visible = 1; export import Alias = Namespace;';
     }
     if (filePath.endsWith('node_modules/mock-package-star-dependency/index.js')) {
       return 'export const fromStar = 1; export function anotherFromStar() {}';
@@ -463,7 +649,10 @@ export { type, other } from './foo';`;
       });
     }
     if (filePath.endsWith('node_modules/mock-package-enum-destructure/src/index.js')) {
-      return `export enum Color {
+      return `export abstract class Base {}
+export const enum Direction { Up }
+export module LegacyModule {}
+export enum Color {
   Red = 'red',
   Blue = 'blue',
 }
@@ -492,13 +681,25 @@ export const [firstItem, ...restItems] = tuple;`;
       });
     }
     if (filePath.endsWith('node_modules/mock-package-browser-conditional/dist/browser.js')) {
-      return 'export const clientOnly = true;';
+      return '// module.exports = legacy;\nexport const clientOnly = true;';
     }
     if (filePath.endsWith('node_modules/mock-package-browser-conditional/dist/server.js')) {
       return 'export const serverOnly = true;';
     }
+    if (filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js')) {
+      return 'export const browserNamed = true;';
+    }
+    if (filePath.endsWith('node_modules/mock-package-cjs-comment/index.js')) {
+      return "// export const phantom = 1;\nmodule['exports'] = { real: 1 };";
+    }
     if (filePath.endsWith('/repo/packages/workspace-shared-lib/package.json')) {
       return JSON.stringify({ name: 'workspace-shared-lib' });
+    }
+    if (filePath.endsWith('/repo/packages/workspace-unknown-exports/package.json')) {
+      return JSON.stringify({ name: 'workspace-unknown-exports' });
+    }
+    if (filePath.endsWith('/repo/packages/workspace-unknown-exports/src/index.ts')) {
+      return "export default {}; export * from 'unresolved-workspace-module';";
     }
     if (filePath.endsWith('/repo/packages/workspace-name-mismatch/package.json')) {
       return JSON.stringify({ name: 'different-package-name' });
@@ -595,6 +796,39 @@ vi.mock('module', async (importOriginal) => {
             __esModule: true,
           };
         }
+        if (pkg === 'mock-package-string-export') {
+          return {
+            'foo-bar': 1,
+            default: {},
+            __esModule: true,
+          };
+        }
+        if (pkg.endsWith('/mock-package-cjs-comment/index.js')) {
+          return {
+            real: 1,
+            default: {},
+            __esModule: true,
+          };
+        }
+        if (pkg.endsWith('/typescript-cjs-barrel.js')) {
+          return {
+            typescriptNamed: 1,
+            default: {},
+            __esModule: true,
+          };
+        }
+        if (pkg.endsWith('/babel-cjs-barrel.js')) {
+          return {
+            babelNamed: 1,
+            default: {},
+            __esModule: true,
+          };
+        }
+        if (pkg.endsWith('/default-only-cjs-lookalikes.js')) {
+          const error = new Error('ERR_REQUIRE_ESM');
+          (error as Error & { code?: string }).code = 'ERR_REQUIRE_ESM';
+          throw error;
+        }
         if (pkg === 'workspace-producer') {
           return {
             useProducer: () => 1,
@@ -604,6 +838,9 @@ vi.mock('module', async (importOriginal) => {
           };
         }
         if (pkg === 'transitive-pkg') {
+          throw new Error('MODULE_NOT_FOUND');
+        }
+        if (pkg === 'host-only-dep') {
           throw new Error('MODULE_NOT_FOUND');
         }
         if (pkg === 'mock-package-esm-only/stores') {
@@ -696,6 +933,9 @@ vi.mock('module', async (importOriginal) => {
           if (pkg === 'workspace-shared-lib') {
             return '/repo/packages/workspace-shared-lib/src/index.tsx';
           }
+          if (pkg === 'workspace-unknown-exports') {
+            return '/repo/packages/workspace-unknown-exports/src/index.ts';
+          }
           if (pkg === 'workspace-esm-symlink') {
             const error = new Error('ERR_PACKAGE_PATH_NOT_EXPORTED');
             (error as Error & { code?: string }).code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
@@ -776,17 +1016,40 @@ describe('writeLoadShareModule', () => {
     expect(writeSyncSpy).toHaveBeenCalled();
     const generatedCode = writeSyncSpy.mock.calls[0][0];
 
-    // Destructuring should alias the keys
-    // const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;
-    expect(generatedCode).toContain(
-      'const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;'
-    );
+    expectLiveSingletonProxy(generatedCode, pkg, ['delete', 'get', 'request']);
+  });
 
-    // Export uses aliased keys AS the original keys
-    // export { __mf_0 as delete, __mf_1 as get, __mf_2 as request };
+  it('uses live exported bindings for eager singleton proxies with known named exports', () => {
+    const pkg = 'mock-package-browser-conditional';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    const cacheDescriptor =
+      '{"canonical":"default:mock-package-browser-conditional","aliases":["mock-package-browser-conditional"]}';
+
+    expect(generatedCode).toContain('let __mfDefaultExport;');
+    expect(generatedCode).toContain('let __mf_0;');
+    expect(generatedCode).toContain('const __mfApplySharedExports = (mod) => {');
+    expect(generatedCode).toContain('__mf_0 = mod["clientOnly"];');
     expect(generatedCode).toContain(
-      'export { __mf_0 as delete, __mf_1 as get, __mf_2 as request };'
+      `__mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplySharedExports);`
     );
+    expect(generatedCode).toContain('__mfApplySharedExports(exportModule);');
+    expect(generatedCode).toContain('export { __mfDefaultExport as default };');
+    expect(generatedCode).toContain('export { __mf_0 as clientOnly };');
+    expect(generatedCode).not.toContain('const { clientOnly: __mf_0 } = exportModule;');
   });
 
   it('aliases reserved named exports in prebuild wrappers instead of declaring them', () => {
@@ -821,7 +1084,7 @@ describe('writeLoadShareModule', () => {
     );
   });
 
-  it('uses prebuild aliases with configured import sources', () => {
+  it('keeps an uninspectable configured prebuild source authoritative', () => {
     const mockShareItem: ShareItem = {
       name: 'mock-package-with-reserved',
       from: '',
@@ -841,12 +1104,11 @@ describe('writeLoadShareModule', () => {
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
     expect(generatedCode).toContain(
-      'import * as __mfPrebuildNamespace from "/abs/mock-package-with-reserved/index.js";'
+      'import * as __mfPrebuildExports from "/abs/mock-package-with-reserved/index.js";'
     );
-    expect(generatedCode).not.toContain('export const delete');
-    expect(generatedCode).toContain(
-      'export { __mf_0 as delete, __mf_1 as get, __mf_2 as request };'
-    );
+    expect(generatedCode).toContain('export * from "/abs/mock-package-with-reserved/index.js";');
+    expect(generatedCode).not.toContain('__mfPrebuildNamespace');
+    expect(generatedCode).not.toContain('__mf_0 as delete');
   });
 
   it('detects prebuild named exports from shareConfig.import when it points at a non-package module', () => {
@@ -954,7 +1216,7 @@ describe('writeLoadShareModule', () => {
       '__mfReadSharedCache(__mfModuleCache.share, {"canonical":"default:react","aliases":["react"]})'
     );
     expect(generatedCode).toContain(
-      '__mfWriteSharedCache(__mfModuleCache.share, {"canonical":"default:react","aliases":["react"]}, exportModule)'
+      '__mfWriteSharedCache(__mfModuleCache.share, {"canonical":"default:react","aliases":["react"]}, exportModule, "test")'
     );
     expect(generatedCode).not.toContain(
       'let exportModule = __mfModuleCache.share["default:react"]'
@@ -979,8 +1241,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const __mfDefaultExport = (() => {');
-    expect(generatedCode).toContain('export default __mfDefaultExport;');
+    expectLiveSingletonProxy(generatedCode, pkg, ['delete', 'get', 'request']);
   });
 
   it('uses shareConfig.import as the concrete import source when provided', () => {
@@ -1029,12 +1290,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       'import * as __mfLocalShare from "/repo/packages/custom-shared-source";'
     );
-    expect(generatedCode).toContain(
-      'const { sharedValue: __mf_0, useSharedFeature: __mf_1 } = exportModule;'
-    );
-    expect(generatedCode).toContain(
-      'export { __mf_0 as sharedValue, __mf_1 as useSharedFeature };'
-    );
+    expectLiveSingletonProxy(generatedCode, pkg, ['sharedValue', 'useSharedFeature']);
     expect(generatedCode).not.toContain('export * from "/repo/packages/custom-shared-source"');
     expect(generatedCode).not.toContain('mock-import-id');
   });
@@ -1058,15 +1314,10 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
-      'const { directExport: __mf_0, fromStar: __mf_1, anotherFromStar: __mf_2 } = exportModule;'
-    );
-    expect(generatedCode).toContain(
-      'export { __mf_0 as directExport, __mf_1 as fromStar, __mf_2 as anotherFromStar };'
-    );
+    expectLiveSingletonProxy(generatedCode, pkg, ['directExport', 'fromStar', 'anotherFromStar']);
   });
 
-  it('falls back to package-based named export detection when shareConfig.import cannot be inspected', () => {
+  it('keeps an uninspectable configured singleton proxy on one local module', () => {
     const pkg = 'mock-package-with-reserved';
     const mockShareItem: ShareItem = {
       name: pkg,
@@ -1088,12 +1339,493 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       'import * as __mfLocalShare from "/missing/mock-package-with-reserved/index.js";'
     );
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export default __mfDefaultExport;');
+    expect(generatedCode).toContain('export * from "/missing/mock-package-with-reserved/index.js"');
+    expect(generatedCode).not.toContain('__mfSubscribeSharedCache(__mfModuleCache.share');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as delete');
+  });
+
+  it('keeps a complete default-only ESM singleton live across cache replacement', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/default-only.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const __mfApplySharedDefaultExport = (mod) => {');
+    expect(generatedCode).toContain('__mfApplySharedDefaultExport(exportModule);');
+    expect(generatedCode).toContain('export { __mfDefaultExport as default };');
+    expect(generatedCode).toContain('export * from "/repo/packages/default-only.js"');
+    expect(generatedCode).not.toContain('let current = __mfLocalShare;');
+    expect(generatedCode).not.toContain('phantom');
+  });
+
+  it.each([
+    ['TypeScript', '/repo/packages/typescript-cjs-barrel.js', 'typescriptNamed'],
+    ['Babel', '/repo/packages/babel-cjs-barrel.js', 'babelNamed'],
+  ])('uses runtime keys for %s-transpiled CommonJS barrels', (_transpiler, importPath, name) => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: importPath,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expectLiveSingletonProxy(generatedCode, pkg, [name]);
+    expect(generatedCode).not.toContain(`export * from ${JSON.stringify(importPath)}`);
+  });
+
+  it('ignores CommonJS export markers in comments, strings, and regular expressions', () => {
+    const pkg = 'mock-package-with-reserved';
+    const importPath = '/repo/packages/default-only-cjs-lookalikes.js';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: importPath,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const __mfApplySharedDefaultExport = (mod) => {');
+    expect(generatedCode).toContain(`export * from ${JSON.stringify(importPath)}`);
+    expect(generatedCode).not.toContain('let current = __mfLocalShare;');
+  });
+
+  it('does not treat a default export with unresolved star exports as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/default-with-unknown-star.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export * from "/repo/packages/default-with-unknown-star.js"');
+    expect(generatedCode).not.toContain('__mfSubscribeSharedCache(__mfModuleCache.share');
+    expect(generatedCode).not.toContain('__mfApplySharedDefaultExport');
+  });
+
+  it('does not treat partial exports with an unresolved star as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/partial-with-unknown-star.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export * from "/repo/packages/partial-with-unknown-star.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+  });
+
+  it('does not treat an ESM barrel over CommonJS as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/barrel-with-cjs-star.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export * from "/repo/packages/barrel-with-cjs-star.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+  });
+
+  it('does not treat multi-declarator exports as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/multi-declarator.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export * from "/repo/packages/multi-declarator.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as first');
+  });
+
+  it('detects multi-declarators after postfix division expressions', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/postfix-multi-declarator.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/postfix-multi-declarator.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as first');
+  });
+
+  it('does not treat string-named export lists as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/string-export-list.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/string-export-list.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as valid');
+  });
+
+  it('does not treat string-named namespace exports as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/string-namespace-export.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/string-namespace-export.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+  });
+
+  it('does not treat nested destructuring exports as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/nested-destructuring.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/nested-destructuring.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+  });
+
+  it('does not infer bogus exports from defaulted destructuring expressions', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/defaulted-destructuring.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/defaulted-destructuring.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+    expect(generatedCode).not.toContain('as fake');
+  });
+
+  it('does not treat typed destructuring exports as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/typed-destructuring.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/typed-destructuring.ts"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+  });
+
+  it('does not treat decorated exports as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/decorated-export.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/decorated-export.ts"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+  });
+
+  it('treats TypeScript export-import aliases as unknown coverage', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/export-import-alias.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+    expect(generatedCode).not.toContain('__mf_0 as visible');
+  });
+
+  it('keeps unknown configured exports local in remote-only serve mode', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: { './App': './src/App.ts' },
+    });
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/missing/virtual-shared-module.js',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
     expect(generatedCode).toContain(
-      'const { delete: __mf_0, get: __mf_1, request: __mf_2 } = exportModule;'
+      'import * as __mfLocalShare from "/missing/virtual-shared-module.js";'
     );
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export * from "/missing/virtual-shared-module.js"');
+    expect(generatedCode).not.toContain('__mfApplyLazyShareExports');
+    expect(generatedCode).not.toContain('pendingShareLoads');
+  });
+
+  it('statically imports unknown workspace exports in serve mode', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: { './App': './src/App.ts' },
+    });
+    const pkg = 'workspace-unknown-exports';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/workspace-unknown-exports/src/index.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
     expect(generatedCode).toContain(
-      'export { __mf_0 as delete, __mf_1 as get, __mf_2 as request };'
+      'import * as __mfLocalShare from "/repo/packages/workspace-unknown-exports/src/index.ts";'
     );
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).not.toContain('__mfApplyLazyShareExports');
+  });
+
+  it('uses a direct local source for unknown workspace exports in build mode', () => {
+    const pkg = 'workspace-unknown-exports';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    const localSource = '/repo/packages/workspace-unknown-exports/src/index.ts';
+
+    expect(generatedCode).toContain(`import * as __mfLocalShare from "${localSource}";`);
+    expect(generatedCode).toContain(`export * from "${localSource}"`);
+    expect(generatedCode).not.toContain('__prebuild__');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+  });
+
+  it('treats unsupported runtime export names as unknown coverage', () => {
+    const pkg = 'mock-package-string-export';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain('export * from "/resolved/mock-package-string-export"');
+    expect(generatedCode).not.toContain('__prebuild__');
+    expect(generatedCode).not.toContain('__mfApplySharedDefaultExport');
   });
 
   it('detects named exports from the ESM entry of configured bare import sources', () => {
@@ -1118,8 +1850,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       'import * as __mfLocalShare from "mock-package-browser-conditional";'
     );
-    expect(generatedCode).toContain('const { clientOnly: __mf_0 } = exportModule;');
-    expect(generatedCode).toContain('export { __mf_0 as clientOnly };');
+    expectLiveSingletonProxy(generatedCode, pkg, ['clientOnly']);
     expect(generatedCode).not.toContain('serverOnly');
   });
 
@@ -1193,10 +1924,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
-      'const { useCounter: __mf_0, useLogger: __mf_1 } = exportModule;'
-    );
-    expect(generatedCode).toContain('export { __mf_0 as useCounter, __mf_1 as useLogger };');
+    expectLiveSingletonProxy(generatedCode, pkg, ['useCounter', 'useLogger']);
     expect(generatedCode).not.toContain('export * from');
   });
 
@@ -1218,8 +1946,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('const { ångstrom: __mf_0, café: __mf_1 } = exportModule;');
-    expect(generatedCode).toContain('export { __mf_0 as ångstrom, __mf_1 as café };');
+    expectLiveSingletonProxy(generatedCode, pkg, ['ångstrom', 'café']);
   });
 
   it('does not reference prebuild modules when import: false', () => {
@@ -1337,6 +2064,53 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).toContain('__mf_0 as clientOnly');
     expect(generatedCode).not.toContain('serverOnly');
+  });
+
+  it('uses the Vite import entry when the require condition has a different shape', () => {
+    const pkg = 'mock-package-dual-shape';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('__mf_0 as browserNamed');
+    expect(mfWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses CommonJS runtime keys instead of comment-like ESM syntax', () => {
+    const pkg = 'mock-package-cjs-comment';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('__mf_0 as real');
+    expect(generatedCode).not.toContain('phantom');
+    expect(mfWarnSpy).not.toHaveBeenCalled();
   });
 
   it('prefers browser conditional exports for project-resolved import paths', () => {
@@ -1542,6 +2316,13 @@ describe('writeLoadShareModule', () => {
     // `export enum Color` is a runtime value and must be re-exported.
     expect(generatedCode).toContain('exportModule["Color"]');
     expect(generatedCode).toContain('as Color');
+    expect(generatedCode).toContain('exportModule["Base"]');
+    expect(generatedCode).toContain('as Base');
+    expect(generatedCode).toContain('exportModule["Direction"]');
+    expect(generatedCode).toContain('as Direction');
+    expect(generatedCode).toContain('exportModule["LegacyModule"]');
+    expect(generatedCode).toContain('as LegacyModule');
+    expect(generatedCode).not.toContain('as enum');
     // Destructuring exports (e.g. createSlice actions) keep their bound names.
     expect(generatedCode).toContain('exportModule["createActionAddItem"]');
     expect(generatedCode).toContain('as createActionAddItem');
@@ -1606,6 +2387,13 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('initPromise.then');
     expect(generatedCode).not.toContain('await ');
     expect(generatedCode.match(/let exportModule/g)?.length ?? 0).toBe(1);
+    expect(generatedCode).toContain('let __mf_default;');
+    expect(generatedCode).toContain('const __mfApplyLazyShareExports = (mod) => {');
+    expect(generatedCode).toContain('__mf_default = mod.default ?? mod;');
+    expect(generatedCode).toContain(
+      '__mfSubscribeSharedCache(__mfModuleCache.share, {"canonical":"default:workspace-shared-lib","aliases":["workspace-shared-lib"]}, __mfApplyLazyShareExports);'
+    );
+    expect(generatedCode).toContain('export { __mf_default as default };');
   });
 
   it('prepends workspace singleton static import for SSR build loads only', async () => {
@@ -1691,6 +2479,13 @@ describe('writeLoadShareModule', () => {
       'import * as __mfLocalShare from "/repo/packages/workspace-cycle-a/src/index.ts";'
     );
     expect(generatedCode).toContain('export { __mf_default as default };');
+    expect(generatedCode).toContain('let __mf_default;');
+    expect(generatedCode).toContain('const __mfApplyEagerShareExports = (mod) => {');
+    expect(generatedCode).toContain('__mf_default = mod.default ?? mod;');
+    expect(generatedCode).toContain(
+      '__mfSubscribeSharedCache(__mfModuleCache.share, {"canonical":"default:workspace-cycle-a","aliases":["workspace-cycle-a"]}, __mfApplyEagerShareExports);'
+    );
+    expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
     expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).not.toContain('await ');
     expect(generatedCode).toContain('Promise.resolve().then');
@@ -1733,8 +2528,17 @@ describe('writeLoadShareModule', () => {
       'import * as __mfLocalShare from "/repo/packages/workspace-producer/src/index.ts";'
     );
     expect(generatedCode).toContain('export { __mf_default as default };');
-    expect(generatedCode).toContain('const __mf_0 = exportModule["useProducer"];');
-    expect(generatedCode).toContain('const __mf_1 = exportModule["createProducer"];');
+    expect(generatedCode).toContain('let __mf_default;');
+    expect(generatedCode).toContain('let __mf_0;');
+    expect(generatedCode).toContain('let __mf_1;');
+    expect(generatedCode).toContain('const __mfApplyEagerShareExports = (mod) => {');
+    expect(generatedCode).toContain('__mf_0 = mod["useProducer"];');
+    expect(generatedCode).toContain('__mf_1 = mod["createProducer"];');
+    expect(generatedCode).toContain('__mf_default = mod.default ?? mod;');
+    expect(generatedCode).toContain(
+      '__mfSubscribeSharedCache(__mfModuleCache.share, {"canonical":"default:workspace-producer","aliases":["workspace-producer"]}, __mfApplyEagerShareExports);'
+    );
+    expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
     expect(generatedCode).toContain('export { __mf_0 as useProducer, __mf_1 as createProducer };');
     expect(generatedCode).not.toContain('export { useProducer, createProducer } from');
     expect(generatedCode).not.toContain('initPromise.then');
@@ -1810,9 +2614,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       'import * as __mfLocalShare from "lit/directives/class-map.js";'
     );
-    expect(generatedCode).toContain('const __mfDefaultExport = (() => {');
-    expect(generatedCode).toContain('export default __mfDefaultExport;');
-    expect(generatedCode).toContain('export { __mf_0 as useCounter, __mf_1 as useLogger };');
+    expectLiveSingletonProxy(generatedCode, pkg, ['useCounter', 'useLogger']);
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('import("lit/directives/class-map.js")');
     expect(generatedCode).not.toContain('const {initPromise} = require(');
@@ -1839,9 +2641,7 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).toContain('const __mfCacheGlobalKey =');
     expect(generatedCode).toContain('import * as __mfLocalShare from "lit";');
-    expect(generatedCode).toContain('const __mfDefaultExport = (() => {');
-    expect(generatedCode).toContain('export default __mfDefaultExport;');
-    expect(generatedCode).toContain('export { __mf_0 as useCounter, __mf_1 as useLogger };');
+    expectLiveSingletonProxy(generatedCode, pkg, ['useCounter', 'useLogger']);
     expect(generatedCode).not.toContain('__prebuild__');
     expect(generatedCode).not.toContain('import("lit")');
     expect(generatedCode).not.toContain('const {initPromise} = require(');
@@ -2037,7 +2837,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('await ');
   });
 
-  it('generates ESM loadShare wrappers for vue root share in serve mode', () => {
+  it('generates a live default binding for default-only vue singletons in serve mode', () => {
     const pkg = 'vue';
     const mockShareItem: ShareItem = {
       name: pkg,
@@ -2054,10 +2854,19 @@ describe('writeLoadShareModule', () => {
     writeLoadShareModule(pkg, mockShareItem, 'serve', false);
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    const cacheDescriptor = '{"canonical":"default:vue","aliases":["vue"]}';
 
     expect(generatedCode).toContain('const __mfCacheGlobalKey =');
-    expect(generatedCode).toContain('export default exportModule.default ?? exportModule');
-    expect(generatedCode).toContain('export * from');
+    expect(generatedCode).toContain('let __mfDefaultExport;');
+    expect(generatedCode).toContain('const __mfApplySharedDefaultExport = (mod) => {');
+    expect(generatedCode).toContain('__mfDefaultExport = mod.default ?? mod;');
+    expect(generatedCode).toContain(
+      `__mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplySharedDefaultExport);`
+    );
+    expect(generatedCode).toContain('__mfApplySharedDefaultExport(exportModule);');
+    expect(generatedCode).toContain('export { __mfDefaultExport as default };');
+    expect(generatedCode).toContain('export * from "mock-import-id"');
+    expect(generatedCode).not.toContain('export default exportModule.default ?? exportModule');
     expect(generatedCode).not.toContain('module.exports = exportModule');
     expect(generatedCode).not.toContain('await ');
   });

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -427,6 +427,7 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/workspace-dual-format/dist/index.js') ||
       filePath.endsWith('/repo/packages/mock-package-star-entry.js') ||
       filePath.endsWith('/repo/packages/default-only.js') ||
+      filePath.endsWith('/repo/packages/default-only-type-exports.ts') ||
       filePath.endsWith('/repo/packages/default-only-export-lookalikes.js') ||
       filePath.endsWith('/repo/packages/minified-star-export.js') ||
       filePath.endsWith('/repo/packages/comment-separated-star-export.js') ||
@@ -460,6 +461,12 @@ export * from 'mock-package-star-dependency'; export const directExport = 1;`;
       return `// docs: export * from './missing-comment';
 const snippet = "export const phantom = 1";
 const pattern = /export\\s+\\*\\s+from/;
+export default function createDefaultOnly() {}`;
+    }
+    if (filePath.endsWith('/repo/packages/default-only-type-exports.ts')) {
+      return `export type { Phantom } from './types';
+export interface Shape { value: string }
+export declare const declaredOnly: string;
 export default function createDefaultOnly() {}`;
     }
     if (filePath.endsWith('/repo/packages/default-only-export-lookalikes.js')) {
@@ -1388,6 +1395,33 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('export * from "/repo/packages/default-only.js"');
     expect(generatedCode).not.toContain('let current = __mfLocalShare;');
     expect(generatedCode).not.toContain('phantom');
+  });
+
+  it('ignores erased TypeScript exports when determining live proxy coverage', () => {
+    const pkg = 'mock-package-with-reserved';
+    const importPath = '/repo/packages/default-only-type-exports.ts';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: importPath,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const __mfApplySharedDefaultExport = (mod) => {');
+    expect(generatedCode).toContain(`export * from ${JSON.stringify(importPath)}`);
+    expect(generatedCode).not.toContain('let current = __mfLocalShare;');
+    expect(generatedCode).not.toContain('Phantom');
+    expect(generatedCode).not.toContain('declaredOnly');
   });
 
   it.each([

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -427,6 +427,9 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/workspace-dual-format/dist/index.js') ||
       filePath.endsWith('/repo/packages/mock-package-star-entry.js') ||
       filePath.endsWith('/repo/packages/default-only.js') ||
+      filePath.endsWith('/repo/packages/default-only-export-lookalikes.js') ||
+      filePath.endsWith('/repo/packages/minified-star-export.js') ||
+      filePath.endsWith('/repo/packages/comment-separated-star-export.js') ||
       filePath.endsWith('/repo/packages/default-only-cjs-lookalikes.js') ||
       filePath.endsWith('/repo/packages/typescript-cjs-barrel.js') ||
       filePath.endsWith('/repo/packages/babel-cjs-barrel.js') ||
@@ -458,6 +461,19 @@ export * from 'mock-package-star-dependency'; export const directExport = 1;`;
 const snippet = "export const phantom = 1";
 const pattern = /export\\s+\\*\\s+from/;
 export default function createDefaultOnly() {}`;
+    }
+    if (filePath.endsWith('/repo/packages/default-only-export-lookalikes.js')) {
+      return `// export*from"./comment.js";
+const minifiedSnippet = 'export*from"./string.js"';
+const separatedSnippet = 'export/* comment */*from"./string.js"';
+const markerPattern = /export\\*from/;
+export default function createDefaultOnly() {}`;
+    }
+    if (filePath.endsWith('/repo/packages/minified-star-export.js')) {
+      return 'export*from"./dependency.js";';
+    }
+    if (filePath.endsWith('/repo/packages/comment-separated-star-export.js')) {
+      return 'export/* first */*/* second */from/* third */"./dependency.js";';
     }
     if (filePath.endsWith('/repo/packages/default-only-cjs-lookalikes.js')) {
       return `// Object.defineProperty(exports, "__esModule", { value: true });
@@ -1372,6 +1388,59 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('export * from "/repo/packages/default-only.js"');
     expect(generatedCode).not.toContain('let current = __mfLocalShare;');
     expect(generatedCode).not.toContain('phantom');
+  });
+
+  it.each([
+    ['minified', '/repo/packages/minified-star-export.js'],
+    ['comment-separated', '/repo/packages/comment-separated-star-export.js'],
+  ])('treats an unrecognized %s export declaration as unknown coverage', (_syntax, importPath) => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: importPath,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('let current = __mfLocalShare;');
+    expect(generatedCode).toContain(`export * from ${JSON.stringify(importPath)}`);
+    expect(generatedCode).not.toContain('__mfApplySharedDefaultExport');
+    expect(generatedCode).not.toContain('__mfSubscribeSharedCache(__mfModuleCache.share');
+  });
+
+  it('ignores unmatched export syntax in comments, strings, and regular expressions', () => {
+    const pkg = 'mock-package-with-reserved';
+    const importPath = '/repo/packages/default-only-export-lookalikes.js';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: importPath,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('const __mfApplySharedDefaultExport = (mod) => {');
+    expect(generatedCode).toContain(`export * from ${JSON.stringify(importPath)}`);
+    expect(generatedCode).not.toContain('let current = __mfLocalShare;');
   });
 
   it.each([

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -364,7 +364,6 @@ const normalizeRuntimeShareCode = `const __mfNormalizeRuntimeShare = (mod) => {
 
 // Emitted into remoteEntry for shared provider selection.
 export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey = Symbol("mf.originalSharedProvider");
-          const __mfTransparentResolverKey = Symbol.for("module-federation.vite.transparent-resolver");
           const __mfResolveShareHook = { emit: (params) => params };
           const __mfCreateProviderSelectionVersions = (versions, strategy) => {
             if (strategy !== "version-first") return versions;
@@ -396,35 +395,20 @@ export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey 
             versions,
             pkg,
             share,
-            strategy,
-            resolveShareHook = __mfResolveShareHook,
-            selectionState
+            strategy
           ) => {
             if (!versions || !share) return undefined;
-            if (selectionState) selectionState.resolveShareHookUsed = false;
             const scopes = Array.isArray(share.scope) ? share.scope : [share.scope || "default"];
             const selectionVersions = __mfCreateProviderSelectionVersions(versions, strategy);
             const shareScopeMap = {};
             for (const scope of scopes) {
               shareScopeMap[scope || "default"] = { [pkg]: selectionVersions };
             }
-            const observedResolveShareHook = selectionState ? {
-              emit(params) {
-                const defaultResolver = params.resolver;
-                const resolvedParams = resolveShareHook.emit(params) || params;
-                let observedResolver = resolvedParams.resolver;
-                while (observedResolver?.[__mfTransparentResolverKey]) {
-                  observedResolver = observedResolver[__mfTransparentResolverKey];
-                }
-                selectionState.resolveShareHookUsed = observedResolver !== defaultResolver;
-                return resolvedParams;
-              }
-            } : resolveShareHook;
             const selected = runtimeShare.getRegisteredShare(
               shareScopeMap,
               pkg,
               { ...share, scope: scopes, strategy },
-              observedResolveShareHook
+              __mfResolveShareHook
             )?.shared;
             return selected?.[__mfOriginalProviderKey] || selected;
           };`;
@@ -433,9 +417,7 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
             versions,
             pkg,
             localShare,
-            strategy,
-            resolveShareHook = __mfResolveShareHook,
-            selectionState
+            strategy
           ) => {
             const isLocalProvider = (provider) => __mfMatchesSharedProvider(provider, localShare);
             const candidates = Object.fromEntries(
@@ -455,9 +437,7 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
               candidates,
               pkg,
               localShare,
-              strategy,
-              resolveShareHook,
-              selectionState
+              strategy
             );
             return isLocalProvider(provider) ? undefined : provider;
           };
@@ -473,10 +453,9 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
             version,
             provider,
             passedProvider,
-            strategy,
-            resolveShareHookUsed = false
+            strategy
           ) => {
-            if (resolveShareHookUsed || strategy !== "version-first" || !passedProvider) return undefined;
+            if (strategy !== "version-first" || !passedProvider) return undefined;
             const scopeRootProviders = scopeRoot?.options?.shared?.[pkg];
             const configuredScopeRootProvider = Array.isArray(scopeRootProviders)
               ? scopeRootProviders.find((candidate) => candidate?.version === version)
@@ -487,7 +466,10 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
             const scopeRootProvider = registeredScopeRootProvider || (
               __mfMatchesSharedProvider(configuredScopeRootProvider, passedProvider)
                 ? configuredScopeRootProvider
-                : undefined
+                // A plain Webpack/Rspack host has no enhanced-runtime instance.
+                // Its pre-init snapshot is still authoritative when this remote's
+                // registration rewrites the same-version provider in-place.
+                : scopeRoot ? undefined : passedProvider
             );
             if (!scopeRootProvider) return undefined;
             const selectedFromLaterInstance = instances.some((instance) =>
@@ -506,8 +488,7 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
             providerEntry,
             selectedExternalProvider,
             passedProvider,
-            strategy,
-            resolveShareHookUsed
+            strategy
           ) => {
             const scopeRootProvider = providerEntry.registered ? __mfGetScopeRootProvider(
               instances,
@@ -518,14 +499,12 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
               providerEntry.version,
               providerEntry.provider,
               passedProvider,
-              strategy,
-              resolveShareHookUsed
+              strategy
             ) : undefined;
             const provider = scopeRootProvider || selectedExternalProvider;
             if (!provider) return undefined;
             if (
               providerEntry.registered &&
-              !resolveShareHookUsed &&
               !__mfMatchesSharedProvider(provider, passedProvider)
             ) return undefined;
             return { provider, scopeRootProvider };
@@ -642,8 +621,7 @@ function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
         initialShared[pkg],
         pkg,
         share,
-        ${JSON.stringify(shareStrategy)},
-        runtimeResolveShareHook
+        ${JSON.stringify(shareStrategy)}
       ));
     };
     const __mfFirstRuntimeSeedBarrierIndex = __mfSeedKeys.findIndex(
@@ -1075,7 +1053,6 @@ export function generateRemoteEntry(
         }
         return resolved;
       };
-      instrumentedResolver[__mfTransparentResolverKey] = resolver;
       args.resolver = instrumentedResolver;
       return args;
     });
@@ -1206,6 +1183,22 @@ export function generateRemoteEntry(
         pinnedMatchesFactory
           ? provider
           : runtimeLoad.selectedProvider;
+      if (
+        runtimeSelectedProvider &&
+        !providerSelections.some((selection) => selection.provider === runtimeSelectedProvider)
+      ) {
+        const runtimeProviderOrigin = __mfRuntimeProviderOrigins.get(runtimeSelectedProvider);
+        const selectedVersion = typeof runtimeSelectedProvider.version === "string" && runtimeSelectedProvider.version
+          ? runtimeSelectedProvider.version
+          : version;
+        providerSelections.push({
+          provider: runtimeSelectedProvider,
+          version: selectedVersion,
+          from: runtimeProviderOrigin ? runtimeProviderOrigin.from : runtimeSelectedProvider.from,
+          registered: versionMap?.[selectedVersion] === runtimeSelectedProvider,
+          loadedFactory: factory
+        });
+      }
       const selection = providerSelections.find(
         (candidate) => candidate.provider === runtimeSelectedProvider
       ) ?? __mfMatchLoadedSharedProvider(providerSelections, factory);
@@ -1237,8 +1230,7 @@ export function generateRemoteEntry(
           versionMap,
           pkg,
           usedShare,
-          '${options.shareStrategy}',
-          runtimeResolveShareHook
+          '${options.shareStrategy}'
         );
         const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
         if (!providerEntry) return;
@@ -1333,19 +1325,18 @@ export function generateRemoteEntry(
         const usedCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, usedShare.shareConfig?.singleton, usedShare.version, usedShare.scope);
         const cachedShare = __mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor);
         const cachedShareOwner = __mfReadSharedCacheOwner(__mfModuleCache.share, usedCacheDescriptor);
-        const externalProviderSelection = {};
         const selectedExternalProvider = __mfSelectExternalSharedProvider(
           versionMap,
           pkg,
           usedShare,
-          '${options.shareStrategy}',
-          runtimeResolveShareHook,
-          externalProviderSelection
+          '${options.shareStrategy}'
         );
         const selectedRuntimeProvider = selectedExternalProvider ||
-          __mfSelectSharedProvider(versionMap, pkg, usedShare, '${options.shareStrategy}', runtimeResolveShareHook);
+          __mfSelectSharedProvider(versionMap, pkg, usedShare, '${options.shareStrategy}') ||
+          usedShare;
         const providerEntry = __mfFindSharedProviderEntry(versionMap, selectedRuntimeProvider);
         if (!providerEntry) return;
+        const selectedLocalProvider = __mfMatchesSharedProvider(selectedRuntimeProvider, usedShare);
         const { version } = providerEntry;
         const passedProvider = passedVersionMap?.[version];
         const resolvedExternalProvider = __mfResolveExternalSharedProvider(
@@ -1357,11 +1348,13 @@ export function generateRemoteEntry(
           providerEntry,
           selectedExternalProvider,
           passedProvider,
-          '${options.shareStrategy}',
-          externalProviderSelection.resolveShareHookUsed
+          '${options.shareStrategy}'
         );
-        if (!resolvedExternalProvider) return;
-        const { provider, scopeRootProvider } = resolvedExternalProvider;
+        if (!resolvedExternalProvider && !selectedLocalProvider) return;
+        const { provider, scopeRootProvider } = resolvedExternalProvider || {
+          provider: selectedRuntimeProvider,
+          scopeRootProvider: undefined
+        };
         // Non-singleton proxies may have already snapshotted their local exports while
         // seeding shared dependencies. Late cache replacement is safe only for the
         // live-bound singleton proxies.
@@ -1386,11 +1379,12 @@ export function generateRemoteEntry(
           version,
           liveProvider,
           provider,
-          providerEntry.registered
+          providerEntry.registered && !selectedLocalProvider
         );
         const actualProvider = loadedShare?.provider;
         const actualSelection = loadedShare?.selection;
         if (!actualSelection) return;
+        if (__mfMatchesSharedProvider(actualProvider, usedShare)) return;
         if (expectedSelection) {
           if (
             expectedSelection.version !== actualSelection.version ||
@@ -1514,9 +1508,8 @@ export function generateRemoteEntry(
         versionMap,
         pkg,
         share,
-        '${options.shareStrategy}',
-        runtimeResolveShareHook
-      );
+        '${options.shareStrategy}'
+      ) || share;
       const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
       if (!providerEntry) return;
       const { version } = providerEntry;
@@ -1528,12 +1521,13 @@ export function generateRemoteEntry(
         version,
         currentProvider,
         provider,
-        providerEntry.registered
+        providerEntry.registered && !__mfMatchesSharedProvider(provider, share)
       );
       const providerSelection = loadedShare?.selection;
       const actualProvider = loadedShare?.provider;
       const resolved = loadedShare?.resolved;
       if (!providerSelection) return;
+      if (__mfMatchesSharedProvider(actualProvider, share)) return;
       if (resolved === undefined) return;
       const latestCachedShare = share.treeShaking
         ? __mfReadTreeShakingSharedSelection(__mfModuleCache.share, cacheDescriptor, mfName)

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1042,7 +1042,11 @@ export function generateRemoteEntry(
             ? undefined
             : __mfRuntimeShareLifecycles.get(loadId);
           if (!lifecycle) return args;
-          lifecycle.defaultResolver = args.resolver;
+          const defaultResolver = args.resolver;
+          args.resolver = (...resolverArgs) => {
+            lifecycle.pinned.reapply();
+            return defaultResolver(...resolverArgs);
+          };
           lifecycle.pinned.reveal();
           return args;
         }
@@ -1052,12 +1056,6 @@ export function generateRemoteEntry(
     const __mfRuntimeProviderOrigins = new WeakMap();
     runtimeResolveShareHook.on((args) => {
       const loadId = args.shareInfo?.[__mfRuntimeShareLoadIdKey];
-      const lifecycle = loadId === undefined
-        ? undefined
-        : __mfRuntimeShareLifecycles.get(loadId);
-      if (lifecycle && args.resolver === lifecycle.defaultResolver) {
-        lifecycle.pinned.reapply();
-      }
       const resolver = args.resolver;
       if (typeof resolver !== "function") return args;
       const instrumentedResolver = (...resolverArgs) => {
@@ -1153,8 +1151,7 @@ export function generateRemoteEntry(
     const __mfLoadRuntimeShare = async (pkg, shareConfig, pinned) => {
       const loadId = ++__mfRuntimeShareLoadId;
       __mfRuntimeShareLifecycles.set(loadId, {
-        pinned,
-        defaultResolver: undefined
+        pinned
       });
       try {
         const factory = await initRes.loadShare(pkg, {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -27,6 +27,7 @@ import {
   getLocalProviderImportPath,
   getProjectResolvedImportPath,
   getSharedImportSource,
+  getSharedNamedExports,
   getTreeShakingSharedProviderImportId,
   hasTreeShakingSharedProvider,
 } from './virtualShared_preBuild';
@@ -130,28 +131,39 @@ export function generateLocalSharedImportMap() {
         .map((key) => {
           const shareItem = getNormalizeShareItem(key);
           if (!shareItem) return null;
-          const treeShakingUsage = getTreeShakingExportUsage(key, shareItem, shareItem.name);
+          const detectedNamedExports = getSharedNamedExports(key, shareItem);
+          const canLiveRebind =
+            shareItem.shareConfig.import === false || detectedNamedExports !== undefined;
+          // A partial runtime provider cannot back an ESM proxy whose complete
+          // export surface is unknown. Keep that share on its coherent local
+          // namespace instead of selecting a different tree provider.
+          const treeShakingConfig = canLiveRebind ? shareItem.shareConfig.treeShaking : undefined;
+          const treeShakingUsage = treeShakingConfig
+            ? getTreeShakingExportUsage(key, shareItem, shareItem.name)
+            : undefined;
           const treeShakingProviderExports =
             treeShakingUsage?.kind === 'exports' ? treeShakingUsage.usedExports : [];
           const treeShakingUsedExports =
             options.injectTreeShakingUsedExports === false
-              ? shareItem.shareConfig.treeShaking?.usedExports || []
+              ? treeShakingConfig?.usedExports || []
               : treeShakingProviderExports;
           // Runtime inference is only sound when the consumer publishes the
           // exports discovered by this build. If injection is disabled, keep
           // the complete provider as the safe fallback instead of advertising
           // a partial provider with incomplete coverage metadata.
           const disableRuntimeInference =
-            shareItem.shareConfig.treeShaking?.mode === 'runtime-infer' &&
+            treeShakingConfig?.mode === 'runtime-infer' &&
             options.injectTreeShakingUsedExports === false;
           const treeShakingProviderImportId =
-            !disableRuntimeInference && hasTreeShakingSharedProvider(key, shareItem)
+            treeShakingConfig &&
+            !disableRuntimeInference &&
+            hasTreeShakingSharedProvider(key, shareItem)
               ? getTreeShakingSharedProviderImportId(key)
               : undefined;
           const treeShakingStatus =
             treeShakingUsage?.kind === 'full' ||
             disableRuntimeInference ||
-            (shareItem.shareConfig.treeShaking?.mode === 'runtime-infer' &&
+            (treeShakingConfig?.mode === 'runtime-infer' &&
               !treeShakingProviderImportId &&
               shareItem.shareConfig.import !== false)
               ? 0
@@ -164,6 +176,7 @@ export function generateLocalSharedImportMap() {
             loaded: false,
             eager: ${Boolean(shareItem.shareConfig.eager)},
             from: ${JSON.stringify(options.name)},
+            canLiveRebind: ${canLiveRebind},
             async get () {
               if (${shareItem.shareConfig.import === false}) {
                 throw new Error(\`[Module Federation] Shared module '\${${JSON.stringify(key)}}' must be provided by host\`);
@@ -191,9 +204,9 @@ export function generateLocalSharedImportMap() {
               ${shareItem.shareConfig.import === false ? 'import: false,' : ''}
             },
             ${
-              shareItem.shareConfig.treeShaking
+              treeShakingConfig
                 ? `treeShaking: {
-              mode: ${JSON.stringify(shareItem.shareConfig.treeShaking.mode)},
+              mode: ${JSON.stringify(treeShakingConfig.mode)},
               usedExports: ${JSON.stringify(treeShakingUsedExports)},
               providedExports: ${JSON.stringify(treeShakingProviderExports)},
               status: ${treeShakingStatus},
@@ -323,6 +336,7 @@ function getShareItemForPreload(pkg: string) {
 
 function generateSharedCacheSeedItem(pkg: string, shareItem: ShareItem, importPath: string) {
   const cacheDescriptor = getSharedCacheDescriptor(pkg, shareItem);
+  const cacheOwner = getNormalizeModuleFederationOptions().name;
   return `if (__mfReadSharedCache(__mfModuleCache.share, ${JSON.stringify(cacheDescriptor)}) === undefined) {
         const mod = await import(${JSON.stringify(importPath)});
         ${normalizeRuntimeShareCode}
@@ -332,7 +346,7 @@ function generateSharedCacheSeedItem(pkg: string, shareItem: ShareItem, importPa
           value: true,
           enumerable: false
         });
-        __mfWriteSharedCache(__mfModuleCache.share, ${JSON.stringify(cacheDescriptor)}, exportModule);
+        __mfWriteSharedCache(__mfModuleCache.share, ${JSON.stringify(cacheDescriptor)}, exportModule, ${JSON.stringify(cacheOwner)});
       }`;
 }
 
@@ -348,8 +362,9 @@ const normalizeRuntimeShareCode = `const __mfNormalizeRuntimeShare = (mod) => {
             return current;
           };`;
 
-// Emitted into remoteEntry for import:false shared provider selection.
+// Emitted into remoteEntry for shared provider selection.
 export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey = Symbol("mf.originalSharedProvider");
+          const __mfTransparentResolverKey = Symbol.for("module-federation.vite.transparent-resolver");
           const __mfResolveShareHook = { emit: (params) => params };
           const __mfCreateProviderSelectionVersions = (versions, strategy) => {
             if (strategy !== "version-first") return versions;
@@ -364,28 +379,162 @@ export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey 
             }
             return selectionVersions;
           };
-          const __mfSelectSharedProvider = (versions, pkg, share, strategy) => {
+          const __mfFindSharedProviderEntry = (versions, provider) => {
+            if (!provider) return undefined;
+            const entries = Object.entries(versions || {});
+            const registeredEntry = entries.find(([, candidate]) => candidate === provider);
+            if (registeredEntry) {
+              return { version: registeredEntry[0], provider, registered: true };
+            }
+            if (typeof provider.version === "string" && provider.version) {
+              return { version: provider.version, provider, registered: false };
+            }
+            const provenanceEntries = entries.filter(([, candidate]) =>
+              candidate === provider || Boolean(provider.from && candidate?.from === provider.from)
+            );
+            if (provenanceEntries.length !== 1) return undefined;
+            return { version: provenanceEntries[0][0], provider, registered: false };
+          };
+          const __mfSelectSharedProvider = (
+            versions,
+            pkg,
+            share,
+            strategy,
+            resolveShareHook = __mfResolveShareHook,
+            selectionState
+          ) => {
             if (!versions || !share) return undefined;
+            if (selectionState) selectionState.resolveShareHookUsed = false;
             const scopes = Array.isArray(share.scope) ? share.scope : [share.scope || "default"];
             const selectionVersions = __mfCreateProviderSelectionVersions(versions, strategy);
             const shareScopeMap = {};
             for (const scope of scopes) {
               shareScopeMap[scope || "default"] = { [pkg]: selectionVersions };
             }
+            const observedResolveShareHook = selectionState ? {
+              emit(params) {
+                const defaultResolver = params.resolver;
+                const resolvedParams = resolveShareHook.emit(params) || params;
+                let observedResolver = resolvedParams.resolver;
+                while (observedResolver?.[__mfTransparentResolverKey]) {
+                  observedResolver = observedResolver[__mfTransparentResolverKey];
+                }
+                selectionState.resolveShareHookUsed = observedResolver !== defaultResolver;
+                return resolvedParams;
+              }
+            } : resolveShareHook;
             const selected = runtimeShare.getRegisteredShare(
               shareScopeMap,
               pkg,
               { ...share, scope: scopes, strategy },
-              __mfResolveShareHook
+              observedResolveShareHook
             )?.shared;
             return selected?.[__mfOriginalProviderKey] || selected;
           };`;
 
-function hasImportFalseShared(options: NormalizedModuleFederationOptions): boolean {
-  return Object.values(options.shared ?? {}).some((share) => share?.shareConfig?.import === false);
-}
+export const externalSharedProviderSelectionHelperCode = `const __mfSelectExternalSharedProvider = (
+            versions,
+            pkg,
+            localShare,
+            strategy,
+            resolveShareHook = __mfResolveShareHook,
+            selectionState
+          ) => {
+            const isLocalProvider = (provider) => __mfMatchesSharedProvider(provider, localShare);
+            const candidates = Object.fromEntries(
+              Object.entries(versions || {}).filter(([, provider]) => !isLocalProvider(provider))
+            );
+            if (localShare?.version) {
+              const sameVersionProvider = candidates[localShare.version];
+              // Runtime registration keeps an existing same-version record,
+              // even when it has only a getter and is not loaded yet. Model
+              // that retained provider here so pre-init seeding cannot choose
+              // the local module while loadShare() later chooses the parent.
+              if (!sameVersionProvider) {
+                candidates[localShare.version] = localShare;
+              }
+            }
+            const provider = __mfSelectSharedProvider(
+              candidates,
+              pkg,
+              localShare,
+              strategy,
+              resolveShareHook,
+              selectionState
+            );
+            return isLocalProvider(provider) ? undefined : provider;
+          };
+          const __mfMatchesSharedProvider = (provider, expected) => provider === expected || Boolean(
+            expected?.from && provider?.from === expected.from
+          );
+          const __mfGetScopeRootProvider = (
+            instances,
+            scopeRoot,
+            shared,
+            scopeName,
+            pkg,
+            version,
+            provider,
+            passedProvider,
+            strategy,
+            resolveShareHookUsed = false
+          ) => {
+            if (resolveShareHookUsed || strategy !== "version-first" || !passedProvider) return undefined;
+            const scopeRootProviders = scopeRoot?.options?.shared?.[pkg];
+            const configuredScopeRootProvider = Array.isArray(scopeRootProviders)
+              ? scopeRootProviders.find((candidate) => candidate?.version === version)
+              : undefined;
+            const registeredScopeRootProvider = passedProvider?.from === scopeRoot?.options?.name
+              ? passedProvider
+              : undefined;
+            const scopeRootProvider = registeredScopeRootProvider || (
+              __mfMatchesSharedProvider(configuredScopeRootProvider, passedProvider)
+                ? configuredScopeRootProvider
+                : undefined
+            );
+            if (!scopeRootProvider) return undefined;
+            const selectedFromLaterInstance = instances.some((instance) =>
+              instance !== scopeRoot &&
+              instance?.options?.name === provider?.from &&
+              instance?.shareScopeMap?.[scopeName] === shared
+            );
+            return selectedFromLaterInstance ? scopeRootProvider : undefined;
+          };
+          const __mfResolveExternalSharedProvider = (
+            instances,
+            scopeRoot,
+            shared,
+            scopeName,
+            pkg,
+            providerEntry,
+            selectedExternalProvider,
+            passedProvider,
+            strategy,
+            resolveShareHookUsed
+          ) => {
+            const scopeRootProvider = providerEntry.registered ? __mfGetScopeRootProvider(
+              instances,
+              scopeRoot,
+              shared,
+              scopeName,
+              pkg,
+              providerEntry.version,
+              providerEntry.provider,
+              passedProvider,
+              strategy,
+              resolveShareHookUsed
+            ) : undefined;
+            const provider = scopeRootProvider || selectedExternalProvider;
+            if (!provider) return undefined;
+            if (
+              providerEntry.registered &&
+              !resolveShareHookUsed &&
+              !__mfMatchesSharedProvider(provider, passedProvider)
+            ) return undefined;
+            return { provider, scopeRootProvider };
+          };`;
 
-function generateRuntimeSharedCacheSeedCode() {
+function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
   // Seeding a share evaluates its module graph, and every share proxy hit
   // during that evaluation must already be cached — the proxies defer their
   // local fallback until after init, so an unseeded proxy leaves its named
@@ -416,34 +565,100 @@ function generateRuntimeSharedCacheSeedCode() {
       }
       __mfSeedKeys.splice(insertIndex, 0, pkg);
     }
-    for (const pkg of __mfSeedKeys) {
+    var __mfSeedLocalShared = async (seedKeys) => {
+      for (const pkg of seedKeys) {
+        const share = usedShared[pkg];
+        const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
+        if (
+          share.shareConfig?.import === false ||
+          Boolean(share.treeShaking) ||
+          __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined
+        ) {
+          continue;
+        }
+        const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);
+        const singletonModule = __mfReadSharedCache(__mfModuleCache.share, singletonCacheDescriptor);
+        if (singletonModule !== undefined) {
+          __mfWriteSharedCache(
+            __mfModuleCache.share,
+            cacheDescriptor,
+            singletonModule,
+            __mfReadSharedCacheOwner(__mfModuleCache.share, singletonCacheDescriptor)
+          );
+          continue;
+        }
+        const factory = await share.get();
+        const mod = typeof factory === "function" ? factory() : factory;
+        const resolved = await Promise.resolve(mod);
+        ${normalizeRuntimeShareCode}
+        const normalizedModule = __mfNormalizeRuntimeShare(resolved);
+        const exportModule = normalizedModule === resolved ? {...resolved} : normalizedModule;
+        Object.defineProperty(exportModule, "__esModule", {
+          value: true,
+          enumerable: false
+        });
+        __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, exportModule, mfName);
+      }
+    };
+    const __mfIsRuntimeOnlySharePending = (pkg) => {
       const share = usedShared[pkg];
-      const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
-      if (
-        share.shareConfig?.import === false ||
-        Boolean(share.treeShaking) ||
-        __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined
-      ) {
-        continue;
-      }
-      const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);
-      const singletonModule = __mfReadSharedCache(__mfModuleCache.share, singletonCacheDescriptor);
-      if (singletonModule !== undefined) {
-        __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, singletonModule);
-        continue;
-      }
-      const factory = await share.get();
-      const mod = typeof factory === "function" ? factory() : factory;
-      const resolved = await Promise.resolve(mod);
-      ${normalizeRuntimeShareCode}
-      const normalizedModule = __mfNormalizeRuntimeShare(resolved);
-      const exportModule = normalizedModule === resolved ? {...resolved} : normalizedModule;
-      Object.defineProperty(exportModule, "__esModule", {
-        value: true,
-        enumerable: false
-      });
-      __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, exportModule);
-    }`;
+      if (!share.treeShaking && share.shareConfig?.import !== false) return false;
+      const cacheDescriptor = __mfGetSharedCacheDescriptor(
+        pkg,
+        share.shareConfig?.singleton,
+        share.version,
+        share.scope
+      );
+      return share.treeShaking
+        ? (
+            __mfReadTreeShakingSharedSelection(
+              __mfModuleCache.share,
+              cacheDescriptor,
+              mfName
+            ) === undefined &&
+            __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) === undefined
+          )
+        : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) === undefined;
+    };
+    const __mfNeedsPreInitSeedBarrier = (pkg) => {
+      const share = usedShared[pkg];
+      const cacheDescriptor = __mfGetSharedCacheDescriptor(
+        pkg,
+        share.shareConfig?.singleton,
+        share.version,
+        share.scope
+      );
+      const cachedShare = share.treeShaking
+        ? (
+            __mfReadTreeShakingSharedSelection(
+              __mfModuleCache.share,
+              cacheDescriptor,
+              mfName
+            ) ?? __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor)
+          )
+        : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor);
+      if (cachedShare !== undefined) return false;
+      if (share.treeShaking || share.shareConfig?.import === false) return true;
+      if (!share.shareConfig?.singleton) return false;
+      if (typeof __mfSelectExternalSharedProvider !== 'function') return false;
+      return Boolean(__mfSelectExternalSharedProvider(
+        initialShared[pkg],
+        pkg,
+        share,
+        ${JSON.stringify(shareStrategy)},
+        runtimeResolveShareHook
+      ));
+    };
+    const __mfFirstRuntimeSeedBarrierIndex = __mfSeedKeys.findIndex(
+      __mfNeedsPreInitSeedBarrier
+    );
+    const __mfImmediateSeedKeys = __mfFirstRuntimeSeedBarrierIndex === -1
+      ? __mfSeedKeys
+      : __mfSeedKeys.slice(0, __mfFirstRuntimeSeedBarrierIndex);
+    var __mfDeferredSeedKeys = __mfFirstRuntimeSeedBarrierIndex === -1
+      ? []
+      : __mfSeedKeys.slice(__mfFirstRuntimeSeedBarrierIndex);
+    await __mfSeedLocalShared(__mfImmediateSeedKeys);`;
 }
 
 function getBrowserImportPath(importPath: string) {
@@ -504,15 +719,15 @@ const getSsrOnlyPluginSpecifier = (importStatement: string): string | undefined 
   [...SSR_ONLY_PLUGIN_SPECIFIERS].find((s) => importStatement.includes(s));
 
 function generateTreeShakingSharedResolutionCode(enabled: boolean): string {
-  if (!enabled) return '';
+  if (!enabled) return 'const __mfResolveTreeShakingShared = async () => {};';
   return `
     // Resolve tree-enabled shares through the Runtime after all providers have
     // registered. Partial providers are stored with their export coverage and
     // never occupy generic/legacy cache keys, which are reserved for complete
     // modules only.
-    for (const [pkg, share] of Object.entries(usedShared)) {
+    const __mfResolveTreeShakingShared = async (pkg, share) => {
       const treeShaking = share.treeShaking;
-      if (!treeShaking) continue;
+      if (!treeShaking) return;
       try {
         const factory = await initRes.loadShare(pkg, {
           customShareInfo: {
@@ -524,22 +739,21 @@ function generateTreeShakingSharedResolutionCode(enabled: boolean): string {
             },
           },
         });
-        if (factory === false) continue;
+        if (factory === false) return;
         const mod = typeof factory === "function" ? factory() : factory;
         const resolved = await Promise.resolve(mod);
         ${normalizeRuntimeShareCode}
         const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
         const normalizedShared = __mfNormalizeRuntimeShare(resolved);
+        const providedExports = treeShaking.providedExports ?? treeShaking.usedExports ?? [];
         const hasPartialProvider =
-          Array.isArray(treeShaking.providedExports) &&
-          treeShaking.providedExports.length > 0 &&
           ((treeShaking.mode === "runtime-infer" && treeShaking.status !== 0) ||
             treeShaking.status === 2);
         if (hasPartialProvider) {
           __mfWriteTreeShakingSharedCache(
             __mfModuleCache.share,
             cacheDescriptor,
-            treeShaking.providedExports,
+            providedExports,
             normalizedShared
           );
           __mfWriteTreeShakingSharedSelection(
@@ -554,18 +768,18 @@ function generateTreeShakingSharedResolutionCode(enabled: boolean): string {
       } catch (e) {
         console.warn('[Module Federation] Failed to load tree-shaken shared module', pkg, e);
       }
-    }`;
+    };`;
 }
 
-export const treeShakingResolveShareBodyCode = `const originalResolver = args.resolver;
+export const treeShakingResolveShareBodyCode = `const consumerTreeShaking = args.shareInfo?.treeShaking;
+      if (consumerTreeShaking?.mode !== "runtime-infer") return args;
+      const requiredExports = consumerTreeShaking.usedExports;
+      if (!Array.isArray(requiredExports)) return args;
+
+      const originalResolver = args.resolver;
       args.resolver = () => {
         const resolved = originalResolver();
         if (!resolved?.useTreesShaking) return resolved;
-
-        const consumerTreeShaking = args.shareInfo?.treeShaking;
-        if (consumerTreeShaking?.mode !== "runtime-infer") return resolved;
-        const requiredExports = consumerTreeShaking.usedExports;
-        if (!Array.isArray(requiredExports)) return resolved;
 
         const selectedExports = resolved.shared?.treeShaking?.usedExports;
         const selectedMatches = Array.isArray(selectedExports) &&
@@ -671,7 +885,7 @@ export function generateRemoteEntry(
   virtualExposesId = getVirtualExposesId(options),
   command = 'build'
 ): string {
-  const needsSharedProviderSelectionHelper = hasImportFalseShared(options);
+  const needsSharedProviderSelectionHelper = Object.keys(options.shared ?? {}).length > 0;
   const hasTreeShakingShared = Object.values(options.shared ?? {}).some(
     (share) => !!share?.shareConfig.treeShaking
   );
@@ -698,6 +912,17 @@ export function generateRemoteEntry(
       ];
     }
   });
+  const initializeSharingCode = `try {
+      await retrySharedInit(async () => {
+        await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
+          strategy: '${options.shareStrategy}',
+          from: "build",
+          initScope
+        }));
+      });
+    } catch (e) {
+      console.error('[Module Federation]', e)
+    }`;
 
   return `
   // Shim Vue HMR runtime for dev-compiled components loaded by a non-Vite host.
@@ -755,6 +980,7 @@ export function generateRemoteEntry(
   }
   ${generateTreeShakingSnapshotPluginCode(hasTreeShakingShared)}
   ${needsSharedProviderSelectionHelper ? sharedProviderSelectionHelperCode : ''}
+  ${needsSharedProviderSelectionHelper ? externalSharedProviderSelectionHelperCode : ''}
 
   async function getLocalSharedImportMap() {
     ${hasEagerShared ? 'return __mfLocalSharedImportMap;' : ''}
@@ -780,53 +1006,32 @@ export function generateRemoteEntry(
 
   async function init(shared = {}, initScope = []) {
     ${sharedCacheHelperCode}
+    const federationInstances = globalThis.__FEDERATION__?.__INSTANCES__ || [];
+    const initRootName = initScope.find((token) => token?.from)?.from;
+    const scopeRoot = federationInstances.find((instance) =>
+      instance?.options?.name === initRootName &&
+      instance?.shareScopeMap?.['${options.shareScope}'] === shared
+    ) || federationInstances.find((instance) =>
+      instance?.options?.name !== mfName &&
+      instance?.shareScopeMap?.['${options.shareScope}'] === shared
+    );
+    const initialShared = Object.create(null);
+    for (const [pkg, versions] of Object.entries(shared)) {
+      const initialVersions = initialShared[pkg] = Object.create(null);
+      for (const [version, provider] of Object.entries(versions)) {
+        // Runtime registration mutates provider records in-place, notably their origin.
+        // Preserve the parent-visible provider and its original provenance.
+        initialVersions[version] = Object.assign({}, provider);
+      }
+    }
     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
-    try {
-      const allInstances = globalThis.__FEDERATION__?.__SHARE__;
-      if (allInstances) {
-        ${normalizeRuntimeShareCode}
-        for (const [, scopes] of Object.entries(allInstances)) {
-          const scopeShare = scopes?.['${options.shareScope}'];
-          if (!scopeShare) continue;
-          for (const [pkg, versionMap] of Object.entries(scopeShare)) {
-            const usedShare = usedShared?.[pkg];
-            const selectedProvider = usedShare?.shareConfig?.import === false
-              ? __mfSelectSharedProvider(versionMap, pkg, usedShare, '${options.shareStrategy}')
-              : undefined;
-            const providerEntries = usedShare?.shareConfig?.import === false
-              ? Object.entries(versionMap).filter(([, provider]) => provider === selectedProvider)
-              : Object.entries(versionMap);
-            for (const [version, provider] of providerEntries) {
-              if (!provider.lib) continue;
-              const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, provider.shareConfig?.singleton, version, ${JSON.stringify(options.shareScope)});
-              if (__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) continue;
-              const mod = typeof provider.lib === "function" ? provider.lib() : provider.lib;
-              const resolved = await Promise.resolve(mod);
-              const normalized = __mfNormalizeRuntimeShare(resolved);
-              __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, normalized);
-              if (provider.shareConfig?.singleton && usedShare) {
-                const usedCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, usedShare.shareConfig?.singleton, usedShare.version, usedShare.scope);
-                if (__mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor) === undefined) {
-                  __mfWriteSharedCache(__mfModuleCache.share, usedCacheDescriptor, normalized);
-                }
-              }
-            }
-          }
-        }
-      }
-    } catch (e) {
-      console.error('[Module Federation] Failed to bridge external shared modules', e)
-    }
-    for (const [pkg, share] of Object.entries(usedShared)) {
-      const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
-      if (__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) continue;
-      const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);
-      const singletonModule = __mfReadSharedCache(__mfModuleCache.share, singletonCacheDescriptor);
-      if (singletonModule !== undefined) {
-        __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, singletonModule);
-      }
-    }
-    ${generateRuntimeSharedCacheSeedCode()}
+    // handling circular init calls before an external provider can re-enter this container
+    var initToken = initTokens[shareScopeName];
+    if (!initToken)
+      initToken = initTokens[shareScopeName] = { from: mfName };
+    if (initScope.indexOf(initToken) >= 0) return;
+    initScope.push(initToken);
+    ${normalizeRuntimeShareCode}
     const __browserPlugins = [${pluginImportNames
       .filter((item) => !isSsrOnlyPlugin(item[1]))
       .map((item) => `${item[0]}(${item[2]})`)
@@ -848,39 +1053,543 @@ export function generateRemoteEntry(
       plugins: [${hasTreeShakingShared ? '__mfTreeShakingSnapshotPlugin(),' : ''} ...__browserPlugins, ...__ssrPlugins],
       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ''}
     });
-    // handling circular init calls
-    var initToken = initTokens[shareScopeName];
-    if (!initToken)
-      initToken = initTokens[shareScopeName] = { from: mfName };
-    if (initScope.indexOf(initToken) >= 0) return;
-    initScope.push(initToken);
     initRes.initShareScopeMap('${options.shareScope}', shared);
-    try {
-      await retrySharedInit(async () => {
-        await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
-          strategy: '${options.shareStrategy}',
-          from: "build",
-          initScope
-        }));
+    const runtimeResolveShareHook = initRes.sharedHandler.hooks.lifecycle.resolveShare;
+    const __mfRuntimeProviderOrigins = new WeakMap();
+    const __mfRuntimeShareLoadIdKey = "__mf_vite_runtime_share_load_id__";
+    let __mfRuntimeShareLoadId = 0;
+    const __mfRuntimeShareSelections = new Map();
+    runtimeResolveShareHook.on((args) => {
+      const resolver = args.resolver;
+      if (typeof resolver !== "function") return args;
+      const instrumentedResolver = (...resolverArgs) => {
+        const resolved = resolver(...resolverArgs);
+        const selectedProvider = resolved?.shared;
+        if (
+          selectedProvider &&
+          (typeof selectedProvider === "object" || typeof selectedProvider === "function") &&
+          !__mfRuntimeProviderOrigins.has(selectedProvider)
+        ) {
+          __mfRuntimeProviderOrigins.set(selectedProvider, { from: selectedProvider.from });
+        }
+        const loadId = args.shareInfo?.[__mfRuntimeShareLoadIdKey];
+        if (loadId !== undefined && selectedProvider) {
+          __mfRuntimeShareSelections.set(loadId, selectedProvider);
+        }
+        return resolved;
+      };
+      instrumentedResolver[__mfTransparentResolverKey] = resolver;
+      args.resolver = instrumentedResolver;
+      return args;
+    });
+    const __mfPinSharedProvider = (versionMap, version, currentProvider, provider) => {
+      if (!versionMap || versionMap[version] !== currentProvider) return undefined;
+      const pinnedProvider = Object.assign({}, provider, {
+        version: provider.version ?? version,
+        scope: provider.scope ?? currentProvider?.scope ?? ['${options.shareScope}'],
+        strategy: 'loaded-first'
       });
+      const providerFrom = provider.from;
+      versionMap[version] = pinnedProvider;
+      return {
+        provider: pinnedProvider,
+        release(loaded, selected = true) {
+          provider.from = providerFrom;
+          if (versionMap[version] !== pinnedProvider) return false;
+          if (!selected) {
+            if (currentProvider === undefined) delete versionMap[version];
+            else versionMap[version] = currentProvider;
+            return true;
+          }
+          if (!loaded) {
+            if (typeof pinnedProvider.get !== 'function') {
+              if (currentProvider === undefined) delete versionMap[version];
+              else versionMap[version] = currentProvider;
+              return false;
+            }
+            delete pinnedProvider.loading;
+            if (provider.lib === undefined) delete pinnedProvider.lib;
+            else pinnedProvider.lib = provider.lib;
+            pinnedProvider.loaded = Boolean(provider.lib);
+          }
+          pinnedProvider.from = providerFrom;
+          if (loaded && pinnedProvider.lib) pinnedProvider.loaded = true;
+          if (provider.strategy === undefined) delete pinnedProvider.strategy;
+          else pinnedProvider.strategy = provider.strategy;
+          return true;
+        }
+      };
+    };
+    const __mfSnapshotSharedProviders = (versionMap) => (
+      Object.entries(versionMap || {}).map(([version, provider]) => ({
+        provider,
+        version,
+        from: provider.from,
+        registered: true
+      }))
+    );
+    const __mfMatchLoadedSharedProvider = (providerSelections, factory) => {
+      if (factory === undefined) return undefined;
+      let match;
+      for (const selection of providerSelections) {
+        const provider = selection.provider;
+        const directProvider = provider.treeShaking || provider;
+        if (
+          selection.loadedFactory !== factory &&
+          provider.lib !== factory &&
+          directProvider.lib !== factory
+        ) continue;
+        if (match) return undefined;
+        match = selection;
+      }
+      return match;
+    };
+    const __mfLoadRuntimeShare = async (pkg, shareConfig) => {
+      const loadId = ++__mfRuntimeShareLoadId;
+      try {
+        const factory = await initRes.loadShare(pkg, {
+          customShareInfo: {
+            shareConfig,
+            [__mfRuntimeShareLoadIdKey]: loadId
+          }
+        });
+        return {
+          factory: factory === false ? undefined : factory,
+          selectedProvider: __mfRuntimeShareSelections.get(loadId)
+        };
+      } finally {
+        __mfRuntimeShareSelections.delete(loadId);
+      }
+    };
+    const __mfLoadPinnedRuntimeShare = async (
+      pkg,
+      shareConfig,
+      versionMap,
+      version,
+      currentProvider,
+      provider,
+      providerRegistered = true
+    ) => {
+      const providerFrom = provider.from;
+      const pinned = __mfPinSharedProvider(
+        versionMap,
+        version,
+        currentProvider,
+        provider
+      );
+      if (!pinned) return undefined;
+      let runtimeLoad;
+      try {
+        runtimeLoad = await __mfLoadRuntimeShare(pkg, shareConfig);
+      } catch (error) {
+        pinned.release(false);
+        throw error;
+      }
+      const factory = runtimeLoad?.factory;
+      if (factory === undefined) {
+        pinned.release(false);
+        return undefined;
+      }
+      const providerSelections = __mfSnapshotSharedProviders(versionMap);
+      const directPinnedProvider = pinned.provider.treeShaking || pinned.provider;
+      const pinnedMatchesFactory =
+        pinned.provider.lib === factory || directPinnedProvider.lib === factory;
+      if (!providerRegistered && pinnedMatchesFactory) {
+        const pinnedSelectionIndex = providerSelections.findIndex(
+          (selection) => selection.provider === pinned.provider
+        );
+        if (pinnedSelectionIndex !== -1) providerSelections.splice(pinnedSelectionIndex, 1);
+      }
+      if (!providerRegistered && !providerSelections.some((selection) => selection.provider === provider)) {
+        providerSelections.push({
+          provider,
+          version,
+          from: providerFrom,
+          registered: false,
+          loadedFactory: pinnedMatchesFactory ? factory : undefined
+        });
+      }
+      const runtimeSelectedProvider =
+        !providerRegistered &&
+        runtimeLoad.selectedProvider === pinned.provider &&
+        pinnedMatchesFactory
+          ? provider
+          : runtimeLoad.selectedProvider;
+      const selection = providerSelections.find(
+        (candidate) => candidate.provider === runtimeSelectedProvider
+      ) ?? __mfMatchLoadedSharedProvider(providerSelections, factory);
+      const providerStayedActive = pinned.release(
+        true,
+        selection?.provider === pinned.provider
+      );
+      if (!providerStayedActive || !selection) return undefined;
+      const runtimeProviderOrigin = __mfRuntimeProviderOrigins.get(selection.provider);
+      selection.from = selection.provider === provider
+        ? providerFrom
+        : runtimeProviderOrigin
+          ? runtimeProviderOrigin.from
+          : selection.provider.from;
+      if (runtimeProviderOrigin) selection.provider.from = runtimeProviderOrigin.from;
+      const mod = typeof factory === "function" ? factory() : factory;
+      const resolved = await Promise.resolve(mod);
+      if (selection.registered && versionMap?.[selection.version] !== selection.provider) return undefined;
+      return { provider: selection.provider, selection, resolved };
+    };
+    const bridgedProviders = new Set();
+    const bridgeSelections = new Map();
+    const __mfBridgeMaterializedProvider = async (pkg, usedShare, versionMap) => {
+      const singleton = Boolean(usedShare.shareConfig?.singleton);
+      if (singleton && '${options.shareStrategy}' !== 'loaded-first') return;
+      if (usedShare.canLiveRebind === false) return;
+      try {
+        const provider = __mfSelectExternalSharedProvider(
+          versionMap,
+          pkg,
+          usedShare,
+          '${options.shareStrategy}',
+          runtimeResolveShareHook
+        );
+        const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
+        if (!providerEntry) return;
+        const { version } = providerEntry;
+        if (!singleton && version !== usedShare.version) return;
+        if (
+          !provider.lib &&
+          !provider.loading &&
+          !(provider.loaded && typeof provider.get === 'function')
+        ) return;
+        const usedCacheDescriptor = __mfGetSharedCacheDescriptor(
+          pkg,
+          singleton,
+          usedShare.version,
+          usedShare.scope
+        );
+        if (__mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor) !== undefined) return;
+        const liveVersionMap = shared[pkg];
+        const liveProvider = liveVersionMap?.[version];
+        if (providerEntry.registered && !__mfMatchesSharedProvider(liveProvider, provider)) return;
+        let loadedShare;
+        ${
+          options.shareStrategy === 'loaded-first'
+            ? `loadedShare = await __mfLoadPinnedRuntimeShare(
+            pkg,
+            usedShare.shareConfig,
+            liveVersionMap,
+            version,
+            liveProvider,
+            provider,
+            providerEntry.registered
+          );`
+            : `// Runtime loadShare() implicitly initializes version-first remotes without
+          // this container's outer initScope. Materialized providers are already active,
+          // so resolve them directly and keep remote initialization on the guarded path.
+          let directFactory = provider.lib;
+          if (!directFactory && provider.loading) directFactory = await provider.loading;
+          if (!directFactory && provider.loaded && typeof provider.get === 'function') {
+            directFactory = await provider.get();
+          }
+          if (!directFactory) return;
+          const directModule = typeof directFactory === "function" ? directFactory() : directFactory;
+          const directResolved = await Promise.resolve(directModule);
+          const directProvider = providerEntry.registered ? liveProvider : provider;
+          loadedShare = {
+            provider: directProvider,
+            selection: {
+              provider: directProvider,
+              version,
+              from: provider.from,
+              registered: providerEntry.registered
+            },
+            resolved: directResolved
+          };`
+        }
+        const actualProvider = loadedShare?.provider;
+        const actualSelection = loadedShare?.selection;
+        if (!actualSelection) return;
+        const resolved = loadedShare?.resolved;
+        if (resolved === undefined) return;
+        if (__mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor) !== undefined) return;
+        ${
+          options.shareStrategy === 'loaded-first'
+            ? `if (
+          actualSelection.registered &&
+          liveVersionMap?.[actualSelection.version] !== actualProvider
+        ) return;`
+            : `if (
+          actualSelection.registered &&
+          liveVersionMap?.[actualSelection.version] !== actualProvider
+        ) return;`
+        }
+        __mfWriteSharedCache(
+          __mfModuleCache.share,
+          usedCacheDescriptor,
+          __mfNormalizeRuntimeShare(resolved),
+          actualSelection.from
+        );
+        bridgedProviders.add(actualProvider);
+      } catch (e) {
+        console.error('[Module Federation] Failed to bridge materialized shared module "' + pkg + '"', e)
+      }
+    };
+    const __mfBridgeExternalSharedProvider = async (
+      pkg,
+      usedShare,
+      versionMap,
+      passedVersionMap,
+      expectedSelection
+    ) => {
+      try {
+        const usedCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, usedShare.shareConfig?.singleton, usedShare.version, usedShare.scope);
+        const cachedShare = __mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor);
+        const cachedShareOwner = __mfReadSharedCacheOwner(__mfModuleCache.share, usedCacheDescriptor);
+        const externalProviderSelection = {};
+        const selectedExternalProvider = __mfSelectExternalSharedProvider(
+          versionMap,
+          pkg,
+          usedShare,
+          '${options.shareStrategy}',
+          runtimeResolveShareHook,
+          externalProviderSelection
+        );
+        const selectedRuntimeProvider = selectedExternalProvider ||
+          __mfSelectSharedProvider(versionMap, pkg, usedShare, '${options.shareStrategy}', runtimeResolveShareHook);
+        const providerEntry = __mfFindSharedProviderEntry(versionMap, selectedRuntimeProvider);
+        if (!providerEntry) return;
+        const { version } = providerEntry;
+        const passedProvider = passedVersionMap?.[version];
+        const resolvedExternalProvider = __mfResolveExternalSharedProvider(
+          federationInstances,
+          scopeRoot,
+          shared,
+          '${options.shareScope}',
+          pkg,
+          providerEntry,
+          selectedExternalProvider,
+          passedProvider,
+          '${options.shareStrategy}',
+          externalProviderSelection.resolveShareHookUsed
+        );
+        if (!resolvedExternalProvider) return;
+        const { provider, scopeRootProvider } = resolvedExternalProvider;
+        // Non-singleton proxies may have already snapshotted their local exports while
+        // seeding shared dependencies. Late cache replacement is safe only for the
+        // live-bound singleton proxies.
+        if (!usedShare.shareConfig?.singleton) return;
+        if (usedShare.canLiveRebind === false) return;
+        // Preserve a singleton already selected by another container. The bridge may
+        // only replace the provisional local fallback seeded by this container.
+        if (cachedShare !== undefined && cachedShareOwner !== mfName) return;
+        // Registration can replace an unloaded same-version root provider in-place.
+        // Pin the chosen provider while loadShare() runs its implicit registration.
+        const liveVersionMap = shared[pkg];
+        const liveProvider = liveVersionMap?.[version];
+        if (
+          providerEntry.registered &&
+          !scopeRootProvider &&
+          !__mfMatchesSharedProvider(liveProvider, provider)
+        ) return;
+        const loadedShare = await __mfLoadPinnedRuntimeShare(
+          pkg,
+          usedShare.shareConfig,
+          liveVersionMap,
+          version,
+          liveProvider,
+          provider,
+          providerEntry.registered
+        );
+        const actualProvider = loadedShare?.provider;
+        const actualSelection = loadedShare?.selection;
+        if (!actualSelection) return;
+        if (expectedSelection) {
+          if (
+            expectedSelection.version !== actualSelection.version ||
+            !__mfMatchesSharedProvider({ from: actualSelection.from }, expectedSelection.provider)
+          ) return;
+        }
+        if (bridgedProviders.has(actualProvider)) return;
+        const resolved = loadedShare?.resolved;
+        if (resolved === undefined) return;
+        const latestCachedShare = __mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor);
+        const latestCachedShareOwner = __mfReadSharedCacheOwner(__mfModuleCache.share, usedCacheDescriptor);
+        if (latestCachedShare !== undefined && latestCachedShareOwner !== mfName) return;
+        if (
+          actualSelection.registered &&
+          liveVersionMap?.[actualSelection.version] !== actualProvider
+        ) return;
+        if (!expectedSelection) {
+          bridgeSelections.set(pkg, {
+            version: actualSelection.version,
+            provider: { from: actualSelection.from }
+          });
+        }
+        bridgedProviders.add(actualProvider);
+        const normalized = __mfNormalizeRuntimeShare(resolved);
+        __mfWriteSharedCache(
+          __mfModuleCache.share,
+          usedCacheDescriptor,
+          normalized,
+          actualSelection.from
+        );
+      } catch (e) {
+        console.error('[Module Federation] Failed to bridge external shared module "' + pkg + '"', e)
+      }
+    };
+    for (const [pkg, usedShare] of Object.entries(usedShared)) {
+      if (usedShare.treeShaking) continue;
+      await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);
+    }
+    for (const [pkg, share] of Object.entries(usedShared)) {
+      if (share.treeShaking) continue;
+      const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
+      if (__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) continue;
+      const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);
+      const singletonModule = __mfReadSharedCache(__mfModuleCache.share, singletonCacheDescriptor);
+      if (singletonModule !== undefined) {
+        __mfWriteSharedCache(
+          __mfModuleCache.share,
+          cacheDescriptor,
+          singletonModule,
+          __mfReadSharedCacheOwner(__mfModuleCache.share, singletonCacheDescriptor)
+        );
+      }
+    }
+    ${generateRuntimeSharedCacheSeedCode(options.shareStrategy)}
+    ${initializeSharingCode}
+    // Calling provider.get() marks a provider as loaded. Wait until the Runtime has
+    // finalized normal same-version precedence before materializing an external share.
+    for (const [pkg, usedShare] of Object.entries(usedShared)) {
+      if (usedShare.treeShaking) continue;
+      await __mfBridgeExternalSharedProvider(
+        pkg,
+        usedShare,
+        shared[pkg],
+        initialShared[pkg],
+        undefined
+      );
+    }
+    try {
+      const allInstances = globalThis.__FEDERATION__?.__SHARE__;
+      const globalVersionsByPackage = Object.create(null);
+      if (allInstances) {
+        for (const [, scopes] of Object.entries(allInstances)) {
+          const scopeShare = scopes?.['${options.shareScope}'];
+          if (!scopeShare) continue;
+          for (const [pkg, versionMap] of Object.entries(scopeShare)) {
+            const usedShare = usedShared?.[pkg];
+            const passedVersions = initialShared[pkg];
+            const bridgeSelection = bridgeSelections.get(pkg);
+            if (!usedShare) continue;
+            if (!passedVersions) continue;
+            if (!bridgeSelection) continue;
+            if (usedShare.treeShaking) continue;
+            const globalVersions = globalVersionsByPackage[pkg] || (globalVersionsByPackage[pkg] = Object.create(null));
+            for (const [version, provider] of Object.entries(versionMap)) {
+              if (!provider.lib) continue;
+              if (bridgeSelection.version !== version) continue;
+              if (!__mfMatchesSharedProvider(provider, bridgeSelection.provider)) continue;
+              const passedProvider = passedVersions[version];
+              const matchesPassedProvider = provider === passedProvider || (
+                passedProvider?.from && provider.from === passedProvider.from
+              );
+              if (!matchesPassedProvider) continue;
+              if (provider === usedShare || (usedShare.from && provider.from === usedShare.from)) continue;
+              if (globalVersions[version] === undefined) globalVersions[version] = provider;
+            }
+          }
+        }
+      }
+      for (const [pkg, versionMap] of Object.entries(globalVersionsByPackage)) {
+        await __mfBridgeExternalSharedProvider(
+          pkg,
+          usedShared[pkg],
+          versionMap,
+          initialShared[pkg],
+          bridgeSelections.get(pkg)
+        );
+      }
     } catch (e) {
-      console.error('[Module Federation]', e)
+      console.error('[Module Federation] Failed to bridge external shared modules', e)
     }
     ${generateTreeShakingSharedResolutionCode(hasTreeShakingShared)}
-    for (const [pkg, share] of Object.entries(usedShared)) {
+    const __mfResolveImportFalseShared = async (pkg, share) => {
       const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
       const cachedShare = share.treeShaking
         ? __mfReadTreeShakingSharedSelection(__mfModuleCache.share, cacheDescriptor, mfName)
         : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor);
-      if (share.shareConfig?.import !== false || cachedShare !== undefined) continue;
+      if (share.shareConfig?.import !== false || cachedShare !== undefined) return;
       ${normalizeRuntimeShareCode}
-      const versions = shared?.[pkg];
-      const provider = __mfSelectSharedProvider(versions, pkg, share, '${options.shareStrategy}');
-      if (!provider) continue;
-      const factory = provider.lib || (provider.loading ? await provider.loading : await provider.get?.());
-      const mod = typeof factory === "function" ? factory() : factory;
-      const resolved = await Promise.resolve(mod);
-      __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, __mfNormalizeRuntimeShare(resolved));
+      const versionMap = shared?.[pkg];
+      const provider = __mfSelectSharedProvider(
+        versionMap,
+        pkg,
+        share,
+        '${options.shareStrategy}',
+        runtimeResolveShareHook
+      );
+      const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
+      if (!providerEntry) return;
+      const { version } = providerEntry;
+      const currentProvider = versionMap?.[version];
+      const loadedShare = await __mfLoadPinnedRuntimeShare(
+        pkg,
+        share.shareConfig,
+        versionMap,
+        version,
+        currentProvider,
+        provider,
+        providerEntry.registered
+      );
+      const providerSelection = loadedShare?.selection;
+      const actualProvider = loadedShare?.provider;
+      const resolved = loadedShare?.resolved;
+      if (!providerSelection) return;
+      if (resolved === undefined) return;
+      const latestCachedShare = share.treeShaking
+        ? __mfReadTreeShakingSharedSelection(__mfModuleCache.share, cacheDescriptor, mfName)
+        : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor);
+      if (latestCachedShare !== undefined) return;
+      if (
+        providerSelection.registered &&
+        versionMap?.[providerSelection.version] !== actualProvider
+      ) return;
+      const normalizedShared = __mfNormalizeRuntimeShare(resolved);
+      if (share.treeShaking) {
+        const providedExports = share.treeShaking.providedExports ?? share.treeShaking.usedExports ?? [];
+        __mfWriteTreeShakingSharedCache(
+          __mfModuleCache.share,
+          cacheDescriptor,
+          providedExports,
+          normalizedShared
+        );
+        __mfWriteTreeShakingSharedSelection(
+          __mfModuleCache.share,
+          cacheDescriptor,
+          mfName,
+          normalizedShared
+        );
+      } else {
+        __mfWriteSharedCache(
+          __mfModuleCache.share,
+          cacheDescriptor,
+          normalizedShared,
+          providerSelection.from
+        );
+      }
+    };
+    // Resolve runtime-only dependencies and seed local fallbacks in dependency
+    // order. Stop at an unresolved provider so its consumers cannot capture an
+    // undefined or provisional singleton.
+    for (const pkg of __mfDeferredSeedKeys) {
+      const share = usedShared[pkg];
+      if (__mfIsRuntimeOnlySharePending(pkg)) {
+        if (share.treeShaking) {
+          await __mfResolveTreeShakingShared(pkg, share);
+        } else if (share.shareConfig?.import === false) {
+          await __mfResolveImportFalseShared(pkg, share);
+        }
+      }
+      if (__mfIsRuntimeOnlySharePending(pkg)) break;
+      await __mfSeedLocalShared([pkg]);
     }
     initResolve(initRes)
     return initRes
@@ -913,6 +1622,7 @@ export function generateHostAutoInitCode(remoteEntryImport: string, _command = '
   const shouldPreloadShares =
     getNormalizeModuleFederationOptions().shareStrategy !== 'loaded-first';
   const hostInitShareOrder = JSON.stringify(getOrderedUsedShares());
+  const cacheOwner = JSON.stringify(getNormalizeModuleFederationOptions().name);
   return `
     ${getRuntimeModuleCacheBootstrapCode()}
     let hostInitPromise;
@@ -946,7 +1656,12 @@ export function generateHostAutoInitCode(remoteEntryImport: string, _command = '
             }).then((factory) => {
               const mod = typeof factory === "function" ? factory() : factory;
               return Promise.resolve(mod).then((resolved) => {
-                __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, __mfNormalizeRuntimeShare(resolved));
+                __mfWriteSharedCache(
+                  __mfModuleCache.share,
+                  cacheDescriptor,
+                  __mfNormalizeRuntimeShare(resolved),
+                  ${cacheOwner}
+                );
               });
             });
           }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -371,9 +371,6 @@ export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey 
             const selectionVersions = {};
             for (const [version, provider] of Object.entries(versions)) {
               selectionVersions[version] = Object.assign({}, provider, {
-                loaded: false,
-                loading: undefined,
-                lib: undefined,
                 [__mfOriginalProviderKey]: provider
               });
             }
@@ -1102,15 +1099,9 @@ export function generateRemoteEntry(
             return true;
           }
           if (!loaded) {
-            if (typeof pinnedProvider.get !== 'function') {
-              if (currentProvider === undefined) delete versionMap[version];
-              else versionMap[version] = currentProvider;
-              return false;
-            }
-            delete pinnedProvider.loading;
-            if (provider.lib === undefined) delete pinnedProvider.lib;
-            else pinnedProvider.lib = provider.lib;
-            pinnedProvider.loaded = Boolean(provider.lib);
+            if (currentProvider === undefined) delete versionMap[version];
+            else versionMap[version] = currentProvider;
+            return false;
           }
           pinnedProvider.from = providerFrom;
           if (loaded && pinnedProvider.lib) pinnedProvider.loaded = true;

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1021,20 +1021,43 @@ export function generateRemoteEntry(
         })
         .join(', ')}])
       : [];
+    const __mfRuntimeShareLoadIdKey = "__mf_vite_runtime_share_load_id__";
+    let __mfRuntimeShareLoadId = 0;
+    const __mfRuntimeShareSelections = new Map();
+    const __mfRuntimeShareLifecycles = new Map();
     const initRes = runtimeInit({
       name: mfName,
       remotes: ${options.shareStrategy === 'loaded-first' ? '[]' : 'usedRemotes'},
       shared: usedShared,
-      plugins: [${hasTreeShakingShared ? '__mfTreeShakingSnapshotPlugin(),' : ''} ...__browserPlugins, ...__ssrPlugins],
+      plugins: [__mfSharePinLifecyclePlugin(), ${hasTreeShakingShared ? '__mfTreeShakingSnapshotPlugin(),' : ''} ...__browserPlugins, ...__ssrPlugins],
       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ''}
     });
     initRes.initShareScopeMap('${options.shareScope}', shared);
+    function __mfSharePinLifecyclePlugin() {
+      return {
+        name: "vite-share-pin-lifecycle-plugin",
+        resolveShare(args) {
+          const loadId = args.shareInfo?.[__mfRuntimeShareLoadIdKey];
+          const lifecycle = loadId === undefined
+            ? undefined
+            : __mfRuntimeShareLifecycles.get(loadId);
+          if (!lifecycle) return args;
+          lifecycle.defaultResolver = args.resolver;
+          lifecycle.pinned.reveal();
+          return args;
+        }
+      };
+    }
     const runtimeResolveShareHook = initRes.sharedHandler.hooks.lifecycle.resolveShare;
     const __mfRuntimeProviderOrigins = new WeakMap();
-    const __mfRuntimeShareLoadIdKey = "__mf_vite_runtime_share_load_id__";
-    let __mfRuntimeShareLoadId = 0;
-    const __mfRuntimeShareSelections = new Map();
     runtimeResolveShareHook.on((args) => {
+      const loadId = args.shareInfo?.[__mfRuntimeShareLoadIdKey];
+      const lifecycle = loadId === undefined
+        ? undefined
+        : __mfRuntimeShareLifecycles.get(loadId);
+      if (lifecycle && args.resolver === lifecycle.defaultResolver) {
+        lifecycle.pinned.reapply();
+      }
       const resolver = args.resolver;
       if (typeof resolver !== "function") return args;
       const instrumentedResolver = (...resolverArgs) => {
@@ -1047,7 +1070,6 @@ export function generateRemoteEntry(
         ) {
           __mfRuntimeProviderOrigins.set(selectedProvider, { from: selectedProvider.from });
         }
-        const loadId = args.shareInfo?.[__mfRuntimeShareLoadIdKey];
         if (loadId !== undefined && selectedProvider) {
           __mfRuntimeShareSelections.set(loadId, selectedProvider);
         }
@@ -1065,11 +1087,27 @@ export function generateRemoteEntry(
       });
       const providerFrom = provider.from;
       versionMap[version] = pinnedProvider;
+      const isCurrentProviderActive = () => currentProvider === undefined
+        ? versionMap[version] === undefined
+        : versionMap[version] === currentProvider;
       return {
         provider: pinnedProvider,
+        reveal() {
+          if (versionMap[version] !== pinnedProvider) return false;
+          if (currentProvider === undefined) delete versionMap[version];
+          else versionMap[version] = currentProvider;
+          return true;
+        },
+        reapply() {
+          if (!isCurrentProviderActive()) return false;
+          versionMap[version] = pinnedProvider;
+          return true;
+        },
         release(loaded, selected = true) {
           provider.from = providerFrom;
-          if (versionMap[version] !== pinnedProvider) return false;
+          if (versionMap[version] !== pinnedProvider) {
+            return !selected && isCurrentProviderActive();
+          }
           if (!selected) {
             if (currentProvider === undefined) delete versionMap[version];
             else versionMap[version] = currentProvider;
@@ -1112,8 +1150,12 @@ export function generateRemoteEntry(
       }
       return match;
     };
-    const __mfLoadRuntimeShare = async (pkg, shareConfig) => {
+    const __mfLoadRuntimeShare = async (pkg, shareConfig, pinned) => {
       const loadId = ++__mfRuntimeShareLoadId;
+      __mfRuntimeShareLifecycles.set(loadId, {
+        pinned,
+        defaultResolver: undefined
+      });
       try {
         const factory = await initRes.loadShare(pkg, {
           customShareInfo: {
@@ -1127,6 +1169,7 @@ export function generateRemoteEntry(
         };
       } finally {
         __mfRuntimeShareSelections.delete(loadId);
+        __mfRuntimeShareLifecycles.delete(loadId);
       }
     };
     const __mfLoadPinnedRuntimeShare = async (
@@ -1148,7 +1191,7 @@ export function generateRemoteEntry(
       if (!pinned) return undefined;
       let runtimeLoad;
       try {
-        runtimeLoad = await __mfLoadRuntimeShare(pkg, shareConfig);
+        runtimeLoad = await __mfLoadRuntimeShare(pkg, shareConfig, pinned);
       } catch (error) {
         pinned.release(false);
         throw error;

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -515,9 +515,9 @@ function getNamedExportsViaRegex(
     }
   }
 
-  // A default export and an empty export list add no runtime named bindings,
-  // so an otherwise complete scan can still use the default-only live proxy.
-  const noNamedExportRegex = /export(?:\s+default\b|\s*\{\s*\})/g;
+  // Default, empty, and type-only exports add no runtime named bindings, so an
+  // otherwise complete scan can still use the default-only live proxy.
+  const noNamedExportRegex = /export(?:\s+default\b|\s*\{\s*\}|\s+(?:type|interface|declare)\b)/g;
   while ((match = noNamedExportRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
     recognizedExportStarts.add(match.index);

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -370,6 +370,7 @@ function getNamedExportsViaRegex(
 ): string[] {
   const names = new Set<string>();
   const codePositions = createCodePositionMap(source);
+  const recognizedExportStarts = new Set<number>();
   visited = visited || new Set();
   if (filePath) visited.add(filePath);
 
@@ -382,6 +383,7 @@ function getNamedExportsViaRegex(
   let match: RegExpExecArray | null;
   while ((match = declRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
+    recognizedExportStarts.add(match.index);
     const name = match[1];
     if (isValidEsmExportName(name)) names.add(name);
   }
@@ -418,6 +420,7 @@ function getNamedExportsViaRegex(
   const bindingNameRegex = new RegExp(`^(${JS_IDENTIFIER_PATTERN})`, 'u');
   while ((match = destructureRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
+    recognizedExportStarts.add(match.index);
     const inner = match[1].slice(1, -1);
     for (const part of inner.split(',')) {
       // strip a default value (`= ...`); rest elements (`...x`) never have one
@@ -440,6 +443,7 @@ function getNamedExportsViaRegex(
   const exportSpecifierRegex = new RegExp(`(?:\\S+\\s+as\\s+)?(${JS_IDENTIFIER_PATTERN})$`, 'u');
   while ((match = listRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
+    recognizedExportStarts.add(match.index);
     const specifiers = match[1].split(',');
     for (const specifier of specifiers) {
       const trimmed = specifier.trim();
@@ -466,6 +470,7 @@ function getNamedExportsViaRegex(
   );
   while ((match = namespaceReExportRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
+    recognizedExportStarts.add(match.index);
     if (isValidEsmExportName(match[1])) names.add(match[1]);
   }
   if (hasCodeMatch(source, /export\s+\*\s+as\s+['"]/g, codePositions)) {
@@ -477,6 +482,7 @@ function getNamedExportsViaRegex(
     const starExportRegex = /export\s+\*\s+from\s+['"]([^'"]+)['"]/g;
     while ((match = starExportRegex.exec(source)) !== null) {
       if (!codePositions[match.index]) continue;
+      recognizedExportStarts.add(match.index);
       const specifier = match[1];
       const resolvedPath = resolveReExportModule(filePath, specifier);
       if (!resolvedPath) {
@@ -506,6 +512,26 @@ function getNamedExportsViaRegex(
       } catch {
         scanState.complete = false;
       }
+    }
+  }
+
+  // A default export and an empty export list add no runtime named bindings,
+  // so an otherwise complete scan can still use the default-only live proxy.
+  const noNamedExportRegex = /export(?:\s+default\b|\s*\{\s*\})/g;
+  while ((match = noNamedExportRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
+    recognizedExportStarts.add(match.index);
+  }
+
+  // Regex extraction must fail closed. Valid syntax can omit whitespace or put
+  // comments between tokens, and silently treating an unmatched declaration as
+  // default-only would mix a cache-backed default with local named exports.
+  const exportKeywordRegex = /\bexport\b/g;
+  while ((match = exportKeywordRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
+    if (!recognizedExportStarts.has(match.index)) {
+      scanState.complete = false;
+      break;
     }
   }
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -14,6 +14,7 @@ import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL } from 'url';
 import { mfWarn } from '../utils/logger';
+import { createCodePositionMap } from '../utils/codePositionMap';
 import {
   getNormalizeModuleFederationOptions,
   type NormalizedShared,
@@ -95,17 +96,51 @@ function getPackageEsmEntryPath(pkg: string): string | undefined {
   );
 }
 
-function getEsmNamedExportsFromFile(entryPath: string | undefined): string[] {
-  try {
-    if (!entryPath) return [];
-    return getNamedExportsViaRegex(readFileSync(entryPath, 'utf-8'), entryPath);
-  } catch {
-    return [];
+type SharedExportInspection = {
+  namedExports: string[] | undefined;
+  commonJs: boolean;
+};
+
+type NamedExportScanState = {
+  complete: boolean;
+};
+
+function hasCodeMatch(source: string, regex: RegExp, codePositions: boolean[]): boolean {
+  regex.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(source)) !== null) {
+    if (codePositions[match.index]) return true;
   }
+  return false;
 }
 
-function getEsmNamedExports(pkg: string): string[] {
-  return getEsmNamedExportsFromFile(getPackageEsmEntryPath(pkg));
+function hasCommonJsExports(source: string): boolean {
+  const codePositions = createCodePositionMap(source);
+  return hasCodeMatch(
+    source,
+    /\bmodule\s*(?:\.exports|\[\s*['"]exports['"]\s*\])|\bexports\s*(?:\.|\[|[,)]|=(?!=|>))/g,
+    codePositions
+  );
+}
+
+function inspectSharedExportsFromFile(
+  entryPath: string | undefined
+): SharedExportInspection | undefined {
+  try {
+    if (!entryPath) return undefined;
+    const source = readFileSync(entryPath, 'utf-8');
+    const scanState: NamedExportScanState = { complete: true };
+    const namedExports = getNamedExportsViaRegex(source, entryPath, undefined, scanState);
+    const commonJs = hasCommonJsExports(source);
+    return {
+      // A complete empty ESM scan is a known default-only export surface. Keep
+      // unresolved re-exports and CommonJS sources conservative instead.
+      namedExports: scanState.complete && !commonJs ? namedExports : undefined,
+      commonJs,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveConfiguredImportPath(importSource: string): string | undefined {
@@ -189,25 +224,189 @@ function resolveReExportModule(filePath: string, specifier: string): string | un
   }
 }
 
+function hasTopLevelDeclaratorComma(source: string, start: number): boolean {
+  let depth = 0;
+  let quote: string | undefined;
+  let escaped = false;
+  let canStartRegex = true;
+
+  for (let index = start; index < source.length; index++) {
+    const char = source[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      canStartRegex = false;
+      continue;
+    }
+    if (char === '/' && source[index + 1] === '/') {
+      index = source.indexOf('\n', index + 2);
+      if (index === -1) return false;
+      continue;
+    }
+    if (char === '/' && source[index + 1] === '*') {
+      const commentEnd = source.indexOf('*/', index + 2);
+      if (commentEnd === -1) return true;
+      index = commentEnd + 1;
+      continue;
+    }
+    if (char === '/' && canStartRegex) {
+      let regexEscaped = false;
+      let inCharacterClass = false;
+      let closed = false;
+      for (index++; index < source.length; index++) {
+        const regexChar = source[index];
+        if (regexEscaped) {
+          regexEscaped = false;
+          continue;
+        }
+        if (regexChar === '\\') {
+          regexEscaped = true;
+          continue;
+        }
+        if (regexChar === '[') {
+          inCharacterClass = true;
+          continue;
+        }
+        if (regexChar === ']' && inCharacterClass) {
+          inCharacterClass = false;
+          continue;
+        }
+        if (regexChar === '/' && !inCharacterClass) {
+          closed = true;
+          while (/[$_\p{ID_Continue}]/u.test(source[index + 1] || '')) index++;
+          break;
+        }
+        if (regexChar === '\n' || regexChar === '\r') return true;
+      }
+      if (!closed) return true;
+      canStartRegex = false;
+      continue;
+    }
+    if (char === '/') {
+      canStartRegex = true;
+      continue;
+    }
+    if (/[$_\p{ID_Start}]/u.test(char)) {
+      const tokenStart = index;
+      while (/[$_\u200C\u200D\p{ID_Continue}]/u.test(source[index + 1] || '')) index++;
+      const token = source.slice(tokenStart, index + 1);
+      canStartRegex =
+        /^(?:await|case|delete|in|instanceof|new|return|throw|typeof|void|yield)$/.test(token);
+      continue;
+    }
+    if (/\d/.test(char)) {
+      while (/[\w.]/.test(source[index + 1] || '')) index++;
+      canStartRegex = false;
+      continue;
+    }
+    if ((char === '+' || char === '-') && source[index + 1] === char) {
+      index++;
+      continue;
+    }
+    if (char === '!' && source[index + 1] !== '=') {
+      continue;
+    }
+    if (char === '(' || char === '[' || char === '{') {
+      depth++;
+      canStartRegex = true;
+      continue;
+    }
+    if (char === ')' || char === ']' || char === '}') {
+      depth = Math.max(0, depth - 1);
+      canStartRegex = false;
+      continue;
+    }
+    if (depth === 0 && char === ',') return true;
+    if (depth === 0 && char === ';') return false;
+    if (!/\s/.test(char)) {
+      canStartRegex = char !== '.';
+    }
+  }
+
+  return false;
+}
+
+function hasUnsupportedBindingPattern(source: string, start: number): boolean {
+  const opening = source[start];
+  if (opening !== '{' && opening !== '[') return false;
+
+  let depth = 0;
+  for (let index = start; index < source.length; index++) {
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') return true;
+    if (char === '(' || char === '/' || (char === ':' && opening === '[')) return true;
+    if (char === '{' || char === '[') {
+      depth++;
+      if (depth > 1) return true;
+      continue;
+    }
+    if (char === '}' || char === ']') {
+      depth--;
+      if (depth === 0) {
+        let next = index + 1;
+        while (/\s/.test(source[next] || '')) next++;
+        return source[next] !== '=';
+      }
+    }
+  }
+
+  return true;
+}
+
 function getNamedExportsViaRegex(
   source: string,
   filePath?: string,
-  visited?: Set<string>
+  visited?: Set<string>,
+  scanState: NamedExportScanState = { complete: true }
 ): string[] {
   const names = new Set<string>();
+  const codePositions = createCodePositionMap(source);
   visited = visited || new Set();
   if (filePath) visited.add(filePath);
 
   const declRegex = new RegExp(
     `export\\s+(?:async\\s+)?(?:` +
       `function(?:\\*\\s*|\\s+\\*?\\s*)` +
-      `|const\\s+|let\\s+|var\\s+|class\\s+|enum\\s+|namespace\\s+)(${JS_IDENTIFIER_PATTERN})`,
+      `|const\\s+enum\\s+|const\\s+|let\\s+|var\\s+|class\\s+|abstract\\s+class\\s+|enum\\s+|namespace\\s+|module\\s+)(${JS_IDENTIFIER_PATTERN})`,
     'gu'
   );
   let match: RegExpExecArray | null;
   while ((match = declRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
     const name = match[1];
     if (isValidEsmExportName(name)) names.add(name);
+  }
+
+  // The declaration matcher above captures only the first binding in
+  // `export const a = 1, b = 2`. Until every declarator is represented by a
+  // live proxy binding, treat that export surface as incomplete.
+  const exportedVariableDeclarationRegex = /export\s+(?:const|let|var)\s+/g;
+  while ((match = exportedVariableDeclarationRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
+    if (hasTopLevelDeclaratorComma(source, exportedVariableDeclarationRegex.lastIndex)) {
+      scanState.complete = false;
+    }
+    if (hasUnsupportedBindingPattern(source, exportedVariableDeclarationRegex.lastIndex)) {
+      scanState.complete = false;
+    }
+  }
+  if (
+    hasCodeMatch(source, /export\s+import\s+/g, codePositions) ||
+    hasCodeMatch(source, /export\s*=/g, codePositions)
+  ) {
+    scanState.complete = false;
+  }
+  if (hasCodeMatch(source, /export\s+@/g, codePositions)) {
+    scanState.complete = false;
   }
 
   // Destructuring exports, e.g. `export const { a, b: alias, ...rest } = obj;`
@@ -218,6 +417,7 @@ function getNamedExportsViaRegex(
   const destructureRegex = /export\s+(?:const|let|var)\s+(\{[^}]*\}|\[[^\]]*\])\s*=/g;
   const bindingNameRegex = new RegExp(`^(${JS_IDENTIFIER_PATTERN})`, 'u');
   while ((match = destructureRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
     const inner = match[1].slice(1, -1);
     for (const part of inner.split(',')) {
       // strip a default value (`= ...`); rest elements (`...x`) never have one
@@ -239,6 +439,7 @@ function getNamedExportsViaRegex(
   );
   const exportSpecifierRegex = new RegExp(`(?:\\S+\\s+as\\s+)?(${JS_IDENTIFIER_PATTERN})$`, 'u');
   while ((match = listRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
     const specifiers = match[1].split(',');
     for (const specifier of specifiers) {
       const trimmed = specifier.trim();
@@ -246,9 +447,16 @@ function getNamedExportsViaRegex(
         continue;
       }
       const asMatch = trimmed.match(exportSpecifierRegex);
-      if (!asMatch) continue;
+      if (!asMatch) {
+        scanState.complete = false;
+        continue;
+      }
       const name = asMatch[1];
-      if (isValidEsmExportName(name)) names.add(name);
+      if (isValidEsmExportName(name)) {
+        names.add(name);
+      } else {
+        scanState.complete = false;
+      }
     }
   }
 
@@ -257,24 +465,46 @@ function getNamedExportsViaRegex(
     'gu'
   );
   while ((match = namespaceReExportRegex.exec(source)) !== null) {
+    if (!codePositions[match.index]) continue;
     if (isValidEsmExportName(match[1])) names.add(match[1]);
+  }
+  if (hasCodeMatch(source, /export\s+\*\s+as\s+['"]/g, codePositions)) {
+    scanState.complete = false;
   }
 
   // Handle `export * from './module'` re-exports
   if (filePath) {
     const starExportRegex = /export\s+\*\s+from\s+['"]([^'"]+)['"]/g;
     while ((match = starExportRegex.exec(source)) !== null) {
+      if (!codePositions[match.index]) continue;
       const specifier = match[1];
       const resolvedPath = resolveReExportModule(filePath, specifier);
-      if (!resolvedPath || visited.has(resolvedPath)) continue;
+      if (!resolvedPath) {
+        scanState.complete = false;
+        continue;
+      }
+      if (visited.has(resolvedPath)) continue;
+      if (path.extname(resolvedPath) === '.cjs') {
+        scanState.complete = false;
+        continue;
+      }
       try {
         const reExportSource = readFileSync(resolvedPath, 'utf-8');
-        const reExportNames = getNamedExportsViaRegex(reExportSource, resolvedPath, visited);
+        if (hasCommonJsExports(reExportSource)) {
+          scanState.complete = false;
+          continue;
+        }
+        const reExportNames = getNamedExportsViaRegex(
+          reExportSource,
+          resolvedPath,
+          visited,
+          scanState
+        );
         for (const name of reExportNames) {
           names.add(name);
         }
       } catch {
-        // skip unreadable files
+        scanState.complete = false;
       }
     }
   }
@@ -282,27 +512,63 @@ function getNamedExportsViaRegex(
   return Array.from(names);
 }
 
-function getPackageNamedExports(pkg: string): string[] {
+function getRequiredNamedExports(specifier: string): string[] | undefined {
   try {
-    // Resolve from the project root (process.cwd()) so that shared packages
-    // like react are found even when the plugin is installed in a nested
-    // pnpm store location where peer dependencies are not hoisted.
     const projectRequire = createRequire(
       pathToFileURL(path.join(getPackageDetectionCwd(), 'package.json'))
     );
-    const mod = projectRequire(pkg);
-    return Object.keys(mod).filter((k) => isValidEsmExportName(k));
+    const mod = projectRequire(specifier);
+    const runtimeNamedKeys = Object.keys(mod).filter(
+      (key) => key !== 'default' && key !== '__esModule'
+    );
+    if (runtimeNamedKeys.some((key) => !isValidEsmExportName(key))) return undefined;
+    return runtimeNamedKeys;
   } catch {
-    return getEsmNamedExports(pkg);
+    return undefined;
   }
 }
 
-function getSharedNamedExports(pkg: string, shareItem?: ShareItem): string[] {
+function getPackageNamedExports(pkg: string): string[] | undefined {
+  // Inspect the browser/import entry that Vite will bundle before considering
+  // the package's require condition. Dual-format packages can expose different
+  // APIs from those two entry points.
+  const esmEntryPath = getInstalledPackageEntry(pkg, {
+    conditions: ['browser', 'import', 'module', 'default'],
+    resolveSubpathWithRequire: false,
+  });
+  if (esmEntryPath) {
+    const inspection = inspectSharedExportsFromFile(esmEntryPath);
+
+    // The selected Vite entry may itself be CommonJS. Requiring that exact file
+    // gives us its runtime namespace without substituting a different condition.
+    if (!inspection || inspection.commonJs || path.extname(esmEntryPath) === '.cjs') {
+      return getRequiredNamedExports(esmEntryPath);
+    }
+    if (inspection.namedExports !== undefined) return inspection.namedExports;
+    return undefined;
+  }
+
+  // Resolve from the project root (process.cwd()) so shared packages like React
+  // are found even when the plugin lives in a nested pnpm store.
+  return getRequiredNamedExports(pkg);
+}
+
+export function getSharedNamedExports(pkg: string, shareItem?: ShareItem): string[] | undefined {
   const configuredImport = shareItem?.shareConfig.import;
   if (typeof configuredImport === 'string') {
     const configuredImportPath = resolveConfiguredImportPath(configuredImport);
-    const configuredNamedExports = getEsmNamedExportsFromFile(configuredImportPath);
-    if (configuredNamedExports.length > 0) return configuredNamedExports;
+    // The configured source is authoritative. Do not fall back to the package
+    // entry when that source is default-only or cannot be inspected: its export
+    // shape may intentionally differ from the package root.
+    const inspection = inspectSharedExportsFromFile(configuredImportPath);
+    if (
+      configuredImportPath &&
+      (inspection?.commonJs || path.extname(configuredImportPath) === '.cjs')
+    ) {
+      return getRequiredNamedExports(configuredImportPath);
+    }
+    if (inspection?.namedExports !== undefined) return inspection.namedExports;
+    return undefined;
   }
 
   return getPackageNamedExports(pkg);
@@ -715,7 +981,7 @@ export function writePreBuildLibPath(pkg: string, shareItem?: ShareItem) {
     );
     return;
   }
-  const namedExports = getSharedNamedExports(pkg, shareItem);
+  const namedExports = getSharedNamedExports(pkg, shareItem) ?? [];
   if (namedExports.length > 0) {
     const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
     const declarations = namedExports
@@ -846,18 +1112,20 @@ function generateEagerWorkspaceSingletonExports(
   namedExports: string[],
   importSource: string,
   cacheDescriptor: string,
+  cacheOwner: string,
   treeShakingConsumer?: string
 ) {
   const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
-  const namedExportAssignments =
+  const declarations =
     namedExports.length > 0
-      ? `\n    ${namedExports
-          .map(
-            (name, i) =>
-              `const ${namedExportVars[i]} = exportModule[${escapeGeneratedStringLiteral(name)}];`
-          )
-          .join('\n    ')}`
-      : '';
+      ? ['let __mf_default;', ...namedExportVars.map((name) => `let ${name};`)].join('\n    ')
+      : 'let __mf_default;';
+  const assignments = [
+    ...namedExports.map(
+      (name, i) => `${namedExportVars[i]} = mod[${escapeGeneratedStringLiteral(name)}];`
+    ),
+    '__mf_default = mod.default ?? mod;',
+  ].join('\n      ');
   const namedExportLine =
     namedExports.length > 0
       ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(', ')} };`
@@ -868,18 +1136,24 @@ function generateEagerWorkspaceSingletonExports(
     if (exportModule === undefined) {
       Promise.resolve().then(() => {
         if (__mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor}) === undefined) {
-          __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfNormalizeShareModule(__mfLocalShare));
+          __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfNormalizeShareModule(__mfLocalShare), ${cacheOwner});
         }
       });
       exportModule = __mfLocalShare;
     }
-    const __mf_default = exportModule.default ?? exportModule;${namedExportAssignments}
+    ${declarations}
+    const __mfApplyEagerShareExports = (mod) => {
+      ${assignments}
+    };
+    __mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplyEagerShareExports);
+    __mfApplyEagerShareExports(exportModule);
     export { __mf_default as default };${namedExportLine}`;
 }
 function generateLazyWorkspaceSingletonExports(
   namedExports: string[],
   importSource: string,
   cacheDescriptor: string,
+  cacheOwner: string,
   treeShakingConsumer?: string
 ) {
   const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
@@ -901,13 +1175,13 @@ function generateLazyWorkspaceSingletonExports(
       ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(', ')} };`
       : '';
   const applyLocalFallback = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
-      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);
-      __mfApplyLazyShareExports(exportModule);`;
+      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});`;
 
   const body = `${declarations}
     const __mfApplyLazyShareExports = (mod) => {
       ${assignments}
     };
+    __mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplyLazyShareExports);
     let exportModule = ${getSharedCacheReadExpression(cacheDescriptor, treeShakingConsumer)};
     if (exportModule === undefined) {
       if (import.meta.env.SSR) {
@@ -921,8 +1195,7 @@ function generateLazyWorkspaceSingletonExports(
           }
           return import(${escapeGeneratedStringLiteral(importSource)}).then((mod) => {
             exportModule = __mfNormalizeShareModule(mod);
-            __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);
-            __mfApplyLazyShareExports(exportModule);
+            __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});
           });
         }));
       }
@@ -1037,6 +1310,7 @@ export function writeLoadShareModule(
   }
   let importLine = getRuntimeModuleCacheBootstrapCode();
   const cacheDescriptor = getSharedCacheDescriptorLiteral(pkg, shareItem);
+  const cacheOwner = JSON.stringify(getNormalizeModuleFederationOptions().name);
   const treeShakingConsumer =
     command === 'build' && shareItem.shareConfig.treeShaking
       ? getNormalizeModuleFederationOptions().name
@@ -1049,7 +1323,8 @@ export function writeLoadShareModule(
     // Try to detect named exports from locally installed devDependencies.
     // This enables `import { ref } from 'vue'` even though the module is provided by the host.
     // For packages that aren't installed, fall back to default-only export.
-    const namedExports = getPackageNamedExports(pkg);
+    const detectedNamedExports = getPackageNamedExports(pkg);
+    const namedExports = detectedNamedExports ?? [];
     let exportLine: string;
     if (namedExports.length > 0) {
       exportLine = generateDeferredHostProvidedExports(
@@ -1059,11 +1334,13 @@ export function writeLoadShareModule(
         treeShakingConsumer
       );
     } else {
-      mfWarn(
-        `Shared dependency "${pkg}" has import: false but is not installed locally.\n` +
-          `  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n` +
-          `  Install it as a devDependency to enable named export detection.`
-      );
+      if (detectedNamedExports === undefined) {
+        mfWarn(
+          `Shared dependency "${pkg}" has import: false but is not installed locally.\n` +
+            `  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n` +
+            `  Install it as a devDependency to enable named export detection.`
+        );
+      }
       exportLine = generateDeferredHostProvidedExports(
         [],
         pkg,
@@ -1088,6 +1365,7 @@ export function writeLoadShareModule(
   const sharedImportSource = concreteSharedImportSource || getPreBuildLibImportId(pkg);
   const devImportSource = concreteSharedImportSource || pkg;
   const localProviderPath = getLocalProviderImportPath(pkg);
+  const coherentLocalSource = concreteSharedImportSource || localProviderPath || devImportSource;
   const isWorkspacePackage =
     isWorkspacePackageEntry(pkg, localProviderPath) ||
     isWorkspacePackageEntry(pkg, concreteSharedImportSource);
@@ -1096,29 +1374,36 @@ export function writeLoadShareModule(
       ? concreteSharedImportSource || localProviderPath || devImportSource
       : concreteSharedImportSource || localProviderPath || sharedImportSource;
   const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
+  const detectedNamedExports = getSharedNamedExports(pkg, shareItem);
+  const namedExports = detectedNamedExports ?? [];
+  const hasCompleteExportCoverage = detectedNamedExports !== undefined;
   const isWorkspaceSingleton = isWorkspacePackage && shareItem.shareConfig.singleton === true;
   const isDefaultShareScope =
     shareItem.scope === undefined ||
     shareItem.scope === 'default' ||
     (Array.isArray(shareItem.scope) && shareItem.scope[0] === 'default');
   const usesDeferredSingletonFallback =
-    isWorkspaceSingleton ||
-    (command !== 'build' && isRemoteOnlyContainer() && shareItem.shareConfig.singleton === true) ||
-    (command === 'build' &&
-      isRemoteOnlyContainer() &&
-      shareItem.shareConfig.singleton === true &&
-      !isDefaultShareScope);
+    hasCompleteExportCoverage &&
+    (isWorkspaceSingleton ||
+      (command !== 'build' &&
+        isRemoteOnlyContainer() &&
+        shareItem.shareConfig.singleton === true) ||
+      (command === 'build' &&
+        isRemoteOnlyContainer() &&
+        shareItem.shareConfig.singleton === true &&
+        !isDefaultShareScope));
   const isConsumedByPeerSingleton = isSharedSingletonConsumedByPeer(pkg);
   const usesEntryInjectedRemoteFallback =
+    hasCompleteExportCoverage &&
     command !== 'build' &&
     !isWorkspaceSingleton &&
     isRemoteOnlyContainer() &&
     shareItem.shareConfig.singleton === true &&
     getNormalizeModuleFederationOptions().hostInitInjectLocation === 'entry' &&
     isConsumedByPeerSingleton;
-  const usesEagerWorkspaceFallback = isWorkspaceSingleton && isConsumedByPeerSingleton;
-  const usesDeferredTreeShakingFallback = Boolean(treeShakingConsumer);
-  const namedExports = getSharedNamedExports(pkg, shareItem);
+  const usesEagerWorkspaceFallback =
+    hasCompleteExportCoverage && isWorkspaceSingleton && isConsumedByPeerSingleton;
+  const usesDeferredTreeShakingFallback = hasCompleteExportCoverage && Boolean(treeShakingConsumer);
   let exportLine: string;
   let initBlock = '';
   if (usesDeferredTreeShakingFallback) {
@@ -1127,6 +1412,7 @@ export function writeLoadShareModule(
       namedExports,
       lazyLocalFallbackSource,
       cacheDescriptor,
+      cacheOwner,
       treeShakingConsumer
     );
   } else if (usesEagerWorkspaceFallback || usesEntryInjectedRemoteFallback) {
@@ -1134,6 +1420,7 @@ export function writeLoadShareModule(
       namedExports,
       lazyLocalFallbackSource,
       cacheDescriptor,
+      cacheOwner,
       treeShakingConsumer
     );
   } else if (usesDeferredSingletonFallback) {
@@ -1142,8 +1429,53 @@ export function writeLoadShareModule(
       namedExports,
       lazyLocalFallbackSource,
       cacheDescriptor,
+      cacheOwner,
       treeShakingConsumer
     );
+  } else if (detectedNamedExports === undefined) {
+    // Unknown export coverage cannot be rebound safely: a live default backed by
+    // the shared cache plus `export *` backed by the local source can mix two
+    // singleton instances. Keep the complete proxy on the local namespace.
+    exportLine = `const __mfDefaultExport = (() => {
+      ${generateShareModuleUnwrapCode({
+        source: '__mfLocalShare',
+        preserveNamedExports: false,
+        stopWithReturn: 'defaultExport ?? current',
+      })}
+    })();
+    export default __mfDefaultExport;
+    export * from ${escapeGeneratedStringLiteral(coherentLocalSource)}`;
+    initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
+      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});`;
+  } else if (namedExports.length > 0 && shareItem.shareConfig.singleton === true) {
+    const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+    const declarations = [
+      'let __mfDefaultExport;',
+      ...namedExportVars.map((name) => `let ${name};`),
+    ].join('\n    ');
+    const assignments = [
+      ...namedExports.map(
+        (name, i) => `${namedExportVars[i]} = mod[${escapeGeneratedStringLiteral(name)}];`
+      ),
+      `__mfDefaultExport = (() => {
+        ${generateShareModuleUnwrapCode({
+          source: 'mod',
+          preserveNamedExports: false,
+          stopWithReturn: 'defaultExport ?? current',
+        })}
+      })();`,
+    ].join('\n      ');
+    const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(', ')} };`;
+    exportLine = `${declarations}
+    const __mfApplySharedExports = (mod) => {
+      ${assignments}
+    };
+    __mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplySharedExports);
+    __mfApplySharedExports(exportModule);
+    export { __mfDefaultExport as default };
+    ${namedExportLine}`;
+    initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
+      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});`;
   } else if (namedExports.length > 0) {
     const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(', ')} } = exportModule;`;
     const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(', ')} };`;
@@ -1158,18 +1490,32 @@ export function writeLoadShareModule(
     ${destructure}
     ${namedExportLine}`;
     initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
-      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);`;
+      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});`;
+  } else if (shareItem.shareConfig.singleton === true) {
+    exportLine = `let __mfDefaultExport;
+    const __mfApplySharedDefaultExport = (mod) => {
+      __mfDefaultExport = mod.default ?? mod;
+    };
+    __mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplySharedDefaultExport);
+    __mfApplySharedDefaultExport(exportModule);
+    export { __mfDefaultExport as default };
+    export * from ${escapeGeneratedStringLiteral(sharedImportSource)}`;
+    initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
+      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});`;
   } else {
     exportLine = `export default exportModule.default ?? exportModule\n    export * from ${escapeGeneratedStringLiteral(sharedImportSource)}`;
     initBlock = `exportModule = __mfNormalizeShareModule(__mfLocalShare);
-      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule);`;
+      __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, exportModule, ${cacheOwner});`;
   }
 
-  const staticLocalShareSource = skipServePrebuildWarmup ? devImportSource : sharedImportSource;
+  const staticLocalShareSource =
+    detectedNamedExports === undefined
+      ? coherentLocalSource
+      : skipServePrebuildWarmup
+        ? devImportSource
+        : sharedImportSource;
   const prebuildImportLine =
-    usesDeferredSingletonFallback ||
-    usesDeferredTreeShakingFallback ||
-    (isWorkspacePackage && command !== 'build')
+    usesDeferredSingletonFallback || usesDeferredTreeShakingFallback
       ? ''
       : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(staticLocalShareSource)};`;
   const devDynamicImportLine = isWorkspacePackage


### PR DESCRIPTION
## Summary

- materialize lazy/get-only shared providers through the Module Federation Runtime before exposing remote modules
- keep singleton proxy exports live when runtime selection replaces a local fallback
- seed root-host singletons before version-first remote initialization, while deferring child fallbacks to real parent providers
- preserve provider provenance, cache ownership, runtime plugin hooks, and circular-init scope
- preserve normal `beforeLoadShare` → `resolveShare` → `afterLoadShare` ordering while honoring custom provider selection
- keep unknown and transpiled CommonJS export surfaces on one coherent module instance
- cover get-only React sharing with a browser regression that executes `useState`

## Root cause

The deployed host supplied React 18 as an unloaded `get` provider, while the layout remote bundled React 17. The Vite remote bridge only copied providers with an existing `lib`, so it skipped the host provider and seeded its local React into the Vite cache. The Runtime share scope selected host React, but the remote's generated imports still resolved to local React; ReactDOM then rendered hooks from a different React instance and raised minified React error #321.

## Verification

- `pnpm fmt.check`
- `pnpm typecheck`
- `pnpm test` — 816 passed, 1 skipped
- `pnpm test:integration` — 45 passed
- `pnpm build`
- Playwright browser matrix — 21 passed across Vite, Webpack, Rspack, and runtime-register scenarios
- deployed-chunk control — upstream reproduces the null `useState` crash; this branch resolves the remote to the host React export identity and mounts successfully
