### PR TITLE
fix: skip unavailable React compiler runtime

### DIFF
--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -280,7 +280,7 @@ describe(`singleton React dev fallback (Vite ${viteVersion})`, () => {
     const requestFailures = new Set<string>();
     const errorResponses = new Set<string>();
     const requests = new Set<string>();
-    page.on('pageerror', (error) => pageErrors.add(error.message));
+    page.on('pageerror', (error) => pageErrors.add(error.stack || error.message));
     page.on('console', (message) => {
       if (message.type() === 'error') consoleErrors.add(message.text());
     });
@@ -318,6 +318,7 @@ describe(`singleton React dev fallback (Vite ${viteVersion})`, () => {
     await expect(
       page.evaluate(() => window.__issue913HostReact === window.__issue913RemoteReact)
     ).resolves.toBe(true);
+    expect([...requests].some((url) => url.includes('/react/compiler-runtime.js'))).toBe(false);
     expect([...pageErrors]).toEqual([]);
     expect(
       [...consoleErrors].filter((error) => /invalid hook call|module is not defined/i.test(error))

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,7 +11,10 @@ import type {
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parsePromise } from '../plugins/pluginModuleParseEnd';
 import { callHook } from '../utils/__tests__/viteHookHelpers';
-import type { PluginManifestOptions } from '../utils/normalizeModuleFederationOptions';
+import type {
+  NormalizedModuleFederationOptions,
+  PluginManifestOptions,
+} from '../utils/normalizeModuleFederationOptions';
 import { toViteEncodedId } from '../utils/VirtualModule';
 import {
   getLoadShareImportId,
@@ -44,6 +47,7 @@ vi.mock('../utils/logger', async () => {
 import { federation } from '../index';
 import VirtualModule from '../utils/VirtualModule';
 import { getPreBuildLibImportId, LOAD_SHARE_TAG, PREBUILD_TAG } from '../virtualModules';
+import { getUsedShares } from '../virtualModules/virtualRemoteEntry';
 import { virtualRuntimeInitStatus } from '../virtualModules/virtualRuntimeInitStatus';
 
 const REACT_EXAMPLE_ROOT = path.join(process.cwd(), 'examples/vite-vite/vite-host');
@@ -1410,6 +1414,42 @@ describe('vite:module-federation-early-init', () => {
 
     expect(config.optimizeDeps.include).toContain('react/jsx-runtime');
     expect(virtualModule?.code).toContain('jsx');
+  });
+
+  it('does not register react/compiler-runtime when the project React version does not export it', () => {
+    const plugins = federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      shared: {
+        react: {
+          singleton: true,
+        },
+      },
+    }) as Plugin[];
+    const earlyInitPlugin = plugins.find(
+      (entry) => entry.name === 'vite:module-federation-early-init'
+    );
+    const federationPlugin = plugins.find((entry) => entry.name === 'module-federation-vite') as
+      | (Plugin & { _options?: NormalizedModuleFederationOptions })
+      | undefined;
+    if (!earlyInitPlugin || !federationPlugin?._options) {
+      throw new Error('module federation plugins not found');
+    }
+    const config: any = {
+      root: path.join(process.cwd(), 'examples/vite-webpack-rspack/remote'),
+      optimizeDeps: {
+        include: [],
+        exclude: [],
+      },
+    };
+
+    runConfig(earlyInitPlugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps.exclude).toContain('react/compiler-runtime');
+    expect(getUsedShares(federationPlugin._options)).not.toContain('react/compiler-runtime');
   });
 
   it('pre-seeds transitive shared dependencies for the dev optimizer', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -521,11 +521,20 @@ export default __mfShared.default ?? __mfShared;`,
               optimizeDeps.include.push(key);
             }
             for (const subpath of getCommonSharedSubpaths(key)) {
+              const canResolveSubpath = canResolveSharedSubpath(subpath, root);
+              if (subpath === 'react/compiler-runtime' && !canResolveSubpath) {
+                // react/compiler-runtime is only exported by newer React
+                // versions. Registering it for React 18 can make a bare import
+                // resolve to an unrelated React version elsewhere in a pnpm
+                // workspace and serve its CommonJS entry directly.
+                optimizeDeps.exclude.push(subpath);
+                continue;
+              }
               getLoadShareModulePath(subpath, isRolldown, options);
               writeLoadShareModule(subpath, shareItem, _command, isRolldown, options);
               writePreBuildLibPath(subpath, shareItem, options);
               addUsedShares(subpath, options);
-              if (canResolveSharedSubpath(subpath, root)) {
+              if (canResolveSubpath) {
                 optimizeDeps.include.push(subpath);
               } else {
                 optimizeDeps.exclude.push(subpath);


### PR DESCRIPTION
# fix: skip unavailable React compiler runtime

## Summary

Prevent `react/compiler-runtime` from being registered as a shared dependency when it is not exported by the project's installed React version.

## Problem

When `react` is configured as a shared dependency, the plugin pre-registers known React subpaths.

React 18 does not export `react/compiler-runtime`. However, the plugin still registered it in the federation `usedShares` collection and generated its virtual modules, even after adding it to `optimizeDeps.exclude`.

In a pnpm workspace containing both React 18 and React 19, the unresolved import could resolve to a React 19 installation from another workspace package. This caused React 19's CommonJS `compiler-runtime.js` to be served directly to the browser, resulting in:

```text
ReferenceError: module is not defined
```

## Changes

- Check whether `react/compiler-runtime` can be resolved from the project root.
- When unavailable:
  - Keep it in `optimizeDeps.exclude`.
  - Do not register it in federation `usedShares`.
  - Do not generate its `loadShare` or prebuild virtual modules.
- Preserve the existing behavior for React versions that export `react/compiler-runtime`.
- Include the browser error stack in integration test diagnostics.

## Tests

- Added a unit test verifying that `react/compiler-runtime` is not registered for a React 18 project.
- Updated the singleton React integration test to verify that `react/compiler-runtime.js` is not incorrectly requested.
- Preserved the existing assertion that the host and remote use the same React singleton instance.

Validation results:

- `pnpm test`: 867 passed, 1 skipped
- `pnpm test:integration`: 45 passed
- `pnpm typecheck`: passed
- `pnpm build`: passed
- `pnpm fmt.check`: passed

## Impact

This change only affects projects whose installed React version does not export `react/compiler-runtime`. Registration behavior for other common shared subpaths remains unchanged.
