### PR TITLE
fix: isolate SSR state by host and share scope

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -1061,6 +1061,40 @@ describe('ssrEntryLoaderPlugin — code transformation', () => {
     expect(written).toContain('file:///abs/node_modules/react/index.js');
     expect(written).not.toMatch(/from\s*["']react["']/);
   });
+
+  it('partitions transformed temp-file cache entries by host shares and scope', async () => {
+    const written: string[] = [];
+    const fsMock = await import('fs');
+    (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (_p: unknown, code: unknown) => {
+        written.push(code as string);
+      }
+    );
+    const entryUrl = 'http://localhost:5001/remoteEntry.ssr.js';
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': { ok: false },
+      [entryUrl]: {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+        text: 'import { v } from "shared-lib"; export const value = v;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+
+    await factory({
+      resolvedShared: { 'shared-lib': '/host-a/shared.mjs' },
+      shareScopeName: 'scope-a',
+    }).loadEntry!({ remoteInfo: { name: 'a', entry: 'http://localhost:5001/remoteEntry.js' } });
+    await factory({
+      resolvedShared: { 'shared-lib': '/host-b/shared.mjs' },
+      shareScopeName: 'scope-b',
+    }).loadEntry!({ remoteInfo: { name: 'b', entry: 'http://localhost:5001/remoteEntry.js' } });
+
+    expect(written).toHaveLength(2);
+    expect(written[0]).toContain('file:///host-a/shared.mjs');
+    expect(written[1]).toContain('file:///host-b/shared.mjs');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/__tests__/ssrVmStrategy.test.ts
+++ b/src/utils/__tests__/ssrVmStrategy.test.ts
@@ -37,7 +37,12 @@ async function freshStrategy() {
   return await import('../ssrVmStrategy');
 }
 
-const baseOptions = { resolvedShared: {}, shareScopeName: 'default', versionKey: 'v1' };
+const baseOptions = {
+  resolvedShared: {},
+  shareScopeName: 'default',
+  versionKey: 'v1',
+  cacheContext: {},
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -167,6 +172,44 @@ describe.skipIf(!hasVmModules)('ssrVmStrategy — module graph evaluation', () =
     expect(namespace.val).toBe('custom');
   });
 
+  it('isolates identical VM coordinates by owning federation instance', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { v } from "shared-lib"; export const val = v;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const hostALoadShare = vi.fn(async () => () => ({ v: 'host-a' }));
+    const hostBLoadShare = vi.fn(async () => () => ({ v: 'host-b' }));
+    const hostA = {
+      options: { shared: { 'shared-lib': { scope: ['default'] } } },
+      loadShare: hostALoadShare,
+    };
+    const hostB = {
+      options: { shared: { 'shared-lib': { scope: ['default'] } } },
+      loadShare: hostBLoadShare,
+    };
+    const strategy = await freshStrategy();
+    const entryUrl = 'http://localhost:5001/remoteEntry.ssr.js';
+
+    const first = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      cacheContext: hostA,
+      federationInstance: hostA,
+    })) as { val: string };
+    const second = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      cacheContext: hostB,
+      federationInstance: hostB,
+    })) as { val: string };
+
+    expect(first.val).toBe('host-a');
+    expect(second.val).toBe('host-b');
+    expect(hostALoadShare).toHaveBeenCalledWith('shared-lib');
+    expect(hostBLoadShare).toHaveBeenCalledWith('shared-lib');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
   it('falls back to the resolvedShared file map when no instance shares the package', async () => {
     const { mkdtempSync, writeFileSync } = await import('fs');
     const { tmpdir } = await import('os');
@@ -289,11 +332,13 @@ describe.skipIf(!hasVmModules)('ssrVmStrategy — module graph evaluation', () =
       ...baseOptions,
       resolvedShared: { 'file-shared': firstShared },
       shareScopeName: 'first-scope',
+      cacheContext: {},
     })) as { val: string };
     const second = (await strategy.loadViaVmStrategy(entryUrl, {
       ...baseOptions,
       resolvedShared: { 'file-shared': secondShared },
       shareScopeName: 'second-scope',
+      cacheContext: {},
     })) as { val: string };
 
     expect(first.val).toBe('first');

--- a/src/utils/__tests__/ssrVmStrategy.test.ts
+++ b/src/utils/__tests__/ssrVmStrategy.test.ts
@@ -133,6 +133,40 @@ describe.skipIf(!hasVmModules)('ssrVmStrategy — module graph evaluation', () =
     expect(namespace.val).toBe(7);
   });
 
