### PR TITLE
fix: only add modulePreload tags when not disabled

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import type {
   ConfigEnv,
   ConfigPluginContext,
@@ -10,9 +13,6 @@ import type {
   ViteDevServer,
 } from 'vite';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
 import { toViteEncodedId, VITE_ID_PREFIX } from '../../utils/VirtualModule';
 
 vi.mock('../../utils/packageUtils', () => ({
@@ -39,9 +39,9 @@ vi.mock('../../utils/normalizeModuleFederationOptions', async () => {
   };
 });
 
-import addEntry from '../pluginAddEntry';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 import { addUsedRemote, getUsedRemotesMap } from '../../virtualModules/virtualRemotes';
+import addEntry from '../pluginAddEntry';
 
 type AddEntryPlugin = ReturnType<typeof addEntry>[number];
 
@@ -1609,6 +1609,86 @@ describe('pluginAddEntry', () => {
     expect(html).not.toContain('chunk-_virtual_mf___app__prebuild__antd__prebuild__.js');
     expect(html.match(/chunk-index\.B_\.js/g)?.length).toBe(1);
     expect(html).not.toContain('index.AA.css');
+  });
+
+  it('skips modulepreloads when disabled', () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+    });
+    const buildPlugin = plugins[1];
+    const emitted: Rollup.EmittedFile[] = [];
+    const bundle: any = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head><script type="module" src="/app/src/main.tsx"></script></head><body></body></html>',
+      },
+      'assets/chunk-hostInit.D8.js': {
+        type: 'chunk',
+        name: 'hostInit',
+        fileName: 'assets/chunk-hostInit.D8.js',
+      },
+      'assets/chunk-remoteEntry.u3.js': {
+        type: 'chunk',
+        name: 'remoteEntry',
+        fileName: 'assets/chunk-remoteEntry.u3.js',
+      },
+      'assets/chunk-_virtual_mf-localSharedImportMap___app.Bl.js': {
+        type: 'chunk',
+        name: '_virtual_mf-localSharedImportMap___app',
+        fileName: 'assets/chunk-_virtual_mf-localSharedImportMap___app.Bl.js',
+      },
+      'assets/chunk-_virtual_mf___app__prebuild__antd__prebuild__.js': {
+        type: 'chunk',
+        name: '_virtual_mf___app__prebuild__antd__prebuild__',
+        fileName: 'assets/chunk-_virtual_mf___app__prebuild__antd__prebuild__.js',
+      },
+      'assets/chunk-index.B_.js': {
+        type: 'chunk',
+        name: 'index',
+        fileName: 'assets/chunk-index.B_.js',
+      },
+      'assets/index.AA.css': {
+        type: 'asset',
+        name: 'index',
+        fileName: 'assets/index.AA.css',
+      },
+    };
+
+    runConfigResolved(buildPlugin, {
+      root: '/repo/host',
+      base: '/app/',
+      command: 'build',
+      build: { rollupOptions: {}, modulePreload: false },
+    } as unknown as ResolvedConfig);
+    runBuildStart(
+      buildPlugin,
+      {
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'host-init-ref';
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedInputOptions
+    );
+    runGenerateBundle(
+      buildPlugin,
+      {
+        getFileName: () => 'assets/hostInit.js',
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return 'bootstrap-ref-' + emitted.length;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle,
+      false
+    );
+
+    const html = String(bundle['index.html'].source);
+    expect(html).not.toContain('rel="modulepreload"');
   });
 
   it('wraps SvelteKit static inline startup behind host init during build', () => {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -1,7 +1,7 @@
-import { createHash } from 'node:crypto';
 import * as fs from 'fs';
+import { createHash } from 'node:crypto';
 import * as path from 'node:path';
-import type { Plugin, Rollup } from 'vite';
+import type { Plugin, ResolvedConfig, Rollup } from 'vite';
 import { normalizePathForImport, rebaseImport } from '../utils/buildPaths';
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 
@@ -145,7 +145,7 @@ const addEntry = ({
   let htmlFilePath: string | undefined;
   let _command: string;
   let emitFileId: string;
-  let viteConfig: any;
+  let viteConfig: ResolvedConfig;
   // Producer remotes are consumed via federation entry URLs, not their index.html.
   // Skip only the broad dev HTML fallback — not isHydrationEntryFallback, which
   // SSR producer apps without index.html still need when hostInitInjectLocation is 'entry'.
@@ -708,7 +708,7 @@ const __mfCurrentScript = document.currentScript;
               htmlContent = htmlContent.replace('<head>', `<head>${scriptContent}`);
             }
           }
-          if (waitsForInit) {
+          if (waitsForInit && viteConfig.build.modulePreload !== false) {
             htmlContent = injectHostInitPreloads(htmlContent, bundle, (builtFileName) =>
               resolvePath(builtFileName, fileName)
             );


### PR DESCRIPTION
The plugin should follow Vite's config (`build.modulePreload`) and not generate preload tags when disabled. We have our own plugin to generate these, and the two would conflict.

Related: https://github.com/module-federation/vite/pull/810 