### PR TITLE
feat: add runtime capability optimization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,28 @@ You can specify the place the host initialization file is injected with the **ho
 The **moduleParseTimeout** option allows you to configure the maximum time to wait for module parsing during the build process.
 The **moduleParseIdleTimeout** option is an alternative that resets the timer on every parsed module. It only fires when there has been no module activity for the configured duration, making it suitable for large codebases where the total build time exceeds the fixed timeout.
 
+## Runtime capability optimization
+
+Runtime features that a build never uses can be removed at build time:
+
+```ts
+federation({
+  name: "remote",
+  exposes: {
+    "./remote-app": "./src/App.vue",
+  },
+  disableRemote: true,
+  disableShared: true,
+  disableSnapshot: true,
+});
+```
+
+- `disableRemote` removes remote-consumption support. Do not enable it when `remotes` are configured.
+- `disableShared` removes shared-dependency support. Do not enable it when `shared` dependencies are configured.
+- `disableSnapshot` removes snapshot support, including manifest-based remotes, preload, dynamic type hints, HMR, and devtools integration.
+
+All three options default to `false`, except `disableSnapshot`, which defaults to `true` for Node/SSR builds. An explicitly configured Vite `define` value takes precedence over the corresponding option.
+
 ## Load the Remote App
 
 In your host app, you can now import and use the remote app with **defineAsyncComponent**

--- a/integration/target-code-elimination.test.ts
+++ b/integration/target-code-elimination.test.ts
@@ -29,3 +29,52 @@ describe('target-specific code elimination', () => {
     });
   });
 });