+  it('selects federation instances from the requested named share scope', async () => {
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { v } from "shared-lib"; export const val = v;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+
+    const defaultLoadShare = vi.fn(async () => () => ({ v: 'default' }));
+    const customLoadShare = vi.fn(async () => () => ({ v: 'custom' }));
+    (globalThis as Record<string, unknown>).__FEDERATION__ = {
+      __INSTANCES__: [
+        {
+          options: { shared: { 'shared-lib': { scope: ['default'] } } },
+          loadShare: defaultLoadShare,
+        },
+        {
+          options: { shared: { 'shared-lib': { scope: ['custom'] } } },
+          loadShare: customLoadShare,
+        },
+      ],
+    };
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions, shareScopeName: 'custom' }
+    )) as { val: string };
+
+    expect(defaultLoadShare).not.toHaveBeenCalled();
+    expect(customLoadShare).toHaveBeenCalledWith('shared-lib');
+    expect(namespace.val).toBe('custom');
+  });
+
   it('falls back to the resolvedShared file map when no instance shares the package', async () => {
     const { mkdtempSync, writeFileSync } = await import('fs');
     const { tmpdir } = await import('os');
@@ -230,5 +264,40 @@ describe.skipIf(!hasVmModules)('ssrVmStrategy — module graph evaluation', () =
       versionKey: 'v2',
     })) as { marker: string };
     expect(next.marker).toBe('v2');
+  });
+
+  it('partitions module and namespace caches by resolved shares and scope', async () => {
+    const { mkdtempSync, writeFileSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const dir = mkdtempSync(join(tmpdir(), 'mf-vm-cache-scope-'));
+    const firstShared = join(dir, 'first.mjs');
+    const secondShared = join(dir, 'second.mjs');
+    writeFileSync(firstShared, 'export const v = "first";', 'utf8');
+    writeFileSync(secondShared, 'export const v = "second";', 'utf8');
+
+    const entryUrl = 'http://localhost:5001/remoteEntry.ssr.js';
+    global.fetch = makeFetchMock({
+      [entryUrl]: {
+        ok: true,
+        text: 'import { v } from "file-shared"; export const val = v;',
+      },
+    }) as unknown as typeof globalThis.fetch;
+    const strategy = await freshStrategy();
+
+    const first = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      resolvedShared: { 'file-shared': firstShared },
+      shareScopeName: 'first-scope',
+    })) as { val: string };
+    const second = (await strategy.loadViaVmStrategy(entryUrl, {
+      ...baseOptions,
+      resolvedShared: { 'file-shared': secondShared },
+      shareScopeName: 'second-scope',
+    })) as { val: string };
+
+    expect(first.val).toBe('first');
+    expect(second.val).toBe('second');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -811,6 +811,8 @@ async function tryVmStrategy(
     shareScopeName: options.shareScopeName,
     versionKey: ssrEntry.versionKey,
     fetchTimeoutMs: options.fetchTimeoutMs,
+    cacheContext: options.cacheContext,
+    federationInstance: options.federationInstance,
   })) as { init: unknown; get: unknown } | null;
 }
 
@@ -976,6 +978,8 @@ interface ResolvedLoaderOptions {
   shareScopeName: string;
   maxAgeMs?: number;
   fetchTimeoutMs: number;
+  cacheContext: object;
+  federationInstance?: object;
 }
 
 // Default export so the module can be referenced as a runtimePlugin path string.
