### PR TITLE
fix: prevent Vite dependency optimization waves

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1414,6 +1414,57 @@ describe('vite:module-federation-early-init', () => {
     expect(virtualModule?.code).toContain('jsx');
   });
 
+  it('pre-seeds transitive shared dependencies for the dev optimizer', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        shared: {
+          '@vite-vite/shared-lib': { singleton: true },
+        },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = {
+      // Use the real vite-vite host fixture so this covers pnpm's isolated
+      // workspace dependency layout rather than a synthetic package graph.
+      root: REACT_EXAMPLE_ROOT,
+      optimizeDeps: { include: [], exclude: [], entries: ['custom-entry.ts'] },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    // The linked shared library must be part of Vite's initial optimizer
+    // inputs, so its transitive imports are discovered before browser startup.
+    expect(config.optimizeDeps.entries).toContain(
+      path.join(REACT_EXAMPLE_ROOT, '..', 'shared-lib', 'src', 'index.tsx')
+    );
+    expect(config.optimizeDeps.entries).toContain('custom-entry.ts');
+  });
+
+  it('does not create optimizer entries for missing exposes', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: { './missing': './does-not-exist.ts' },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = { root: REACT_EXAMPLE_ROOT };
+    runConfig(plugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps?.entries).toBeUndefined();
+  });
+
   it('registers zustand shared subpath loadShare modules during early init', () => {
     const plugin = (
       federation({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL } from 'url';
@@ -40,6 +40,8 @@ import { normalizeModuleFederationOptions } from './utils/normalizeModuleFederat
 import normalizeOptimizeDepsPlugin from './utils/normalizeOptimizeDeps';
 import {
   getIsRolldown,
+  getInstalledPackageEntry,
+  getInstalledPackageJson,
   hasPackageDependency,
   resolveImportPath,
   setPackageDetectionCwd,
@@ -258,6 +260,61 @@ function canResolveSharedSubpath(subpath: string, projectRoot: string): boolean 
   } catch {
     return false;
   }
+}
+
+/**
+ * Vite's dependency scanner cannot see through the virtual loadShare modules
+ * generated for shared packages. As a result, dependencies of a linked/shared
+ * package may be discovered one request at a time and each discovery starts a
+ * new optimizer pass. Seed the optimizer with the complete dependency graph
+ * before the first request instead.
+ *
+ * Vite then resolves the package's own dependency graph using its normal
+ * scanner, preserving package and peer-dependency resolution semantics.
+ */
+function includeLinkedSharedEntries(
+  optimizeDeps: NonNullable<UserConfig['optimizeDeps']>,
+  shared: NormalizedModuleFederationOptions['shared'],
+  projectRoot: string,
+  exposes: NormalizedModuleFederationOptions['exposes'],
+  outDir: string
+): void {
+  const additions = new Set<string>();
+
+  const entries = new Set(
+    Array.isArray(optimizeDeps.entries)
+      ? optimizeDeps.entries
+      : optimizeDeps.entries
+        ? [optimizeDeps.entries]
+        : [
+            '**/*.html',
+            '!**/node_modules/**',
+            `!**/${outDir.replace(/\\/g, '/')}/**`,
+            '!**/__tests__/**',
+            '!**/coverage/**',
+          ]
+  );
+
+  for (const [packageName, share] of Object.entries(shared ?? {})) {
+    if (share?.shareConfig?.import === false) continue;
+    const installed = getInstalledPackageJson(packageName, { cwd: projectRoot });
+    if (!installed || installed.dir.replaceAll('\\', '/').includes('/node_modules/')) continue;
+    const entry = getInstalledPackageEntry(packageName, { cwd: projectRoot });
+    if (entry && existsSync(entry)) additions.add(entry);
+  }
+
+  for (const expose of Object.values(exposes ?? {})) {
+    const source = expose.import;
+    if (source.startsWith('.') || path.isAbsolute(source)) {
+      const entry = path.resolve(projectRoot, source);
+      if (existsSync(entry)) additions.add(entry);
+    }
+  }
+
+  if (additions.size === 0) return;
+
+  for (const entry of additions) entries.add(entry);
+  optimizeDeps.entries = [...entries];
 }
 
 /**
@@ -487,6 +544,16 @@ export default __mfShared.default ?? __mfShared;`,
           }
         }
         writeLocalSharedImportMap();
+      }
+      if (_command === 'serve') {
+        config.optimizeDeps ??= {};
+        includeLinkedSharedEntries(
+          config.optimizeDeps,
+          shared,
+          root,
+          options.exposes,
+          config.build?.outDir ?? 'dist'
+        );
       }
     },
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2523,6 +2523,10 @@ describe('writeLoadShareModule', () => {
       'import * as __mfLocalShare from "/repo/packages/workspace-shared-lib/src/index.tsx";'
     );
     expect(prependWorkspaceSingletonSsrImport(ssrCode)).toBe(ssrCode);
+
+    const duplicateImport = `${ssrCode}\nimport * as __mfLocalShare from "/repo/packages/workspace-shared-lib/src/index.tsx";`;
+    const deduped = prependWorkspaceSingletonSsrImport(duplicateImport);
+    expect(deduped.match(/import \* as __mfLocalShare/g)).toHaveLength(1);
   });
 
   it('detects symlinked ESM-only workspace singleton fallbacks without eager prebuild imports', () => {
@@ -2630,6 +2634,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       'import * as __mfLocalShare from "/repo/packages/workspace-producer/src/index.ts";'
     );
+    expect(generatedCode.match(/import \* as __mfLocalShare/g)).toHaveLength(1);
     expect(generatedCode).toContain('export { __mf_default as default };');
     expect(generatedCode).toContain('let __mf_default;');
     expect(generatedCode).toContain('let __mf_0;');

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1251,7 +1251,16 @@ const WORKSPACE_SINGLETON_SSR_LOCAL_SHARE = '__mfNormalizeShareModule(__mfLocalS
 export function prependWorkspaceSingletonSsrImport(code: string): string {
   if (!code.includes('if (import.meta.env.SSR)')) return code;
   if (!code.includes(WORKSPACE_SINGLETON_SSR_LOCAL_SHARE)) return code;
-  if (code.includes('import * as __mfLocalShare')) return code;
+
+  const localShareImport =
+    /^[ \t]*import\s+\*\s+as\s+__mfLocalShare\s+from\s+(['"])(.+?)\1\s*;?[ \t]*\r?\n?/gm;
+  let hasLocalShareImport = false;
+  code = code.replace(localShareImport, (statement) => {
+    if (hasLocalShareImport) return '';
+    hasLocalShareImport = true;
+    return statement;
+  });
+  if (hasLocalShareImport) return code;
 
   const importMatch =
     code.match(
@@ -1566,14 +1575,16 @@ export function writeLoadShareModule(
         ? devImportSource
         : sharedImportSource;
   const prebuildImportLine =
-    usesDeferredSingletonFallback || usesDeferredTreeShakingFallback
-      ? servesRemoteSingletonFallback ||
-        (usesDeferredSingletonFallback &&
-          command !== 'build' &&
-          (isWorkspaceSingleton || isWorkspacePackage))
-        ? `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(lazyLocalFallbackSource)};`
-        : ''
-      : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(staticLocalShareSource)};`;
+    usesEagerWorkspaceFallback || usesEntryInjectedRemoteFallback
+      ? ''
+      : usesDeferredSingletonFallback || usesDeferredTreeShakingFallback
+        ? servesRemoteSingletonFallback ||
+          (usesDeferredSingletonFallback &&
+            command !== 'build' &&
+            (isWorkspaceSingleton || isWorkspacePackage))
+          ? `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(lazyLocalFallbackSource)};`
+          : ''
+        : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(staticLocalShareSource)};`;
   const devDynamicImportLine = isWorkspacePackage
     ? ''
     : usesDeferredSingletonFallback || usesDeferredTreeShakingFallback


### PR DESCRIPTION
Close #923 

Fix Vite development dependency reload waves by pre-scanning linked shared packages and federation exposes, while preventing duplicate workspace singleton imports that caused __mfLocalShare syntax errors.