### PR TITLE
fix: constrain development runner boundary

### DIFF
--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -650,6 +650,55 @@ describe('pluginSSRRemoteEntry', () => {
       expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
     });
 
+    it.each([
+      '/@id/__x00__/../../etc/passwd',
+      '/@id/__x00__../../etc/passwd',
+      '/@id/__x00__..%2F..%2Fetc%2Fpasswd',
+    ])('rejects traversal hidden behind a Vite-encoded null prefix: %s', async (unsafeId) => {
+      const handleInvoke = vi.fn().mockResolvedValue({ result: { code: 'escaped' } });
+
+      const res = await invokeRunnerMiddleware(
+        {
+          type: 'custom',
+          event: 'vite:invoke',
+          data: {
+            id: 'send',
+            name: 'fetchModule',
+            data: [unsafeId],
+          },
+        },
+        {
+          fetchModule: vi.fn(),
+          hot: { handleInvoke },
+        }
+      );
+
+      expect(handleInvoke).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+    });
+
+    it('preserves legitimate Vite-encoded internal module ids', async () => {
+      const handleInvoke = vi.fn().mockResolvedValue({ result: { code: 'export default 1' } });
+      const payload = {
+        type: 'custom',
+        event: 'vite:invoke',
+        data: {
+          id: 'send',
+          name: 'fetchModule',
+          data: ['/@id/__x00__vite/internal-helper'],
+        },
+      };
+
+      const res = await invokeRunnerMiddleware(payload, {
+        fetchModule: vi.fn(),
+        hot: { handleInvoke },
+      });
+
+      expect(handleInvoke).toHaveBeenCalledWith(payload);
+      expect(res.statusCode).toBe(200);
+    });
+
     it('returns 400 for malformed encoded /@fs/ ids before calling Vite', async () => {
       const handleInvoke = vi.fn();
 

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -106,7 +106,8 @@ async function invokeRunnerMiddleware(
   payload: unknown,
   env: { fetchModule?: unknown; hot?: { handleInvoke?: (payload: unknown) => Promise<unknown> } },
   rawPayload?: string,
-  serverConfig: Record<string, unknown> = { root: '/mock/cwd' }
+  serverConfig: Record<string, unknown> = { root: '/mock/cwd' },
+  method = 'POST'
 ) {
   const plugins = pluginSSRRemoteEntry(makeOptions());
   const mainPlugin = plugins[1];
@@ -142,7 +143,7 @@ async function invokeRunnerMiddleware(
   const runner = handlers.find((entry) => entry.path === '/__mf_runner__')?.handler;
   expect(runner).toBeDefined();
 
-  const req = createMockRequest('POST', payload, rawPayload);
+  const req = createMockRequest(method, payload, rawPayload);
   const res = createMockResponse();
   await runner!(req, res);
   return res;
@@ -440,7 +441,73 @@ describe('pluginSSRRemoteEntry', () => {
       expect(handleInvoke).toHaveBeenCalledWith(payload);
       expect(res.statusCode).toBe(200);
       expect(res.headers['Content-Type']).toBe('application/json');
+      expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
       expect(JSON.parse(res.body)).toEqual({ result: { code: 'export default 1' } });
+    });
+
+    it('leaves CORS and preflight policy to Vite middleware', async () => {
+      const handleInvoke = vi.fn();
+      const res = await invokeRunnerMiddleware(
+        undefined,
+        { fetchModule: vi.fn(), hot: { handleInvoke } },
+        undefined,
+        { root: '/mock/cwd' },
+        'OPTIONS'
+      );
+
+      expect(handleInvoke).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(405);
+      expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+      expect(res.headers['Access-Control-Allow-Methods']).toBeUndefined();
+    });
+
+    it.each([
+      { startOffset: -1 },
+      { startOffset: 1.5 },
+      { startOffset: Number.MAX_SAFE_INTEGER },
+      { startOffset: '10' },
+      { cached: 'yes' },
+      { inlineSourceMap: 1 },
+      { unknown: true },
+    ])('rejects unsafe fetchModule options: %j', async (opts) => {
+      const handleInvoke = vi.fn();
+      const res = await invokeRunnerMiddleware(
+        {
+          type: 'custom',
+          event: 'vite:invoke',
+          data: { id: 'send', name: 'fetchModule', data: ['virtual:safe', null, opts] },
+        },
+        { fetchModule: vi.fn(), hot: { handleInvoke } }
+      );
+
+      expect(handleInvoke).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+    });
+
+    it('accepts bounded supported fetchModule options', async () => {
+      const handleInvoke = vi.fn().mockResolvedValue({ result: { code: 'export default 1' } });
+      const payload = {
+        type: 'custom',
+        event: 'vite:invoke',
+        data: {
+          id: 'send',
+          name: 'fetchModule',
+          data: [
+            'virtual:safe',
+            null,
+            { cached: false, inlineSourceMap: true, startOffset: 1024 * 1024 },
+          ],
+        },
+      };
+
+      const res = await invokeRunnerMiddleware(payload, {
+        fetchModule: vi.fn(),
+        hot: { handleInvoke },
+      });
+
+      expect(handleInvoke).toHaveBeenCalledWith(payload);
+      expect(res.statusCode).toBe(200);
     });
 
     it('rejects malformed or unsupported runner invokes before calling Vite', async () => {

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -108,7 +108,7 @@ function isSafeRunnerFetchModuleId(id: unknown, config: RunnerValidationConfig):
 
   const rawDecoded = decodeViteId(id);
   const decoded = rawDecoded.replace(/^\0+/, '');
-  if (!decoded || rawDecoded.startsWith('\0') || decoded.startsWith('virtual:')) return !!decoded;
+  if (!decoded || decoded.startsWith('virtual:')) return !!decoded;
   if (decoded.startsWith('file://')) {
     try {
       const filePath = decodeURIComponent(new URL(decoded).pathname);

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -14,6 +14,7 @@ import {
 } from '../virtualModules/virtualRemoteEntrySSR';
 
 const MAX_RUNNER_BODY_BYTES = 1024 * 1024;
+const MAX_RUNNER_START_OFFSET = 1024 * 1024;
 const ALLOWED_RUNNER_INVOKE_NAMES = new Set(['fetchModule', 'getBuiltins']);
 const VITE_FS_PREFIX = '/@fs/';
 
@@ -34,6 +35,27 @@ type RunnerValidationConfig = {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isSafeRunnerFetchModuleOptions(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const allowedKeys = new Set(['cached', 'startOffset', 'inlineSourceMap']);
+  for (const [key, option] of Object.entries(value)) {
+    if (!allowedKeys.has(key)) return false;
+    if (key === 'startOffset') {
+      if (
+        typeof option !== 'number' ||
+        !Number.isSafeInteger(option) ||
+        option < 0 ||
+        option > MAX_RUNNER_START_OFFSET
+      ) {
+        return false;
+      }
+    } else if (typeof option !== 'boolean') {
+      return false;
+    }
+  }
+  return true;
 }
 
 function stripQueryAndHash(id: string): string {
@@ -140,7 +162,7 @@ function isRunnerInvokePayload(
   return (
     isSafeRunnerFetchModuleId(id, config) &&
     (importer === undefined || importer === null || isSafeRunnerFetchModuleId(importer, config)) &&
-    (opts === undefined || isPlainObject(opts))
+    (opts === undefined || isSafeRunnerFetchModuleOptions(opts))
   );
 }
 
@@ -360,14 +382,6 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         if (typeof (ssrEnv?.fetchModule ?? clientEnv?.fetchModule) === 'function' && runnerEnv) {
           const runnerBase = '/__mf_runner__';
           server.middlewares.use(runnerBase, async (req, res) => {
-            res.setHeader('Access-Control-Allow-Origin', '*');
-            if (req.method === 'OPTIONS') {
-              res.setHeader('Access-Control-Allow-Methods', 'POST');
-              res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-              res.statusCode = 204;
-              res.end();
-              return;
-            }
             if (req.method !== 'POST') {
               res.statusCode = 405;
               res.end('Method not allowed');


### PR DESCRIPTION
## Summary
- stop the federation runner middleware from overriding the Vite server CORS policy with a wildcard origin
- allow only supported `fetchModule` option keys and value types
- require `startOffset` to be a non-negative safe integer capped at 1 MiB
- add regressions for CORS ownership and rejected or accepted runner options

## Testing
- [x] `pnpm test src/plugins/__tests__/pluginSSRRemoteEntry.test.ts`
- [x] `pnpm test` — 840 passed, 1 skipped
- [x] `pnpm typecheck`
- [x] `pnpm fmt.check`
- [x] `pnpm build`
- [x] `pnpm build:shared-lib`
- [x] `pnpm playwright test` — 21 passed locally
- [x] manual production-preview smoke — federated host/remote content rendered with no browser page errors
- [x] GitHub unit, Playwright, Vite 5–8 integration, Node 22/24/25 package, lint, title, and publish checks
- [x] `git diff --check`

## Risks
- browser clients that relied on the runner route wildcard must configure the intended origin through Vite CORS settings
- server-to-server SSR requests are not subject to browser CORS enforcement