@@ -986,21 +990,29 @@ export default function ssrEntryLoaderPlugin(options: SsrEntryLoaderOptions = {}
     shareScopeName: options.shareScopeName ?? 'default',
     maxAgeMs: options.maxAgeMs,
     fetchTimeoutMs: options.fetchTimeoutMs ?? DEFAULT_SSR_FETCH_TIMEOUT_MS,
+    cacheContext: {},
   };
   return {
     name: 'mf-vite:ssr-entry-loader',
-    async loadEntry({ remoteInfo }: { remoteInfo: RemoteInfo }) {
+    async loadEntry({ remoteInfo, origin }: { remoteInfo: RemoteInfo; origin?: object }) {
       // Only intercept on the server — browser should use the normal path.
       if (!isNodeServer()) return;
 
+      // The runtime supplies the owning ModuleFederation instance as `origin`.
+      // Its identity is the VM graph's true share-resolution boundary. Keep a
+      // stable factory-local fallback for direct or older-runtime invocations.
+      const loadOptions = origin
+        ? { ...resolved, cacheContext: origin, federationInstance: origin }
+        : resolved;
+
       const ssrEntry = await getSSREntry(
         remoteInfo.entry,
-        resolved.maxAgeMs,
-        resolved.fetchTimeoutMs
+        loadOptions.maxAgeMs,
+        loadOptions.fetchTimeoutMs
       );
       if (!ssrEntry) return;
 
-      const mod = await loadSSRRemoteEntry(ssrEntry, resolved);
+      const mod = await loadSSRRemoteEntry(ssrEntry, loadOptions);
       if (!mod) return;
 
       return mod;

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -540,6 +540,16 @@ export function revalidate(remoteEntryUrl?: string): void {
 const tempFileCache = new Map<string, Promise<string>>();
 const tempFilePathCache = new Map<string, Promise<string>>();
 
+function getSsrTransformContextKey(
+  resolvedShared: Record<string, string>,
+  shareScopeName: string
+): string {
+  return JSON.stringify([
+    shareScopeName,
+    Object.entries(resolvedShared).sort(([left], [right]) => left.localeCompare(right)),
+  ]);
+}
+
 // Lazily initialised on the server only — avoids evaluating Node APIs in browser.
 let ssrCacheDirPromise: Promise<string> | undefined;
 async function getSSRCacheDir(): Promise<string> {
@@ -649,9 +659,10 @@ async function fetchEsmToTempFile(
   pending: Set<Promise<string>>,
   sharedPkgMap?: Map<string, string>,
   versionKey: string = UNVERSIONED,
-  fetchTimeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS
+  fetchTimeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS,
+  contextKey = 'default'
 ): Promise<string> {
-  const cacheKey = JSON.stringify([fetchTimeoutMs, versionKey, url]);
+  const cacheKey = JSON.stringify([fetchTimeoutMs, versionKey, url, contextKey]);
   if (visited.has(url)) return visited.get(url)!;
   const cached = tempFileCache.get(cacheKey);
   if (cached) {
@@ -711,7 +722,8 @@ async function fetchEsmToTempFile(
             pending,
             sharedPkgMap,
             versionKey,
-            fetchTimeoutMs
+            fetchTimeoutMs,
+            contextKey
           );
           subMap.set(u, `file://${tmpPath}`);
         })
@@ -743,7 +755,8 @@ async function fetchEsmGraphToTempFile(
   tmpDir: string,
   sharedPkgMap?: Map<string, string>,
   versionKey: string = UNVERSIONED,
-  fetchTimeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS
+  fetchTimeoutMs: number = DEFAULT_SSR_FETCH_TIMEOUT_MS,
+  contextKey = 'default'
 ): Promise<string> {
   const pending = new Set<Promise<string>>();
   const rootFile = await fetchEsmToTempFile(
@@ -753,7 +766,8 @@ async function fetchEsmGraphToTempFile(
     pending,
     sharedPkgMap,
     versionKey,
-    fetchTimeoutMs
+    fetchTimeoutMs,
+    contextKey
   );
   // Circular edges return their reserved path immediately. Wait for every
   // discovered writer before importing the root so all referenced files exist.
@@ -887,7 +901,8 @@ async function loadSSRRemoteEntry(
         cacheDir,
         sharedPkgMap,
         versionKey,
-        options.fetchTimeoutMs
+        options.fetchTimeoutMs,
+        getSsrTransformContextKey(resolvedShared, options.shareScopeName)
       );
       return await importTempModule(tmpFile, versionKey);
     } catch (error) {

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -26,6 +26,8 @@ interface VmStrategyOptions {
   shareScopeName: string;
   versionKey: string;
   fetchTimeoutMs?: number;
+  cacheContext: object;
+  federationInstance?: object;
 }
 
 // Minimal structural typings for the experimental vm module APIs so this file
@@ -104,7 +106,9 @@ function getFederationInstances(): FederationInstanceLike[] {
  * build-time resolvedShared file map, then plain host import.
  */
 async function loadBareModule(specifier: string, options: VmStrategyOptions): Promise<unknown> {
-  for (const instance of getFederationInstances()) {
+  const owner = options.federationInstance as FederationInstanceLike | undefined;
+  const instances = owner ? [owner] : getFederationInstances();
+  for (const instance of instances) {
     if (typeof instance?.loadShare !== 'function') continue;
     // Only consult instances that actually declare the package as shared —
     // loadShare on an unknown package can register it as a side effect.
@@ -168,8 +172,21 @@ const httpModuleCache = new Map<string, Promise<VmModule>>();
 // Evaluated entry namespaces, same keying.
 const namespaceCache = new Map<string, Promise<unknown>>();
 
+const contextIds = new WeakMap<object, number>();
+let nextContextId = 1;
+
+function getContextId(context: object): number {
+  let id = contextIds.get(context);
+  if (id === undefined) {
+    id = nextContextId++;
+    contextIds.set(context, id);
+  }
+  return id;
+}
+
 function getVmCacheContextKey(options: VmStrategyOptions): string {
   return JSON.stringify([
+    getContextId(options.cacheContext),
     options.shareScopeName,
     Object.entries(options.resolvedShared).sort(([left], [right]) => left.localeCompare(right)),
   ]);

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -86,7 +86,9 @@ export async function isVmStrategyAvailable(): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 interface FederationInstanceLike {
-  options?: { shared?: Record<string, unknown> };
+  options?: {
+    shared?: Record<string, { scope?: string | string[] } | undefined>;
+  };
   loadShare?: (name: string) => Promise<false | (() => unknown | undefined) | undefined>;
 }
 
@@ -106,7 +108,10 @@ async function loadBareModule(specifier: string, options: VmStrategyOptions): Pr
     if (typeof instance?.loadShare !== 'function') continue;
     // Only consult instances that actually declare the package as shared —
     // loadShare on an unknown package can register it as a side effect.
-    if (!instance.options?.shared || !(specifier in instance.options.shared)) continue;
+    const shared = instance.options?.shared?.[specifier];
+    if (!shared) continue;
+    const scopes = Array.isArray(shared.scope) ? shared.scope : [shared.scope ?? 'default'];
+    if (!scopes.includes(options.shareScopeName)) continue;
     try {
       const factory = await instance.loadShare(specifier);
       if (typeof factory === 'function') {
@@ -163,6 +168,13 @@ const httpModuleCache = new Map<string, Promise<VmModule>>();
 // Evaluated entry namespaces, same keying.
 const namespaceCache = new Map<string, Promise<unknown>>();
 
+function getVmCacheContextKey(options: VmStrategyOptions): string {
+  return JSON.stringify([
+    options.shareScopeName,
+    Object.entries(options.resolvedShared).sort(([left], [right]) => left.localeCompare(right)),
+  ]);
+}
+
 function getBodyPreview(body: string): string {
   return body.slice(0, 240).replace(/\s+/g, ' ').trim();
 }
@@ -191,6 +203,7 @@ function resolveSpecifierUrl(specifier: string, referencerUrl: string): string |
 
 function getHttpModule(vm: VmApi, url: string, options: VmStrategyOptions): Promise<VmModule> {
   const cacheKey = JSON.stringify([
+    getVmCacheContextKey(options),
     options.fetchTimeoutMs ?? DEFAULT_SSR_FETCH_TIMEOUT_MS,
     options.versionKey,
     url,
@@ -253,7 +266,7 @@ export async function loadViaVmStrategy(
   const vm = await getVmApi();
   if (!vm) return null;
 
-  const cacheKey = `${options.versionKey}::${entryUrl}`;
+  const cacheKey = `${getVmCacheContextKey(options)}::${options.versionKey}::${entryUrl}`;
   if (!namespaceCache.has(cacheKey)) {
     namespaceCache.set(
       cacheKey,


### PR DESCRIPTION
## Summary
- bind SSR VM module graphs and evaluated namespaces to the owning Module Federation runtime instance
- include the named share scope and resolved shared-package map in SSR temp-file and VM cache identities
- resolve bare shared packages only through the owning instance and requested named scope
- retain circular-graph handling, failed-promise eviction, and fetch-timeout cache partitioning
- add regressions for different resolved paths, different scopes, and identical coordinates across distinct hosts

## Testing
- [x] `pnpm test src/utils/__tests__/ssrEntryLoader.test.ts src/utils/__tests__/ssrVmStrategy.test.ts` — 56 passed, 1 skipped
- [x] `pnpm test` — 835 passed, 1 skipped
- [x] `pnpm typecheck`
- [x] `pnpm fmt.check`
- [x] `pnpm build`
- [x] `pnpm build:shared-lib`
- [x] `pnpm playwright test` — 21 passed locally
- [x] manual production-preview smoke — complete host/remote surface rendered with no browser page errors
- [x] GitHub unit, Playwright, Vite 5–8 integration, Node 22/24/25 package, lint, title, and publish checks
- [x] `git diff --check`

## Risks
- distinct host instances now produce distinct VM graph cache entries, increasing cache cardinality when many SSR hosts share a process
- cache reuse remains unchanged within the same owning host, share scope, and resolved shared-package map
- VM cache eviction remains separate lifecycle work and is not changed here