+
+describe('runtime capability code elimination', () => {
+  it('removes remote consumption internals when disableRemote is enabled', async () => {
+    const output = await buildFixture({
+      mfOptions: {
+        ...BASIC_REMOTE_MF_OPTIONS,
+        disableRemote: true,
+      },
+    });
+    const allCode = getAllChunkCode(output);
+
+    expect(allCode).toContain(
+      'Remote loading is disabled by experiments.optimization.disableRemote.'
+    );
+    expect(allCode).not.toContain('beforeRegisterRemote');
+  });
+
+  it('removes shared dependency internals when disableShared is enabled', async () => {
+    const output = await buildFixture({
+      mfOptions: {
+        ...BASIC_REMOTE_MF_OPTIONS,
+        disableShared: true,
+      },
+    });
+    const allCode = getAllChunkCode(output);
+
+    expect(allCode).toContain(
+      'Shared dependency loading is disabled by experiments.optimization.disableShared.'
+    );
+    expect(allCode).not.toContain('initContainerShareScopeMap');
+  });
+
+  it('removes snapshot plugins when disableSnapshot is enabled', async () => {
+    const defaultOutput = await buildFixture({
+      mfOptions: BASIC_REMOTE_MF_OPTIONS,
+    });
+    const optimizedOutput = await buildFixture({
+      mfOptions: {
+        ...BASIC_REMOTE_MF_OPTIONS,
+        disableSnapshot: true,
+      },
+    });
+
+    expect(getAllChunkCode(defaultOutput)).toContain('generatePreloadAssetsPlugin');
+    expect(getAllChunkCode(optimizedOutput)).not.toContain(
+      'generatePreloadAssetsPlugin'
+    );
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,7 +11,10 @@ import type {
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parsePromise } from '../plugins/pluginModuleParseEnd';
 import { callHook } from '../utils/__tests__/viteHookHelpers';
-import type { PluginManifestOptions } from '../utils/normalizeModuleFederationOptions';
+import type {
+  ModuleFederationOptions,
+  PluginManifestOptions,
+} from '../utils/normalizeModuleFederationOptions';
 import { toViteEncodedId } from '../utils/VirtualModule';
 import {
   getLoadShareImportId,
@@ -179,10 +182,17 @@ function getNormalizeOptimizeDepsPlugin(): FederationPlugin {
 }
 
 function getModuleFederationVitePlugin(): FederationPlugin {
+  return getModuleFederationVitePluginWithOptions({});
+}
+
+function getModuleFederationVitePluginWithOptions(
+  overrides: Partial<ModuleFederationOptions>
+): FederationPlugin {
   const plugin = (
     federation({
       name: 'host',
       filename: 'remoteEntry.js',
+      ...overrides,
     }) as Plugin[]
   ).find((entry) => entry.name === 'module-federation-vite');
 
@@ -1658,6 +1668,93 @@ describe('vite:module-federation-early-init', () => {
     expect(config.define.FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN).toBe('true');
   });
 
+  it('maps runtime capability options to build-time defines', () => {
+    const plugin = getModuleFederationVitePluginWithOptions({
+      disableRemote: true,
+      disableShared: true,
+      disableSnapshot: true,
+    });
+    const config: any = {
+      root: process.cwd(),
+      define: {},
+      resolve: { alias: [] },
+      build: {},
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'build',
+      mode: 'test',
+    });
+
+    expect(config.define).toMatchObject({
+      FEDERATION_OPTIMIZE_NO_REMOTE: 'true',
+      FEDERATION_OPTIMIZE_NO_SHARED: 'true',
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'true',
+    });
+  });
+
+  it('warns once when disabled capabilities are configured for use', () => {
+    const plugin = getModuleFederationVitePluginWithOptions({
+      disableRemote: true,
+      disableShared: true,
+      remotes: {
+        remoteApp: {
+          name: 'remoteApp',
+          entry: 'https://example.com/remoteEntry.js',
+        },
+      },
+      shared: {
+        react: {},
+      },
+    });
+    const config: any = {
+      root: process.cwd(),
+      resolve: { alias: [] },
+      build: {},
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'build',
+      mode: 'test',
+    });
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'build',
+      mode: 'test',
+    });
+
+    const warningMessages = vi.mocked(mfWarn).mock.calls.map(([message]) => message);
+    expect(
+      warningMessages.filter((message) =>
+        message.includes('disableRemote is true, but remotes are configured')
+      )
+    ).toHaveLength(1);
+    expect(
+      warningMessages.filter((message) =>
+        message.includes('disableShared is true, but shared dependencies are configured')
+      )
+    ).toHaveLength(1);
+  });
+
+  it('allows explicitly keeping snapshots in SSR builds', () => {
+    const plugin = getModuleFederationVitePluginWithOptions({
+      disableSnapshot: false,
+    });
+    const config: any = {
+      root: process.cwd(),
+      define: {},
+      resolve: { alias: [] },
+      build: { ssr: true },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'build',
+      mode: 'test',
+    });
+
+    expect(config.define.FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN).toBe('false');
+  });
+
   it('sets ENV_TARGET node for Vite Environment API ssr builds', () => {
     hasPackageDependencyMock.mockReturnValue(false);
     const plugin = getModuleFederationVitePlugin();
@@ -1681,6 +1778,37 @@ describe('vite:module-federation-early-init', () => {
     expect(ssrConfig.define.FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN).toBe('true');
     expect(sharedDefine).not.toHaveProperty('ENV_TARGET');
     expect(sharedDefine).not.toHaveProperty('FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN');
+  });
+
+  it('sets capability defines for Vite Environment API server builds', () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    const plugin = getModuleFederationVitePluginWithOptions({
+      disableRemote: true,
+      disableShared: true,
+      disableSnapshot: false,
+    });
+    const sharedDefine = { __APP__: 'true' };
+    const serverConfig: any = {
+      define: sharedDefine,
+      build: { ssr: true },
+      consumer: 'server',
+    };
+
+    const env = { command: 'build', mode: 'test' } as ConfigEnv;
+    const hook = plugin.configEnvironment;
+    if (!hook) throw new Error('configEnvironment hook not found');
+    if (typeof hook === 'function') {
+      hook.call({} as ConfigPluginContext, 'ssr', serverConfig, env);
+    } else {
+      hook.handler.call({} as ConfigPluginContext, 'ssr', serverConfig, env);
+    }
+
+    expect(serverConfig.define).toMatchObject({
+      FEDERATION_OPTIMIZE_NO_REMOTE: 'true',
+      FEDERATION_OPTIMIZE_NO_SHARED: 'true',
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'false',
+    });
+    expect(sharedDefine).toEqual({ __APP__: 'true' });
   });
 
   it('preserves env-level ENV_TARGET in Vite Environment API ssr builds', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ import {
   resolveImportPath,
   setPackageDetectionCwd,
 } from './utils/packageUtils';
+import {
+  applyRuntimeCapabilityDefines,
+  getRuntimeCapabilityConfigurationWarnings,
+} from './utils/runtimeCapabilityOptimization';
 import { getSsrCapabilities } from './utils/ssrCapabilities';
 import { getCommonSharedSubpaths, isAssetLikeImport } from './utils/pathNormalization';
 import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualModule';
@@ -605,6 +609,36 @@ export default __mfShared.default ?? __mfShared;`,
 
 const SSR_ONLY_PLUGINS = new Set(['@module-federation/vite/ssrEntryLoader']);
 
+type DefineConfig = NonNullable<UserConfig['define']>;
+
+type RuntimeDefineContext = {
+  target: 'web' | 'node';
+  isAstro: boolean;
+  defaultDisableSnapshot?: boolean;
+};
+
+function applyBuildTimeRuntimeDefines(
+  define: DefineConfig,
+  options: NormalizedModuleFederationOptions,
+  { target, isAstro, defaultDisableSnapshot }: RuntimeDefineContext
+): void {
+  const envTargetDefineValue = !options.target && isAstro ? 'undefined' : JSON.stringify(target);
+
+  if (!('ENV_TARGET' in define)) {
+    define.ENV_TARGET = envTargetDefineValue;
+  }
+  applyRuntimeCapabilityDefines(define, options, {
+    defaultDisableSnapshot,
+    onConflict: mfWarn,
+  });
+
+  if (options.target && define.ENV_TARGET !== JSON.stringify(options.target)) {
+    mfWarn(
+      `ENV_TARGET define (${define.ENV_TARGET}) differs from target option ("${options.target}"). ENV_TARGET will not be overridden.`
+    );
+  }
+}
+
 function loadPluginDts(options: NormalizedModuleFederationOptions): any[] {
   if (options.dts === false) {
     return [];
@@ -630,6 +664,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
   let command: string;
   let desiredRolldownOutput: OutputNameOptions[] | undefined;
   let isSsrBuild = false;
+  const emittedRuntimeCapabilityWarnings = new Set<string>();
 
   return [
     {
@@ -1254,29 +1289,18 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         // Resolve target: explicit option > SSR detection > 'web'
         // (Environment API server/ssr targets are set in configEnvironment.)
         const resolvedTarget = options.target ?? (config.build?.ssr ? 'node' : 'web');
-        const envTargetDefineValue =
-          !options.target && isAstro ? 'undefined' : JSON.stringify(resolvedTarget);
 
-        // Set ENV_TARGET define for tree-shaking Node.js code from the federation runtime
         if (!config.define) config.define = {};
-        if (!('ENV_TARGET' in config.define)) {
-          config.define['ENV_TARGET'] = envTargetDefineValue;
-        }
-        if (
-          resolvedTarget === 'node' &&
-          !('FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN' in config.define)
-        ) {
-          config.define['FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN'] = 'true';
-        }
+        applyBuildTimeRuntimeDefines(config.define, options, {
+          target: resolvedTarget,
+          isAstro,
+          defaultDisableSnapshot: resolvedTarget === 'node' ? true : undefined,
+        });
 
-        if (
-          options.target &&
-          'ENV_TARGET' in config.define &&
-          config.define['ENV_TARGET'] !== JSON.stringify(options.target)
-        ) {
-          mfWarn(
-            `ENV_TARGET define (${config.define['ENV_TARGET']}) differs from target option ("${options.target}"). ENV_TARGET will not be overridden.`
-          );
+        for (const warning of getRuntimeCapabilityConfigurationWarnings(options)) {
+          if (emittedRuntimeCapabilityWarnings.has(warning)) continue;
+          emittedRuntimeCapabilityWarnings.add(warning);
+          mfWarn(warning);
         }
       },
       configResolved(config: ResolvedConfig) {
@@ -1304,22 +1328,13 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         if (!isServerEnvironment) return;
 
         const isAstro = hasPackageDependency('astro');
-        const envTargetDefineValue =
-          !options.target && isAstro ? 'undefined' : JSON.stringify(options.target ?? 'node');
         // Copy define per environment — Vite may reuse the same object across envs.
         config.define = { ...(config.define ?? {}) };
-        if (!('ENV_TARGET' in config.define)) {
-          config.define['ENV_TARGET'] = envTargetDefineValue;
-        }
-        if (!('FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN' in config.define)) {
-          config.define['FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN'] = 'true';
-        }
-
-        if (options.target && config.define['ENV_TARGET'] !== JSON.stringify(options.target)) {
-          mfWarn(
-            `ENV_TARGET define (${config.define['ENV_TARGET']}) differs from target option ("${options.target}"). ENV_TARGET will not be overridden.`
-          );
-        }
+        applyBuildTimeRuntimeDefines(config.define, options, {
+          target: options.target ?? 'node',
+          isAstro,
+          defaultDisableSnapshot: true,
+        });
       },
     },
     ...pluginManifest(options),

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -55,7 +55,25 @@ describe('normalizeModuleFederationOption', () => {
       moduleParseTimeout: 10,
       moduleParseIdleTimeout: undefined,
       target: undefined,
+      disableRemote: undefined,
+      disableShared: undefined,
+      disableSnapshot: undefined,
       varFilename: undefined,
+    });
+  });
+
+  it('preserves runtime capability optimization options', () => {
+    const normalized = normalizeModuleFederationOptions({
+      ...minimalOptions,
+      disableRemote: true,
+      disableShared: true,
+      disableSnapshot: true,
+    });
+
+    expect(normalized).toMatchObject({
+      disableRemote: true,
+      disableShared: true,
+      disableSnapshot: true,
     });
   });
 

--- a/src/utils/__tests__/runtimeCapabilityOptimization.test.ts
+++ b/src/utils/__tests__/runtimeCapabilityOptimization.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type ModuleFederationOptions,
+  normalizeModuleFederationOptions,
+} from '../normalizeModuleFederationOptions';
+import {
+  applyRuntimeCapabilityDefines,
+  getRuntimeCapabilityConfigurationWarnings,
+} from '../runtimeCapabilityOptimization';
+
+function normalizeOptions(overrides: Partial<ModuleFederationOptions> = {}) {
+  return normalizeModuleFederationOptions({
+    name: 'host',
+    ...overrides,
+  });
+}
+
+describe('runtime capability optimization', () => {
+  it('maps explicitly configured capabilities to runtime defines', () => {
+    const define = {};
+    const options = normalizeOptions({
+      disableRemote: true,
+      disableShared: false,
+      disableSnapshot: true,
+    });
+
+    applyRuntimeCapabilityDefines(define, options);
+
+    expect(define).toEqual({
+      FEDERATION_OPTIMIZE_NO_REMOTE: 'true',
+      FEDERATION_OPTIMIZE_NO_SHARED: 'false',
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'true',
+    });
+  });
+
+  it('applies the environment snapshot default without enabling other defaults', () => {
+    const define = {};
+
+    applyRuntimeCapabilityDefines(define, normalizeOptions(), {
+      defaultDisableSnapshot: true,
+    });
+
+    expect(define).toEqual({
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'true',
+    });
+  });
+
+  it('allows an explicit snapshot option to override the environment default', () => {
+    const define = {};
+
+    applyRuntimeCapabilityDefines(define, normalizeOptions({ disableSnapshot: false }), {
+      defaultDisableSnapshot: true,
+    });
+
+    expect(define).toEqual({
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'false',
+    });
+  });
+
+  it('preserves existing defines and reports only conflicting explicit options', () => {
+    const onConflict = vi.fn();
+    const define = {
+      FEDERATION_OPTIMIZE_NO_REMOTE: 'false',
+      FEDERATION_OPTIMIZE_NO_SHARED: true,
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'false',
+    };
+
+    applyRuntimeCapabilityDefines(
+      define,
+      normalizeOptions({
+        disableRemote: true,
+        disableShared: true,
+      }),
+      {
+        defaultDisableSnapshot: true,
+        onConflict,
+      }
+    );
+
+    expect(define).toEqual({
+      FEDERATION_OPTIMIZE_NO_REMOTE: 'false',
+      FEDERATION_OPTIMIZE_NO_SHARED: true,
+      FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'false',
+    });
+    expect(onConflict).toHaveBeenCalledTimes(1);
+    expect(onConflict).toHaveBeenCalledWith(
+      expect.stringContaining('FEDERATION_OPTIMIZE_NO_REMOTE define')
+    );
+  });
+
+  it('reports incompatible remote and shared configurations', () => {
+    const warnings = getRuntimeCapabilityConfigurationWarnings(
+      normalizeOptions({
+        disableRemote: true,
+        disableShared: true,
+        remotes: {
+          remoteApp: {
+            name: 'remoteApp',
+            entry: 'https://example.com/remoteEntry.js',
+          },
+        },
+        shared: {
+          react: {},
+        },
+      })
+    );
+
+    expect(warnings).toEqual([
+      expect.stringContaining('disableRemote is true, but remotes are configured'),
+      expect.stringContaining('disableShared is true, but shared dependencies are configured'),
+    ]);
+  });
+});

--- a/src/utils/__tests__/runtimeCapabilityOptimization.test.ts
+++ b/src/utils/__tests__/runtimeCapabilityOptimization.test.ts
@@ -30,6 +30,7 @@ describe('runtime capability optimization', () => {
       FEDERATION_OPTIMIZE_NO_REMOTE: 'true',
       FEDERATION_OPTIMIZE_NO_SHARED: 'false',
       FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'true',
+      FEDERATION_HAS_EXPOSES: 'false',
     });
   });
 
@@ -42,6 +43,7 @@ describe('runtime capability optimization', () => {
 
     expect(define).toEqual({
       FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'true',
+      FEDERATION_HAS_EXPOSES: 'false',
     });
   });
 
@@ -54,6 +56,33 @@ describe('runtime capability optimization', () => {
 
     expect(define).toEqual({
       FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'false',
+      FEDERATION_HAS_EXPOSES: 'false',
+    });
+  });
+
+  it('sets FEDERATION_HAS_EXPOSES to true when exposes are configured', () => {
+    const define = {};
+
+    applyRuntimeCapabilityDefines(
+      define,
+      normalizeOptions({ exposes: { './App': './src/App.vue' } })
+    );
+
+    expect(define).toMatchObject({
+      FEDERATION_HAS_EXPOSES: 'true',
+    });
+  });
+
+  it('does not override an explicitly configured FEDERATION_HAS_EXPOSES define', () => {
+    const define = { FEDERATION_HAS_EXPOSES: 'false' };
+
+    applyRuntimeCapabilityDefines(
+      define,
+      normalizeOptions({ exposes: { './App': './src/App.vue' } })
+    );
+
+    expect(define).toEqual({
+      FEDERATION_HAS_EXPOSES: 'false',
     });
   });
 
@@ -81,6 +110,7 @@ describe('runtime capability optimization', () => {
       FEDERATION_OPTIMIZE_NO_REMOTE: 'false',
       FEDERATION_OPTIMIZE_NO_SHARED: true,
       FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN: 'false',
+      FEDERATION_HAS_EXPOSES: 'false',
     });
     expect(onConflict).toHaveBeenCalledTimes(1);
     expect(onConflict).toHaveBeenCalledWith(

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -530,6 +530,27 @@ export type ModuleFederationOptions = {
    */
   target?: 'web' | 'node';
   /**
+   * Removes remote-consumption support from the federation runtime.
+   * Only enable this for builds that never load remotes.
+   *
+   * @default false
+   */
+  disableRemote?: boolean;
+  /**
+   * Removes shared-dependency support from the federation runtime.
+   * Only enable this when the build has no shared dependencies.
+   *
+   * @default false
+   */
+  disableShared?: boolean;
+  /**
+   * Removes snapshot support, including manifest-based remotes, preload,
+   * dynamic type hints, HMR, and devtools integration.
+   *
+   * @default false (true for Node/SSR builds)
+   */
+  disableSnapshot?: boolean;
+  /**
    * Additional packages to mark as external in the SSR remote entry build.
    * Shared packages and MF runtime packages are always external. Use this to
    * add any other Node-only packages that should not be bundled into the SSR entry.
@@ -745,6 +766,9 @@ export function normalizeModuleFederationOptions(
     moduleParseIdleTimeout: options.moduleParseIdleTimeout,
     varFilename: options.varFilename,
     target: options.target,
+    disableRemote: options.disableRemote,
+    disableShared: options.disableShared,
+    disableSnapshot: options.disableSnapshot,
   };
   explicitSharedKeysByOptions.set(normalized, new Set(explicitSharedKeys));
   return (config = normalized);

--- a/src/utils/runtimeCapabilityOptimization.ts
+++ b/src/utils/runtimeCapabilityOptimization.ts
@@ -59,6 +59,10 @@ export function applyRuntimeCapabilityDefines(
       );
     }
   }
+
+  if (!('FEDERATION_HAS_EXPOSES' in define)) {
+    define['FEDERATION_HAS_EXPOSES'] = JSON.stringify(Object.keys(options.exposes).length > 0);
+  }
 }
 
 export function getRuntimeCapabilityConfigurationWarnings(

--- a/src/utils/runtimeCapabilityOptimization.ts
+++ b/src/utils/runtimeCapabilityOptimization.ts
@@ -1,0 +1,82 @@
+import type { UserConfig } from 'vite';
+import type { NormalizedModuleFederationOptions } from './normalizeModuleFederationOptions';
+
+type RuntimeCapabilityOption = 'disableRemote' | 'disableShared' | 'disableSnapshot';
+type DefineConfig = NonNullable<UserConfig['define']>;
+
+const RUNTIME_CAPABILITIES = [
+  {
+    option: 'disableRemote',
+    define: 'FEDERATION_OPTIMIZE_NO_REMOTE',
+  },
+  {
+    option: 'disableShared',
+    define: 'FEDERATION_OPTIMIZE_NO_SHARED',
+  },
+  {
+    option: 'disableSnapshot',
+    define: 'FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN',
+  },
+] as const satisfies ReadonlyArray<{
+  option: RuntimeCapabilityOption;
+  define: string;
+}>;
+
+type RuntimeCapabilityDefineOptions = {
+  defaultDisableSnapshot?: boolean;
+  onConflict?: (message: string) => void;
+};
+
+function isEquivalentBooleanDefine(value: unknown, expected: boolean): boolean {
+  return String(value) === JSON.stringify(expected);
+}
+
+export function applyRuntimeCapabilityDefines(
+  define: DefineConfig,
+  options: NormalizedModuleFederationOptions,
+  { defaultDisableSnapshot, onConflict }: RuntimeCapabilityDefineOptions = {}
+): void {
+  for (const capability of RUNTIME_CAPABILITIES) {
+    const explicitValue = options[capability.option];
+    const desiredValue =
+      capability.option === 'disableSnapshot'
+        ? (explicitValue ?? defaultDisableSnapshot)
+        : explicitValue;
+
+    if (desiredValue === undefined) continue;
+
+    if (!(capability.define in define)) {
+      define[capability.define] = JSON.stringify(desiredValue);
+      continue;
+    }
+
+    if (
+      explicitValue !== undefined &&
+      !isEquivalentBooleanDefine(define[capability.define], explicitValue)
+    ) {
+      onConflict?.(
+        `${capability.define} define (${define[capability.define]}) differs from ${capability.option} option (${explicitValue}). The existing define will not be overridden.`
+      );
+    }
+  }
+}
+
+export function getRuntimeCapabilityConfigurationWarnings(
+  options: NormalizedModuleFederationOptions
+): string[] {
+  const warnings: string[] = [];
+
+  if (options.disableRemote && Object.keys(options.remotes).length > 0) {
+    warnings.push(
+      'disableRemote is true, but remotes are configured. Remote loading will be unavailable at runtime.'
+    );
+  }
+
+  if (options.disableShared && Object.keys(options.shared).length > 0) {
+    warnings.push(
+      'disableShared is true, but shared dependencies are configured. Shared dependency loading will be unavailable at runtime.'
+    );
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Related release

- Module Federation Core v2.8.0: https://github.com/module-federation/core/releases/tag/v2.8.0

## Summary

This PR exposes the Module Federation Core build-time runtime capability optimizations through the Vite plugin:

```ts
federation({
  name: "remote",
  exposes: {
    "./remote-app": "./src/App.vue",
  },
  disableRemote: true,
  disableShared: true,
  disableSnapshot: true,
});
```

Each option is mapped to the corresponding compile-time define. The Core runtime uses these defines to tree-shake capabilities that are not required by a build.

| Vite option       | Runtime define                           | Effect                                        |
| ----------------- | ---------------------------------------- | --------------------------------------------- |
| `disableRemote`   | `FEDERATION_OPTIMIZE_NO_REMOTE`          | Removes remote consumption internals          |
| `disableShared`   | `FEDERATION_OPTIMIZE_NO_SHARED`          | Removes shared dependency loading internals   |
| `disableSnapshot` | `FEDERATION_OPTIMIZE_NO_SNAPSHOT_PLUGIN` | Removes snapshot and related plugin internals |

## Motivation

Core v2.8 introduced build-time flags for removing unused runtime capabilities. The Vite plugin already disabled the snapshot plugin for Node/SSR builds, but it did not expose a consistent public API for controlling remote, shared, and snapshot capabilities.

This PR has two goals:

1. Make the Core runtime optimization flags safely configurable through the Vite plugin.
2. Preserve the existing behavior of web, Node/SSR, Astro, and Vite Environment API builds.

## Behavior

### Defaults

| Environment | `disableRemote` | `disableShared` | `disableSnapshot` |
| ----------- | --------------- | --------------- | ----------------- |
| Web/client  | `false`         | `false`         | `false`           |
| Node/SSR    | `false`         | `false`         | `true`            |

The Node/SSR default of `disableSnapshot: true` is existing plugin behavior preserved by this PR, not a newly introduced default.

Users can explicitly set `disableSnapshot: false` to retain snapshot support in a Node/SSR build.

### Configuration precedence

Configuration is resolved in the following order:

1. An existing user-provided Vite `define`
2. An explicit federation capability option
3. An environment default

For example, the existing Vite `define` is preserved in the following configuration, and the plugin emits a conflict warning:

```ts
export default defineConfig({
  define: {
    FEDERATION_OPTIMIZE_NO_REMOTE: "false",
  },
  plugins: [
    federation({
      name: "host",
      disableRemote: true,
    }),
  ],
});
```

The plugin does not overwrite existing defines because an application or an integrating framework may own the final build-time policy.

### Unsafe option combinations

The following configurations are accepted but produce warnings because the disabled runtime capability conflicts with the federation configuration:

- `disableRemote: true` with non-empty `remotes`
- `disableShared: true` with non-empty `shared`

Each warning is emitted only once per plugin instance. These cases remain warnings rather than build errors because different graphs or entries may be produced from the same federation configuration.

### Vite Environment API

The server environment receives a copied `define` object before server-specific defines are applied. This prevents server-only defines from leaking into the client graph if Vite reuses the same object across environments.

The existing behavior is preserved:

- Server environments default to `ENV_TARGET: "node"`.
- Explicit `target` values and existing `ENV_TARGET` defines are preserved.
- Astro mixed builds do not force `ENV_TARGET` to Node.
- Server environments retain the existing snapshot-disabled default.

## Implementation structure

The implementation separates capability policy from Vite hook integration.

### `normalizeModuleFederationOptions.ts`

- Defines the public options.
- Preserves the three capability options in the normalized configuration.

### `runtimeCapabilityOptimization.ts`

- Maps capability options to runtime defines.
- Resolves explicit options, environment defaults, and existing define precedence.
- Reports explicit option/define conflicts.
- Validates incompatible `remotes`/`shared` and disable option combinations.

### `index.ts`

- Applies build-time defines from the root `config` and `configEnvironment` hooks.
- Selects the environment-specific snapshot default.
- Deduplicates incompatible-configuration warnings.

This separation allows capability policy to be tested independently from the Vite plugin lifecycle.

## Bundle-level verification

The integration tests verify actual Core runtime code elimination, not only the generated define values.

| Option                  | Bundle assertion                                                                |
| ----------------------- | ------------------------------------------------------------------------------- |
| `disableRemote: true`   | The disabled remote path remains, while `beforeRegisterRemote` is removed       |
| `disableShared: true`   | The disabled shared path remains, while `initContainerShareScopeMap` is removed |
| `disableSnapshot: true` | `generatePreloadAssetsPlugin`, present in the default bundle, is removed        |

## Suggested review order

Because this PR touches configuration, environment integration, and bundle output, the following review order may be useful:

1. `src/utils/normalizeModuleFederationOptions.ts`
   - Review the public API and documented defaults.
2. `src/utils/runtimeCapabilityOptimization.ts`
   - Review option-to-define mapping and precedence.
   - Review existing define preservation and conflict reporting.
3. `src/index.ts`
   - Review root config and Environment API wiring.
   - Confirm that existing Node/SSR and Astro behavior is preserved.
4. Unit tests
   - Review explicit `true`/`false`, environment defaults, and conflict handling.
5. `integration/target-code-elimination.test.ts`
   - Review bundle-level tree-shaking assertions.
6. `README.md`
   - Review the user-facing documentation and safety guidance.

Areas where reviewer feedback would be especially useful:

- Whether an existing Vite `define` should have the highest precedence
- Whether the previous Node/SSR snapshot behavior is preserved correctly
- Whether incompatible option combinations should remain warnings
- Whether the selected bundle markers provide sufficiently stable code-elimination coverage

## Backward compatibility

- Existing web/client configurations are unchanged when the new options are omitted.
- The existing Node/SSR snapshot optimization remains enabled.
- Existing capability-related Vite defines are never overwritten.
- An explicit `disableSnapshot: false` overrides the Node/SSR default.

## Tests

The following local checks passed:

- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
  - 876 passed
  - 1 skipped
- `pnpm exec vitest run integration/target-code-elimination.test.ts`
  - 5 passed
- Focused runtime capability coverage:
  - option normalization
  - define mapping
  - define conflict handling
  - environment defaults
  - incompatible-configuration warning deduplication
  - actual bundle code elimination

## Checklist

- [x] Added public option types
- [x] Added option normalization
- [x] Added Core runtime define mapping
- [x] Preserved existing Vite define precedence
- [x] Preserved Node/SSR and Environment API behavior
- [x] Added warnings for incompatible configurations
- [x] Added unit coverage
- [x] Added bundle-level code-elimination coverage
- [x] Added README documentation
