### PR TITLE
feat: support multiple provider share scopes

### DIFF
--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -59,6 +59,15 @@ describe('normalizeModuleFederationOption', () => {
     });
   });
 
+  it('preserves multiple provider share scopes', () => {
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shareScope: ['default', 'scope1'],
+      }).shareScope
+    ).toEqual(['default', 'scope1']);
+  });
+
   it('maps reserved remote name internally', () => {
     mfWarnSpy.mockClear();
 
@@ -217,6 +226,21 @@ describe('normalizeModuleFederationOption', () => {
       expect(mfWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Reserved internal remoteAlias prefix "__mfe_internal__" detected')
       );
+    });
+
+    it('preserves multiple share scopes on remote config', () => {
+      expect(
+        normalizeModuleFederationOptions({
+          ...minimalOptions,
+          remotes: {
+            remote1: {
+              name: 'remote1',
+              entry: 'http://localhost:3001/remoteEntry.js',
+              shareScope: ['default', 'scope1'],
+            },
+          },
+        }).remotes.remote1.shareScope
+      ).toEqual(['default', 'scope1']);
     });
   });
 

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -46,7 +46,7 @@ export interface RemoteObjectConfig {
   internalName?: string;
   entry: string;
   entryGlobalName?: string;
-  shareScope?: string;
+  shareScope?: string | string[];
 }
 
 const INTERNAL_NAME_PREFIX = '__mfe_internal__';
