### PR TITLE
fix: preserve shared packages’ internal imports

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1091,6 +1091,39 @@ describe('vite:module-federation-early-init', () => {
     ).toBeUndefined();
   });
 
+  it('does not proxy a shared package self-referencing its own subpath', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        shared: { zustand: { singleton: true } },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = { root: process.cwd(), optimizeDeps: { include: [] } };
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const optimizeSharedProxy = config.optimizeDeps.esbuildOptions.plugins.find(
+      (entry: any) => entry.name === 'module-federation:optimize-shared-proxy'
+    );
+    const onResolveHandlers: any[] = [];
+    optimizeSharedProxy.setup({
+      onResolve: (_options: unknown, handler: unknown) => onResolveHandlers.push(handler),
+      onLoad: () => undefined,
+    });
+
+    expect(
+      onResolveHandlers[1]({
+        path: 'zustand/react',
+        importer: '/repo/node_modules/zustand/esm/index.mjs',
+        kind: 'import-statement',
+      })
+    ).toBeUndefined();
+  });
+
   it('excludes asset imports from esbuild optimizeDeps shared proxy', () => {
     const plugin = (
       federation({

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ import {
   getIsRolldown,
   getInstalledPackageEntry,
   getInstalledPackageJson,
+  getPackageName,
+  getPackageNameFromNodeModulePath,
   hasPackageDependency,
   resolveImportPath,
   setPackageDetectionCwd,
@@ -457,6 +459,8 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   if (isSharedResolverInternalImporter(args.importer)) return;
                   const key = findSharedKey(args.path, shared);
                   if (!key || isAssetLikeImport(args.path)) return;
+                  if (getPackageNameFromNodeModulePath(args.importer) === getPackageName(args.path))
+                    return;
                   return { path: args.path, namespace: 'mf-shared' };
                 });
                 build.onLoad({ filter: /.*/, namespace: 'mf-shared' }, (args: any) => {


### PR DESCRIPTION
Close #954

Prevent shared packages’ internal subpath imports from being incorrectly proxied during Vite 7 dependency optimisation.