### PR TITLE
fix: fix Vite 7 shared dependency optimization

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -12,10 +12,10 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parsePromise } from '../plugins/pluginModuleParseEnd';
 import { callHook } from '../utils/__tests__/viteHookHelpers';
 import type { PluginManifestOptions } from '../utils/normalizeModuleFederationOptions';
+import { toViteEncodedId } from '../utils/VirtualModule';
 import {
   getLoadShareImportId,
   getLoadShareModulePath,
-  toViteOptimizedDepVirtualId,
 } from '../virtualModules/virtualShared_preBuild';
 
 const { hasPackageDependencyMock, mfWarn } = vi.hoisted(() => ({
@@ -1025,14 +1025,14 @@ describe('vite:module-federation-early-init', () => {
 
     const result = onLoadHandlers[0]({ path: 'pkg-foo/a' });
     const loadSharePath = getLoadShareModulePath('pkg-foo/a', false);
-    const optimizedLoadSharePath = toViteOptimizedDepVirtualId(loadSharePath);
+    const encodedLoadSharePath = toViteEncodedId(loadSharePath);
 
-    expect(onResolveHandlers[0]({ path: optimizedLoadSharePath })).toEqual({
-      path: optimizedLoadSharePath,
+    expect(onResolveHandlers[0]({ path: encodedLoadSharePath })).toEqual({
+      path: encodedLoadSharePath,
       external: true,
     });
-    expect(result.contents).toContain(JSON.stringify(optimizedLoadSharePath));
-    expect(result.contents).not.toContain(`from ${JSON.stringify(loadSharePath)}`);
+    expect(result.contents).toContain(JSON.stringify(loadSharePath));
+    expect(result.contents).not.toContain(JSON.stringify(encodedLoadSharePath));
   });
 
   it('does not proxy shared deps when esbuild resolves optimizeDeps entry points', () => {
@@ -1380,10 +1380,8 @@ describe('vite:module-federation-early-init', () => {
     const optimizedRequireReact = resolver.load('module-federation:optimized-require-react');
     expect(optimizedRequireReact).toContain(JSON.stringify(getLoadShareModulePath('react', true)));
     expect(optimizedRequireReact).not.toContain('/@id/__x00__');
-    expect(
-      resolver.resolveId(toViteOptimizedDepVirtualId(getLoadShareModulePath('react', true)))
-    ).toEqual({
-      id: toViteOptimizedDepVirtualId(getLoadShareModulePath('react', true)),
+    expect(resolver.resolveId(toViteEncodedId(getLoadShareModulePath('react', true)))).toEqual({
+      id: toViteEncodedId(getLoadShareModulePath('react', true)),
       external: true,
     });
     expect(resolver.resolveId('react/jsx-runtime', '/repo/src/App.tsx')).toEqual({

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,6 @@ import {
   getLoadShareModulePath,
   materializeCachedLoadShareModule,
   prependWorkspaceSingletonSsrImport,
-  toViteOptimizedDepVirtualId,
   writeLoadShareModule,
   writePreBuildLibPath,
 } from './virtualModules/virtualShared_preBuild';
@@ -464,7 +463,6 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   if (!key) return;
                   const shareItem = shared[key];
                   const loadSharePath = getLoadShareModulePath(args.path, isRolldown);
-                  const optimizedLoadSharePath = toViteOptimizedDepVirtualId(loadSharePath);
                   writeLoadShareModule(args.path, shareItem, _command, isRolldown);
                   if (shareItem.shareConfig?.import !== false) {
                     writePreBuildLibPath(args.path, shareItem);
@@ -473,8 +471,8 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   return {
                     loader: 'js',
                     resolveDir: root,
-                    contents: `import * as __mfShared from ${JSON.stringify(optimizedLoadSharePath)};
-export * from ${JSON.stringify(optimizedLoadSharePath)};
+                    contents: `import * as __mfShared from ${JSON.stringify(loadSharePath)};
+export * from ${JSON.stringify(loadSharePath)};
 export default __mfShared.default ?? __mfShared;`,
                   };
                 });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -30,7 +30,7 @@ import {
   getSharedCacheDescriptor,
   sharedCacheHelperCode,
 } from '../utils/packageUtils';
-import VirtualModule, { normalizeVirtualModuleId, toViteEncodedId } from '../utils/VirtualModule';
+import VirtualModule, { normalizeVirtualModuleId } from '../utils/VirtualModule';
 import { normalizeNodeModulePath } from '../utils/pathNormalization';
 import {
   getRuntimeInitPromiseBootstrapCode,
@@ -1093,10 +1093,6 @@ export function getLoadShareModulePath(pkg: string, isRolldown: boolean): string
   if (!loadShareCacheMap[pkg]) getLoadShareImportId(pkg, isRolldown);
   const filepath = loadShareCacheMap[pkg].getImportId();
   return filepath;
-}
-
-export function toViteOptimizedDepVirtualId(id: string): string {
-  return toViteEncodedId(id);
 }
 
 export function getCachedLoadSharePkg(id: string): string | undefined {


### PR DESCRIPTION
Close #936

Use virtual IDs for Vite 7 esbuild optimization, preserve Vite 8 Rolldown behavior.