@@ -460,7 +460,7 @@ export type ModuleFederationOptions = {
   // remoteType?: string;
   remotes?: Record<string, string | RemoteObjectConfig> | undefined;
   runtime?: any;
-  shareScope?: string;
+  shareScope?: string | string[];
   /**
    * Override the public path used for remote entries
    * Defaults to Vite's base config or "auto" if base is empty
@@ -547,7 +547,7 @@ export interface NormalizedModuleFederationOptions extends Omit<
   library: any;
   remotes: Record<string, RemoteObjectConfig>;
   runtime: any;
-  shareScope: string;
+  shareScope: string | string[];
   shared: NormalizedShared;
   runtimePlugins: Array<string | [string, Record<string, unknown>]>;
   implementation: string;

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -910,6 +910,9 @@ describe('virtualRemoteEntry', () => {
     );
 
     expect(code).toContain('const shareScopeNames = Array.isArray(["default","scope1"])');
+    expect(code).toContain('const getShareScopeName = (pkg, share) =>');
+    expect(code).toContain('return [...new Set([...configuredScopes, ...shareScopeNames])]');
+    expect(code).toContain('getShareScope(getShareScopeName(pkg, usedShare))');
     expect(code).toContain('for (const shareScopeName of shareScopeNames)');
     expect(code).toContain('initRes.initShareScopeMap(shareScopeName, scopeShare)');
     expect(code).toContain('initRes.initializeSharing(shareScopeName');

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -892,6 +892,29 @@ describe('virtualRemoteEntry', () => {
     expect(generatedCode).not.toContain('.catch(remoteEntry.init)');
   });
 
+  it('initializes all configured provider share scopes in remoteEntry', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        remotes: {},
+        runtimePlugins: [],
+        shareScope: ['default', 'scope1'],
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+
+    expect(code).toContain('const shareScopeNames = Array.isArray(["default","scope1"])');
+    expect(code).toContain('for (const shareScopeName of shareScopeNames)');
+    expect(code).toContain('initRes.initShareScopeMap(shareScopeName, scopeShare)');
+    expect(code).toContain('initRes.initializeSharing(shareScopeName');
+  });
+
   it('inlines a dedicated build-only initResolve bootstrap into remoteEntry', async () => {
     const mod = await import('../virtualRemoteEntry');
 

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -24,4 +24,19 @@ describe('virtualRemoteEntrySSR', () => {
     expect(code).not.toContain('name: "__mfe_internal__remote"');
     expect(code).not.toContain('from: "__mfe_internal__remote"');
   });
+
+  it('initializes all configured SSR provider share scopes', () => {
+    const options = getDefaultMockOptions({
+      name: 'remote',
+      shareScope: ['default', 'scope1'],
+      shareStrategy: 'version-first',
+    } as any);
+
+    const code = generateRemoteEntrySSR(options);
+
+    expect(code).toContain('const shareScopeNames = Array.isArray(["default","scope1"])');
+    expect(code).toContain('for (const scopeName of shareScopeNames)');
+    expect(code).toContain('initRes.initShareScopeMap(scopeName, scopeShare)');
+    expect(code).toContain('initRes.initializeSharing(scopeName');
+  });
 });

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -36,6 +36,7 @@ describe('virtualRemoteEntrySSR', () => {
 
     expect(code).toContain('const shareScopeNames = Array.isArray(["default","scope1"])');
     expect(code).toContain('for (const scopeName of shareScopeNames)');
+    expect(code).toContain("console.error('[Module Federation SSR]', e);");
     expect(code).toContain('initRes.initShareScopeMap(scopeName, scopeShare)');
     expect(code).toContain('initRes.initializeSharing(scopeName');
   });

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -867,6 +867,7 @@ export function generateRemoteEntry(
   const hasEagerShared = Object.values(options.shared ?? {}).some(
     (share) => share?.shareConfig.eager === true && share.shareConfig.import !== false
   );
+  const hasMultipleShareScopes = Array.isArray(options.shareScope);
   const runtimeImports = [
     'init as runtimeInit',
     'loadRemote',
@@ -887,7 +888,21 @@ export function generateRemoteEntry(
       ];
     }
   });
-  const initializeSharingCode = `try {
+  const initializeSharingCode = hasMultipleShareScopes
+    ? `for (const shareScopeName of shareScopeNamesToInitialize) {
+      try {
+        await retrySharedInit(async () => {
+          await Promise.all(await initRes.initializeSharing(shareScopeName, {
+            strategy: '${options.shareStrategy}',
+            from: "build",
+            initScope
+          }));
+        });
+      } catch (e) {
+        console.error('[Module Federation]', e)
+      }
+    }`
+    : `try {
       await retrySharedInit(async () => {
         await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
           strategy: '${options.shareStrategy}',
@@ -930,7 +945,10 @@ export function generateRemoteEntry(
   }
   ${getRuntimeModuleCacheBootstrapCode()}
   const initTokens = {}
-  const shareScopeName = ${JSON.stringify(options.shareScope)}
+  const shareScopeNames = Array.isArray(${JSON.stringify(options.shareScope)}) ? ${JSON.stringify(options.shareScope)} : [${JSON.stringify(options.shareScope)}]
+  const shareScopeName = ${JSON.stringify(
+    hasMultipleShareScopes ? options.shareScope[0] : options.shareScope
+  )}
   const mfName = ${JSON.stringify(options.name)}
   let localSharedImportMapPromise
   let exposesMapPromise
@@ -981,31 +999,72 @@ export function generateRemoteEntry(
 
   async function init(shared = {}, initScope = []) {
     ${sharedCacheHelperCode}
+    const getShareScope = (scopeName) => ${hasMultipleShareScopes} ? (shared?.[scopeName] || {}) : shared;
+    const getShareVersions = (pkg, share) => {
+      const configuredScopes = Array.isArray(share?.scope) ? share.scope : [share?.scope || shareScopeName];
+      for (const scopeName of configuredScopes) {
+        const versions = getShareScope(scopeName)?.[pkg];
+        if (versions) return versions;
+      }
+      return getShareScope(shareScopeName)?.[pkg];
+    };
     const federationInstances = globalThis.__FEDERATION__?.__INSTANCES__ || [];
     const initRootName = initScope.find((token) => token?.from)?.from;
     const scopeRoot = federationInstances.find((instance) =>
       instance?.options?.name === initRootName &&
-      instance?.shareScopeMap?.['${options.shareScope}'] === shared
+      ${
+        hasMultipleShareScopes
+          ? 'shareScopeNames.some((scopeName) => instance?.shareScopeMap?.[scopeName] === getShareScope(scopeName))'
+          : `instance?.shareScopeMap?.['${options.shareScope}'] === shared`
+      }
     ) || federationInstances.find((instance) =>
       instance?.options?.name !== mfName &&
-      instance?.shareScopeMap?.['${options.shareScope}'] === shared
+      ${
+        hasMultipleShareScopes
+          ? 'shareScopeNames.some((scopeName) => instance?.shareScopeMap?.[scopeName] === getShareScope(scopeName))'
+          : `instance?.shareScopeMap?.['${options.shareScope}'] === shared`
+      }
     );
     const initialShared = Object.create(null);
-    for (const [pkg, versions] of Object.entries(shared)) {
+    ${
+      hasMultipleShareScopes
+        ? `for (const scopeName of shareScopeNames) {
+      for (const [pkg, versions] of Object.entries(getShareScope(scopeName))) {
+        if (initialShared[pkg]) continue;
+        const initialVersions = initialShared[pkg] = Object.create(null);
+        for (const [version, provider] of Object.entries(versions)) {
+          initialVersions[version] = Object.assign({}, provider);
+        }
+      }
+    }`
+        : `for (const [pkg, versions] of Object.entries(shared)) {
       const initialVersions = initialShared[pkg] = Object.create(null);
       for (const [version, provider] of Object.entries(versions)) {
         // Runtime registration mutates provider records in-place, notably their origin.
         // Preserve the parent-visible provider and its original provenance.
         initialVersions[version] = Object.assign({}, provider);
       }
+    }`
     }
     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
     // handling circular init calls before an external provider can re-enter this container
-    var initToken = initTokens[shareScopeName];
+    ${
+      hasMultipleShareScopes
+        ? `const shareScopeNamesToInitialize = [];
+    for (const shareScopeName of shareScopeNames) {
+      let initToken = initTokens[shareScopeName];
+      if (!initToken) initToken = initTokens[shareScopeName] = { from: mfName };
+      if (initScope.indexOf(initToken) >= 0) continue;
+      initScope.push(initToken);
+      shareScopeNamesToInitialize.push(shareScopeName);
+    }
+    if (shareScopeNamesToInitialize.length === 0) return;`
+        : `var initToken = initTokens[shareScopeName];
     if (!initToken)
       initToken = initTokens[shareScopeName] = { from: mfName };
     if (initScope.indexOf(initToken) >= 0) return;
-    initScope.push(initToken);
+    initScope.push(initToken);`
+    }
     ${normalizeRuntimeShareCode}
     const __browserPlugins = [${pluginImportNames
       .filter((item) => !isSsrOnlyPlugin(item[1]))
@@ -1032,7 +1091,14 @@ export function generateRemoteEntry(
       plugins: [__mfSharePinLifecyclePlugin(), ${hasTreeShakingShared ? '__mfTreeShakingSnapshotPlugin(),' : ''} ...__browserPlugins, ...__ssrPlugins],
       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ''}
     });
-    initRes.initShareScopeMap('${options.shareScope}', shared);
+    ${
+      hasMultipleShareScopes
+        ? `for (const shareScopeName of shareScopeNamesToInitialize) {
+      const scopeShare = getShareScope(shareScopeName);
+      initRes.initShareScopeMap(shareScopeName, scopeShare);
+    }`
+        : `initRes.initShareScopeMap('${options.shareScope}', shared);`
+    }
     function __mfSharePinLifecyclePlugin() {
       return {
         name: "vite-share-pin-lifecycle-plugin",
@@ -1080,7 +1146,9 @@ export function generateRemoteEntry(
       if (!versionMap || versionMap[version] !== currentProvider) return undefined;
       const pinnedProvider = Object.assign({}, provider, {
         version: provider.version ?? version,
-        scope: provider.scope ?? currentProvider?.scope ?? ['${options.shareScope}'],
+        scope: provider.scope ?? currentProvider?.scope ?? ${JSON.stringify(
+          hasMultipleShareScopes ? options.shareScope : [options.shareScope]
+        )},
         strategy: 'loaded-first'
       });
       const providerFrom = provider.from;
@@ -1288,7 +1356,9 @@ export function generateRemoteEntry(
           usedShare.scope
         );
         if (__mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor) !== undefined) return;
-        const liveVersionMap = shared[pkg];
+        const liveVersionMap = ${
+          hasMultipleShareScopes ? 'getShareVersions(pkg, usedShare)' : 'shared[pkg]'
+        };
         const liveProvider = liveVersionMap?.[version];
         if (providerEntry.registered && !__mfMatchesSharedProvider(liveProvider, provider)) return;
         let loadedShare;
@@ -1382,8 +1452,16 @@ export function generateRemoteEntry(
         const resolvedExternalProvider = __mfResolveExternalSharedProvider(
           federationInstances,
           scopeRoot,
-          shared,
-          '${options.shareScope}',
+          ${
+            hasMultipleShareScopes
+              ? 'getShareScope(Array.isArray(usedShare.scope) ? usedShare.scope[0] : (usedShare.scope || shareScopeName))'
+              : 'shared'
+          },
+          ${
+            hasMultipleShareScopes
+              ? 'Array.isArray(usedShare.scope) ? usedShare.scope[0] : (usedShare.scope || shareScopeName)'
+              : `'${options.shareScope}'`
+          },
           pkg,
           providerEntry,
           selectedExternalProvider,
@@ -1405,7 +1483,9 @@ export function generateRemoteEntry(
         if (cachedShare !== undefined && cachedShareOwner !== mfName) return;
         // Registration can replace an unloaded same-version root provider in-place.
         // Pin the chosen provider while loadShare() runs its implicit registration.
-        const liveVersionMap = shared[pkg];
+        const liveVersionMap = ${
+          hasMultipleShareScopes ? 'getShareVersions(pkg, usedShare)' : 'shared[pkg]'
+        };
         const liveProvider = liveVersionMap?.[version];
         if (
           providerEntry.registered &&
@@ -1487,7 +1567,7 @@ export function generateRemoteEntry(
       await __mfBridgeExternalSharedProvider(
         pkg,
         usedShare,
-        shared[pkg],
+        ${hasMultipleShareScopes ? 'getShareVersions(pkg, usedShare)' : 'shared[pkg]'},
         initialShared[pkg],
         undefined
       );
@@ -1497,9 +1577,10 @@ export function generateRemoteEntry(
       const globalVersionsByPackage = Object.create(null);
       if (allInstances) {
         for (const [, scopes] of Object.entries(allInstances)) {
-          const scopeShare = scopes?.['${options.shareScope}'];
-          if (!scopeShare) continue;
-          for (const [pkg, versionMap] of Object.entries(scopeShare)) {
+          for (const scopeName of shareScopeNames) {
+            const scopeShare = scopes?.[scopeName];
+            if (!scopeShare) continue;
+            for (const [pkg, versionMap] of Object.entries(scopeShare)) {
             const usedShare = usedShared?.[pkg];
             const passedVersions = initialShared[pkg];
             const bridgeSelection = bridgeSelections.get(pkg);
@@ -1519,6 +1600,7 @@ export function generateRemoteEntry(
               if (!matchesPassedProvider) continue;
               if (provider === usedShare || (usedShare.from && provider.from === usedShare.from)) continue;
               if (globalVersions[version] === undefined) globalVersions[version] = provider;
+            }
             }
           }
         }
@@ -1543,7 +1625,7 @@ export function generateRemoteEntry(
         : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor);
       if (share.shareConfig?.import !== false || cachedShare !== undefined) return;
       ${normalizeRuntimeShareCode}
-      const versionMap = shared?.[pkg];
+      const versionMap = ${hasMultipleShareScopes ? 'getShareVersions(pkg, share)' : 'shared?.[pkg]'};
       const provider = __mfSelectSharedProvider(
         versionMap,
         pkg,

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1002,9 +1002,19 @@ export function generateRemoteEntry(
   async function init(shared = {}, initScope = []) {
     ${sharedCacheHelperCode}
     const getShareScope = (scopeName) => ${hasMultipleShareScopes} ? (shared?.[scopeName] || {}) : shared;
-    const getShareVersions = (pkg, share) => {
+    const getShareScopeNames = (share) => {
       const configuredScopes = Array.isArray(share?.scope) ? share.scope : [share?.scope || shareScopeName];
-      for (const scopeName of configuredScopes) {
+      if (!${hasMultipleShareScopes}) return configuredScopes;
+      return [...new Set([...configuredScopes, ...shareScopeNames])];
+    };
+    const getShareScopeName = (pkg, share) => {
+      for (const scopeName of getShareScopeNames(share)) {
+        if (getShareScope(scopeName)?.[pkg]) return scopeName;
+      }
+      return shareScopeName;
+    };
+    const getShareVersions = (pkg, share) => {
+      for (const scopeName of getShareScopeNames(share)) {
         const versions = getShareScope(scopeName)?.[pkg];
         if (versions) return versions;
       }
@@ -1454,15 +1464,9 @@ export function generateRemoteEntry(
         const resolvedExternalProvider = __mfResolveExternalSharedProvider(
           federationInstances,
           scopeRoot,
+          ${hasMultipleShareScopes ? 'getShareScope(getShareScopeName(pkg, usedShare))' : 'shared'},
           ${
-            hasMultipleShareScopes
-              ? 'getShareScope(Array.isArray(usedShare.scope) ? usedShare.scope[0] : (usedShare.scope || shareScopeName))'
-              : 'shared'
-          },
-          ${
-            hasMultipleShareScopes
-              ? 'Array.isArray(usedShare.scope) ? usedShare.scope[0] : (usedShare.scope || shareScopeName)'
-              : `'${options.shareScope}'`
+            hasMultipleShareScopes ? 'getShareScopeName(pkg, usedShare)' : `'${options.shareScope}'`
           },
           pkg,
           providerEntry,

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -58,15 +58,19 @@ export function generateRemoteEntrySSR(options: NormalizedModuleFederationOption
       : [${JSON.stringify(options.shareScope)}];
     try {
       for (const scopeName of shareScopeNames) {
-      const scopeShare = Array.isArray(${JSON.stringify(options.shareScope)}) ? (shared?.[scopeName] || {}) : shared;
-      initRes.initShareScopeMap(scopeName, scopeShare);
-      await Promise.all(
-        await initRes.initializeSharing(scopeName, {
-          strategy: ${JSON.stringify(options.shareStrategy ?? 'version-first')},
-          from: 'build',
-          initScope,
-        })
-      );
+        try {
+          const scopeShare = Array.isArray(${JSON.stringify(options.shareScope)}) ? (shared?.[scopeName] || {}) : shared;
+          initRes.initShareScopeMap(scopeName, scopeShare);
+          await Promise.all(
+            await initRes.initializeSharing(scopeName, {
+              strategy: ${JSON.stringify(options.shareStrategy ?? 'version-first')},
+              from: 'build',
+              initScope,
+            })
+          );
+        } catch (e) {
+          console.error('[Module Federation SSR]', e);
+        }
       }
     } catch (e) {
       console.error('[Module Federation SSR]', e);

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -53,15 +53,21 @@ export function generateRemoteEntrySSR(options: NormalizedModuleFederationOption
     const initToken = { from: ${JSON.stringify(options.name)} };
     if (initScope.indexOf(initToken) >= 0) return;
     initScope.push(initToken);
-    initRes.initShareScopeMap(${JSON.stringify(options.shareScope)}, shared);
+    const shareScopeNames = Array.isArray(${JSON.stringify(options.shareScope)})
+      ? ${JSON.stringify(options.shareScope)}
+      : [${JSON.stringify(options.shareScope)}];
     try {
+      for (const scopeName of shareScopeNames) {
+      const scopeShare = Array.isArray(${JSON.stringify(options.shareScope)}) ? (shared?.[scopeName] || {}) : shared;
+      initRes.initShareScopeMap(scopeName, scopeShare);
       await Promise.all(
-        await initRes.initializeSharing(${JSON.stringify(options.shareScope)}, {
+        await initRes.initializeSharing(scopeName, {
           strategy: ${JSON.stringify(options.shareStrategy ?? 'version-first')},
           from: 'build',
           initScope,
         })
       );
+      }
     } catch (e) {
       console.error('[Module Federation SSR]', e);
     }


### PR DESCRIPTION
## Summary
- accept `string | string[]` for top-level and per-remote `shareScope` configuration
- initialize every configured provider scope in browser and SSR remote entries
- preserve the existing single-scope path and the current circular-init/lazy-provider protections
- cover normalization and browser/SSR code generation for multiple scopes

## Testing
- [x] `pnpm test` (824 passed, 1 skipped)
- [x] `pnpm run typecheck`
- [x] `pnpm run fmt.check`
- [x] `pnpm run build`

## Risks
- The change touches generated remote-entry initialization. Array configuration uses the new multi-scope path; string configuration retains the existing path and is covered by the full source test suite.