### PR TITLE
fix: preserve legacy shared subpath exports

### DIFF
--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import * as path from 'node:path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
@@ -114,6 +114,34 @@ describe('getInstalledPackageJson', () => {
     const entry = getInstalledPackageEntry(packageName, { cwd: hostDir });
 
     expect(entry).toBe(path.join(packageDir, 'dist/browser.js'));
+  });
+
+  it('preserves legacy package subpaths when ESM condition resolution is requested', () => {
+    const packageName = 'mf-test-legacy-subpath';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-legacy-subpath-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: packageName, main: './index.js' })
+    );
+    writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = { root: true };');
+    writeFileSync(
+      path.join(packageDir, 'jsx-runtime.js'),
+      'module.exports = { Fragment: Symbol.for("fragment"), jsx() {}, jsxs() {} };'
+    );
+
+    const entry = getInstalledPackageEntry(`${packageName}/jsx-runtime`, {
+      cwd: hostDir,
+      conditions: ['browser', 'import', 'module', 'default'],
+      resolveSubpathWithRequire: false,
+    });
+
+    expect(entry).toBe(realpathSync(path.join(packageDir, 'jsx-runtime.js')));
   });
 
   it('resolves wildcard subpath exports (e.g. "./components/*")', () => {

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -511,7 +511,11 @@ export function getInstalledPackageEntry(
   if (!installed) return undefined;
   const cwd = opts?.cwd || getPackageDetectionCwd();
   const packageName = opts?.packageName || getPackageName(pkg);
-  if (pkg !== packageName && opts?.resolveSubpathWithRequire !== false) {
+  const packageJson = installed.packageJson;
+  if (
+    pkg !== packageName &&
+    (opts?.resolveSubpathWithRequire !== false || packageJson.exports === undefined)
+  ) {
     try {
       const projectRequire = createRequire(pathToFileURL(path.join(cwd, 'package.json')));
       return projectRequire.resolve(pkg);
@@ -519,7 +523,6 @@ export function getInstalledPackageEntry(
       // Fall back to root package entry resolution below.
     }
   }
-  const packageJson = installed.packageJson;
   const exportsEntry = resolveExportsEntry(
     getPackageExportsTarget(pkg, packageName, packageJson.exports),
     opts?.conditions

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -176,6 +176,9 @@ vi.mock('../../utils/packageUtils', () => ({
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
   resolveImportPath: vi.fn(() => '/repo/node_modules/@module-federation/runtime/dist/index.js'),
   getInstalledPackageEntry: vi.fn((pkg: string, opts?: { cwd?: string }) => {
+    if (pkg === 'react/jsx-runtime') {
+      return '/repo/apps/remote/node_modules/react/jsx-runtime.js';
+    }
     if (pkg === 'mock-package-star-dependency') {
       return '/repo/apps/remote/node_modules/mock-package-star-dependency/index.js';
     }
@@ -414,6 +417,7 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-cjs-comment/index.js') ||
       filePath.endsWith('/mock-package-cjs-comment/index.js') ||
+      filePath.endsWith('node_modules/react/jsx-runtime.js') ||
       filePath.endsWith('/repo/packages/workspace-shared-lib/package.json') ||
       filePath.endsWith('/repo/packages/workspace-unknown-exports/package.json') ||
       filePath.endsWith('/repo/packages/workspace-unknown-exports/src/index.ts') ||
@@ -723,6 +727,9 @@ export const [firstItem, ...restItems] = tuple;`;
     if (filePath.endsWith('node_modules/mock-package-cjs-comment/index.js')) {
       return "// export const phantom = 1;\nmodule['exports'] = { real: 1 };";
     }
+    if (filePath.endsWith('node_modules/react/jsx-runtime.js')) {
+      return "module.exports = require('./cjs/react-jsx-runtime.production.min.js');";
+    }
     if (filePath.endsWith('/repo/packages/workspace-shared-lib/package.json')) {
       return JSON.stringify({ name: 'workspace-shared-lib' });
     }
@@ -839,6 +846,13 @@ vi.mock('module', async (importOriginal) => {
             real: 1,
             default: {},
             __esModule: true,
+          };
+        }
+        if (pkg.endsWith('/react/jsx-runtime.js')) {
+          return {
+            Fragment: Symbol.for('react.fragment'),
+            jsx: () => undefined,
+            jsxs: () => undefined,
           };
         }
         if (pkg.endsWith('/typescript-cjs-barrel.js')) {
@@ -2017,6 +2031,29 @@ describe('writeLoadShareModule', () => {
     );
     expect(generatedCode).not.toContain('providerModulePromise');
     expect(generatedCode).not.toContain('await ');
+  });
+
+  it('generates React 17 JSX runtime exports from the legacy subpath entry', () => {
+    const pkg = 'react/jsx-runtime';
+    const mockShareItem: ShareItem = {
+      name: 'react',
+      from: '',
+      version: '17.0.2',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^17.0.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', true);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expectLiveSingletonProxy(generatedCode, pkg, ['Fragment', 'jsx', 'jsxs']);
+    expect(generatedCode).not.toContain('createElement');
+    expect(generatedCode).not.toContain('useState');
   });
 
   it('reads React compiler runtime internals from the compatible React cache key', () => {


### PR DESCRIPTION
## Summary

Preserve exact package subpaths during ESM-oriented export inspection for legacy packages without an `exports` map. This prevents React 17 `react/jsx-runtime` from being inspected as the root `react/index.js` module and generating incorrect load-share named exports.

## Changes

- Resolve legacy package subpaths through the project resolver when no `exports` map exists.
- Add package-resolution coverage for packages with a root `main` and separate runtime subpath.
- Add React 17 JSX runtime wrapper coverage for `Fragment`, `jsx`, and `jsxs`.

## Testing

- `pnpm test` (898 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm build`
- `pnpm fmt.check`
- `git diff --check`