### PR TITLE
fix: fix up context paths and HMR

### DIFF
--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -13,6 +13,29 @@ import { addUsedShares, generateHostAutoInitCode, getHostAutoInitPath } from '..
 import pluginProxyRemoteEntry from '../pluginProxyRemoteEntry';
 
 describe('pluginProxyRemoteEntry', () => {
+  it('does not treat an HTML proxy query containing host auto-init as the init module', async () => {
+    normalizeModuleFederationOptions({ name: 'test' });
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions(),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+
+    const proxyId = `\0virtual:mf-html-entry-proxy?init=${encodeURIComponent(getHostAutoInitPath())}&entry=%2Fsrc%2Fmain.jsx`;
+    expect(
+      await callHook(plugin.resolveId, {} as Rollup.PluginContext, proxyId, undefined, {
+        isEntry: false,
+      })
+    ).toBeUndefined();
+    expect(await callHook(plugin.load, {} as Rollup.PluginContext, proxyId)).toBeUndefined();
+  });
+
   it('keeps dev host-init shared seeds bound to their owning options', () => {
     const optionsA = normalizeModuleFederationOptions({
       name: 'tenant-a',
@@ -159,5 +182,38 @@ describe('pluginProxyRemoteEntry', () => {
 
     expect(result.code).toContain('origin + "/remoteEntry.js"');
     expect(result.code).not.toContain('remoteEntry-[hash]');
+  });
+
+  it('uses an explicitly configured Vite base for dev host init', async () => {
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions({ filename: 'remoteEntry.js' }),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      { base: '/bbb/' },
+      { command: 'serve', mode: 'development' }
+    );
+    callHook(
+      plugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        root: '/repo',
+        base: '/bbb/',
+        server: { host: 'localhost', port: 4173 },
+      } as unknown as ResolvedConfig
+    );
+
+    const result = (await callHook(
+      plugin.transform,
+      {} as Rollup.TransformPluginContext,
+      '',
+      getHostAutoInitPath()
+    )) as { code: string };
+
+    expect(result.code).toContain('origin + "/bbb/remoteEntry.js"');
   });
 });

--- a/src/plugins/hmr/__tests__/react.test.ts
+++ b/src/plugins/hmr/__tests__/react.test.ts
@@ -112,7 +112,18 @@ describe('reactAdapter', () => {
     expect(res.end).not.toHaveBeenCalled();
   });
 
-  it('does not register a host-side hook namespace', () => {
-    expect(reactAdapter.host).toBeUndefined();
+  it('injects the host React refresh URL with the configured base path', () => {
+    const { ctx } = createCtx('/bbb/');
+    const tags = reactAdapter.host?.transformIndexHtml?.(ctx);
+
+    expect(tags).toEqual([
+      expect.objectContaining({
+        tag: 'script',
+        injectTo: 'head-prepend',
+        children: expect.stringContaining(
+          'globalThis.__MF_REACT_REFRESH_URL__ = new URL("/bbb/@react-refresh"'
+        ),
+      }),
+    ]);
   });
 });

--- a/src/plugins/hmr/react.ts
+++ b/src/plugins/hmr/react.ts
@@ -6,6 +6,7 @@ import type { HmrAdapter } from '../pluginDevRemoteHmr';
 
 const REACT_REFRESH_PATH = '/@react-refresh';
 const LOCAL_REACT_REFRESH_PATH = '/@mf-react-refresh-local';
+const HOST_REACT_REFRESH_URL = '__MF_REACT_REFRESH_URL__';
 
 function stripQuery(url?: string): string | undefined {
   return url?.replace(/\?.*$/, '');
@@ -42,7 +43,7 @@ function resolveReactRefreshRuntime(root: string): string {
  */
 const REACT_REFRESH_PROXY_MODULE = [
   `const __remoteUrl = new URL(import.meta.url);`,
-  `const __target = window.location.origin === __remoteUrl.origin ? new URL('.${LOCAL_REACT_REFRESH_PATH}', __remoteUrl).href : window.location.origin + '${REACT_REFRESH_PATH}';`,
+  `const __target = window.location.origin === __remoteUrl.origin ? new URL('.${LOCAL_REACT_REFRESH_PATH}', __remoteUrl).href : globalThis.${HOST_REACT_REFRESH_URL} || window.location.origin + '${REACT_REFRESH_PATH}';`,
   `const __rt = await import(__target);`,
   `export const injectIntoGlobalHook = __rt.injectIntoGlobalHook;`,
   `export const register = __rt.register;`,
@@ -59,6 +60,18 @@ export const reactAdapter: HmrAdapter = {
     'vite:react-refresh', // @vitejs/plugin-react
     'vite:react-swc', // @vitejs/plugin-react-swc
   ],
+  host: {
+    transformIndexHtml({ server }) {
+      const refreshPath = `${server.config.base.replace(/\/$/, '')}${REACT_REFRESH_PATH}`;
+      return [
+        {
+          tag: 'script',
+          children: `globalThis.${HOST_REACT_REFRESH_URL} = new URL(${JSON.stringify(refreshPath)}, window.location.origin).href;`,
+          injectTo: 'head-prepend',
+        },
+      ];
+    },
+  },
   remote: {
     configureServer({ server }) {
       let reactRefreshRuntime: string | undefined;

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -42,14 +42,18 @@ export default function ({
   remoteEntryId,
   virtualExposesId,
 }: ProxyRemoteEntryParams): Plugin {
-  let viteConfig: any, _command: string, root: string;
+  let viteConfig: any, _command: string, root: string, originalConfigBase: string | undefined;
   let exposeRemoteDependencies: Record<string, string[]> = {};
   let exposeRemoteDependenciesDirty = true;
   let refreshPromise: Promise<void> | undefined;
   let dependencyInvalidationVersion = 0;
 
-  const isHostAutoInitId = (id: string) =>
-    id.includes(getHostAutoInitPath(options)) || id.includes(getHostAutoInitPath());
+  const isHostAutoInitId = (id: string) => {
+    const cleanId = id.split('?')[0];
+    return (
+      cleanId.includes(getHostAutoInitPath(options)) || cleanId.includes(getHostAutoInitPath())
+    );
+  };
 
   function isRemoteImport(source: string): boolean {
     return Object.keys(options.remotes).some(
@@ -141,8 +145,9 @@ export default function ({
       viteConfig = config;
       root = config.root;
     },
-    config(_config, { command }) {
+    config(config, { command }) {
       _command = command;
+      originalConfigBase = config.base;
     },
     async buildStart() {
       await refreshExposeRemoteDependencies(this);
@@ -223,7 +228,11 @@ export default function ({
               typeof viteConfig.server?.host === 'string' && viteConfig.server.host !== '0.0.0.0'
                 ? viteConfig.server.host
                 : 'localhost';
-            const resolvedPublicPath = resolvePublicPath(options, viteConfig.base);
+            const resolvedPublicPath = resolvePublicPath(
+              options,
+              viteConfig.base,
+              originalConfigBase
+            );
             const publicPath = JSON.stringify(
               (resolvedPublicPath === 'auto' ? '/' : resolvedPublicPath) +
                 resolveDevHashEntryFileName(options.filename)


### PR DESCRIPTION
Close #959

Fix Vite context-path support for Module Federation HMR and bootstrap by preserving configured base paths, correctly resolving host remote entries, and preventing HTML proxy IDs from being misclassified as host auto-init modules.