### PR TITLE
fix: exclude unoptimizable raw JSX shares

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1460,6 +1460,43 @@ describe('vite:module-federation-early-init', () => {
     expect(getUsedShares(federationPlugin._options)).not.toContain('react/compiler-runtime');
   });
 
+  it('excludes a workspace-linked shared subpath resolving to raw .tsx source from dev optimizeDeps', () => {
+    const plugins = federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      shared: {
+        '@test-issue/theme/provider': {
+          singleton: true,
+        },
+      },
+    }) as Plugin[];
+    const earlyInitPlugin = plugins.find(
+      (entry) => entry.name === 'vite:module-federation-early-init'
+    );
+    if (!earlyInitPlugin) {
+      throw new Error('module federation plugins not found');
+    }
+    const config: any = {
+      root: path.join(process.cwd(), 'test-issue/host'),
+      optimizeDeps: {
+        include: [],
+        exclude: [],
+      },
+    };
+
+    runConfig(earlyInitPlugin, {} as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    // Vite's optimizer only ever bundles .js/.cjs/.mjs/.ts/.cts/.mts entries
+    // (not .jsx/.tsx). Forcing a raw .tsx workspace source into `include`
+    // makes Vite warn "Cannot optimize dependency" on every dev start and
+    // leaves it permanently unresolved from the optimizer's perspective.
+    expect(config.optimizeDeps.include).not.toContain('@test-issue/theme/provider');
+    expect(config.optimizeDeps.exclude).toContain('@test-issue/theme/provider');
+  });
+
   it('pre-seeds transitive shared dependencies for the dev optimizer', () => {
     const plugin = (
       federation({

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,11 @@ import {
   getRuntimeCapabilityConfigurationWarnings,
 } from './utils/runtimeCapabilityOptimization';
 import { getSsrCapabilities } from './utils/ssrCapabilities';
-import { getCommonSharedSubpaths, isAssetLikeImport } from './utils/pathNormalization';
+import {
+  getCommonSharedSubpaths,
+  isAssetLikeImport,
+  isViteOptimizableEntry,
+} from './utils/pathNormalization';
 import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualModule';
 import {
   getHostAutoInitImportId,
@@ -251,14 +255,15 @@ function isFederationHtmlPreloadDependency(dep: string, includeSharedRuntime = f
   );
 }
 
-// Returns false for subpaths not exported by the installed package (e.g.
-// react/compiler-runtime on React 18) so we can exclude them from Vite's dep
-// optimizer instead of letting Vite's resolver error on the missing export.
+// Returns false for subpaths that either aren't exported by the installed
+// package (e.g. react/compiler-runtime on React 18) or resolve to a file
+// Vite's optimizer refuses to bundle (e.g. raw .tsx source), so callers can
+// exclude them from Vite's dep optimizer instead of letting Vite silently
+// drop them with a "Cannot optimize dependency" warning every dev start.
 function canResolveSharedSubpath(subpath: string, projectRoot: string): boolean {
   try {
     const req = createRequire(pathToFileURL(path.join(projectRoot, 'package.json')));
-    req.resolve(subpath);
-    return true;
+    return isViteOptimizableEntry(req.resolve(subpath));
   } catch {
     return false;
   }
@@ -516,7 +521,9 @@ export default __mfShared.default ?? __mfShared;`,
             // local prebuild fallbacks receive Vite's CJS-to-ESM interop.
             // Singleton identity is enforced by the federation share cache
             // and loadShare proxy, independently from dependency optimization.
-            const shouldBypassOptimizeDep = isLitShare(key);
+            // Shares resolving to raw .jsx/.tsx source can't be optimized by
+            // Vite at all, so route them to exclude the same way.
+            const shouldBypassOptimizeDep = isLitShare(key) || !canResolveSharedSubpath(key, root);
             if (optimizeDeps.include.includes(key)) {
               optimizeDeps.exclude = optimizeDeps.exclude.filter((dep) => dep !== key);
             } else if (shouldBypassOptimizeDep) {

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -55,6 +55,33 @@ describe('getInstalledPackageJson', () => {
     );
   });
 
+  it('caches lookups per (cwd, pkg) instead of re-reading the filesystem every call', () => {
+    const packageName = 'mf-test-cache-pkg';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-cache-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: packageName, version: '1.0.0', main: './index.js' })
+    );
+    writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = {};');
+
+    const first = getInstalledPackageJson(packageName, { cwd: hostDir });
+    expect(first?.packageJson.name).toBe(packageName);
+
+    // A fresh (uncached) lookup would now fail — the package is gone from
+    // disk. If getInstalledPackageJson still returns the earlier result,
+    // it served it from the cache instead of re-reading the filesystem.
+    rmSync(packageDir, { recursive: true, force: true });
+
+    const second = getInstalledPackageJson(packageName, { cwd: hostDir });
+    expect(second).toBe(first);
+  });
+
   it('prefers browser conditional exports for installed package entries', () => {
     const packageName = 'mf-test-browser-conditional';
     const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-browser-'));

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -19,6 +19,13 @@ function getDependencyCacheKey(cwd: string, dependencyName: string) {
   return `${cwd}:${dependencyName}`;
 }
 
+// getInstalledPackageJson's fallback path can scan every entry in
+// node_modules/.pnpm (thousands in a real monorepo) with synchronous fs
+// calls. It's invoked repeatedly for the same specifier from resolveId
+// hooks during dev serving, so cache results for the process lifetime the
+// same way hasPackageDependency already does above.
+const installedPackageJsonCache = new Map<string, InstalledPackageJson | undefined>();
+
 export function setPackageDetectionCwd(cwd: string) {
   packageDetectionCwd = cwd;
 }
@@ -392,6 +399,21 @@ export function getInstalledPackageJson(
 ): InstalledPackageJson | undefined {
   const cwd = opts?.cwd || getPackageDetectionCwd();
   const packageName = opts?.packageName || getPackageName(pkg);
+  const cacheKey = `${cwd}\0${pkg}\0${packageName}\0${opts?.fromResolvedEntry ?? ''}`;
+  if (installedPackageJsonCache.has(cacheKey)) {
+    return installedPackageJsonCache.get(cacheKey);
+  }
+  const result = resolveInstalledPackageJson(pkg, cwd, packageName, opts);
+  installedPackageJsonCache.set(cacheKey, result);
+  return result;
+}
+
+function resolveInstalledPackageJson(
+  pkg: string,
+  cwd: string,
+  packageName: string,
+  opts?: PackageEntryConditions
+): InstalledPackageJson | undefined {
   const tryReadPackageJson = (packageJsonPath: string): InstalledPackageJson | undefined => {
     if (!existsSync(packageJsonPath)) return undefined;
     try {

--- a/src/utils/pathNormalization.ts
+++ b/src/utils/pathNormalization.ts
@@ -53,6 +53,14 @@ export function isAssetLikeImport(source: string): boolean {
   return ASSET_LIKE_IMPORT_RE.test(source);
 }
 
+// Mirrors Vite's own OPTIMIZABLE_ENTRY_RE: its dependency optimizer only
+// bundles .js/.cjs/.mjs/.ts/.cts/.mts entries — notably not .jsx/.tsx.
+const VITE_OPTIMIZABLE_ENTRY_RE = /\.[cm]?[jt]s$/;
+
+export function isViteOptimizableEntry(resolvedPath: string): boolean {
+  return VITE_OPTIMIZABLE_ENTRY_RE.test(resolvedPath);
+}
+
 export function removeTrailingSlash(value: string): string {
   return value.endsWith('/') ? value.slice(0, -1) : value;
 }


### PR DESCRIPTION
Speeds up dev-server cold start for shared deps that resolve to raw .jsx/.tsx workspace source, common in monorepos where a shared package has no prebuilt dist/. Vite's optimizer never bundles .jsx/.tsx, so forcing them into optimizeDeps.include left them stuck unresolved (triggering repeated Cannot optimize dependency warnings and, in some cases, indefinite hangs) instead of routing them to exclude like other unoptimizable shares already are.