### PR TITLE
fix: fix React HMR with base paths

### DIFF
--- a/src/plugins/hmr/__tests__/react.test.ts
+++ b/src/plugins/hmr/__tests__/react.test.ts
@@ -11,10 +11,11 @@ type Middleware = (
   next: () => void
 ) => void;
 
-function createCtx(): { ctx: AdapterContext; middlewares: Middleware[] } {
+function createCtx(base = '/'): { ctx: AdapterContext; middlewares: Middleware[] } {
   const middlewares: Middleware[] = [];
   const ctx: AdapterContext = {
     server: {
+      config: { base, root: process.cwd() },
       middlewares: {
         use: (handler: Middleware) => {
           middlewares.push(handler);
@@ -58,6 +59,41 @@ describe('reactAdapter', () => {
     );
     expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
     expect(res.end).toHaveBeenCalledWith(expect.stringContaining('window.location.origin'));
+  });
+
+  it('serves the React refresh proxy under the configured base path', () => {
+    const { ctx, middlewares } = createCtx('/aaa/');
+    reactAdapter.remote?.configureServer?.(ctx);
+
+    const res = { setHeader: vi.fn(), end: vi.fn() };
+    const next = vi.fn();
+    middlewares[0](
+      { url: '/aaa/@react-refresh?v=abc' } as IncomingMessage,
+      res as unknown as ServerResponse<IncomingMessage>,
+      next
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('window.location.origin'));
+    expect(res.end).toHaveBeenCalledWith(
+      expect.stringContaining("new URL('./@mf-react-refresh-local', __remoteUrl).href")
+    );
+  });
+
+  it('serves the local React refresh runtime under the configured base path', () => {
+    const { ctx, middlewares } = createCtx('/aaa/');
+    reactAdapter.remote?.configureServer?.(ctx);
+
+    const res = { setHeader: vi.fn(), end: vi.fn() };
+    const next = vi.fn();
+    middlewares[0](
+      { url: '/aaa/@mf-react-refresh-local' } as IncomingMessage,
+      res as unknown as ServerResponse<IncomingMessage>,
+      next
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('injectIntoGlobalHook'));
   });
 
   it('passes other requests through', () => {

--- a/src/plugins/hmr/react.ts
+++ b/src/plugins/hmr/react.ts
@@ -41,8 +41,8 @@ function resolveReactRefreshRuntime(root: string): string {
  * falls back to this remote's local runtime when the remote is opened directly.
  */
 const REACT_REFRESH_PROXY_MODULE = [
-  `const __remoteOrigin = new URL(import.meta.url).origin;`,
-  `const __target = window.location.origin === __remoteOrigin ? '${LOCAL_REACT_REFRESH_PATH}' : window.location.origin + '${REACT_REFRESH_PATH}';`,
+  `const __remoteUrl = new URL(import.meta.url);`,
+  `const __target = window.location.origin === __remoteUrl.origin ? new URL('.${LOCAL_REACT_REFRESH_PATH}', __remoteUrl).href : window.location.origin + '${REACT_REFRESH_PATH}';`,
   `const __rt = await import(__target);`,
   `export const injectIntoGlobalHook = __rt.injectIntoGlobalHook;`,
   `export const register = __rt.register;`,
@@ -65,7 +65,7 @@ export const reactAdapter: HmrAdapter = {
 
       server.middlewares.use((req, res, next) => {
         const url = stripQuery(req.url);
-        if (url === LOCAL_REACT_REFRESH_PATH) {
+        if (url?.endsWith(LOCAL_REACT_REFRESH_PATH)) {
           reactRefreshRuntime ??= resolveReactRefreshRuntime(server.config.root);
           res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
           res.setHeader('Access-Control-Allow-Origin', '*');
@@ -73,7 +73,7 @@ export const reactAdapter: HmrAdapter = {
           return;
         }
 
-        if (url !== REACT_REFRESH_PATH) return next();
+        if (!url?.endsWith(REACT_REFRESH_PATH)) return next();
 
         res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
         res.setHeader('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
Close #949

Fix React remote HMR with non-root Vite base paths by matching refresh endpoints by suffix and resolving the local refresh runtime relative to the remote URL.