### PR TITLE
fix: order React roots before subpaths

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -833,6 +833,43 @@ describe('virtualRemoteEntry', () => {
     expect(hostInit).toContain('const __mfHostInitShareOrder = ["react","@repro/react-consumer"]');
   });
 
+  it('orders React package roots before their subpath shares', async () => {
+    const share = (name: string) => ({
+      name,
+      version: '18.3.1',
+      scope: 'default',
+      shareConfig: { singleton: true, strictVersion: false },
+    });
+    normalizedSharedMock.mockReturnValue({
+      'react/jsx-runtime': share('react/jsx-runtime'),
+      react: share('react'),
+      'react-dom/client': share('react-dom/client'),
+      'react-dom': share('react-dom'),
+    });
+
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react/jsx-runtime');
+    mod.addUsedShares('react');
+    mod.addUsedShares('react-dom/client');
+    mod.addUsedShares('react-dom');
+
+    const hostInit = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'serve');
+    const orderMarker = 'const __mfHostInitShareOrder = ';
+    const orderStart = hostInit.indexOf(orderMarker);
+    const orderLineEnd = hostInit.indexOf('\n', orderStart);
+    const orderSource =
+      orderStart === -1 || orderLineEnd === -1
+        ? '[]'
+        : hostInit.slice(orderStart + orderMarker.length, orderLineEnd).trim();
+    const order = JSON.parse(
+      orderSource.endsWith(';') ? orderSource.slice(0, -1) : orderSource
+    ) as string[];
+
+    expect(order.indexOf('react')).toBeLessThan(order.indexOf('react/jsx-runtime'));
+    expect(order.indexOf('react-dom')).toBeLessThan(order.indexOf('react-dom/client'));
+  });
+
   it('uses auto-detected workspace import path in localSharedImportMap', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -310,11 +310,23 @@ function orderSharedDependenciesFirst(sharedPackages: string[]) {
       const sharedDependency = sharedKeyByPackageName.get(dependency);
       if (sharedDependency) visit(sharedDependency);
     });
-    // A package's modules can consume its own shared subpath exports through
+    // Most packages can consume their own shared subpath exports through
     // self-referencing bare specifiers at module-evaluation time, so subpath
     // share keys must come before their package root (see #767, #805).
+    // React's subpath implementations have the opposite dependency: React 18
+    // evaluates react/jsx-runtime against ReactSharedInternals from the root
+    // package. Initializing the subpath first crashes in dev (see #924).
     if (pkg === packageName) {
-      (subpathKeysByPackageName.get(packageName) || []).forEach(visit);
+      const subpaths = subpathKeysByPackageName.get(packageName) || [];
+      const rootMustBeInitializedFirst = packageName === 'react' || packageName === 'react-dom';
+      if (rootMustBeInitializedFirst) {
+        visiting.delete(pkg);
+        visited.add(pkg);
+        ordered.push(pkg);
+        subpaths.forEach(visit);
+        return;
+      }
+      subpaths.forEach(visit);
     }
     visiting.delete(pkg);
     visited.add(pkg);


### PR DESCRIPTION
Close #924 