### PR TITLE
fix: fix cold root remote imports

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -750,7 +750,7 @@ describe('pluginAddEntry', () => {
     expect(result).toContain('entry=%2F_nuxt%2Fentry.async.js');
   });
 
-  it('preloads scoped remote subpaths but skips the bare scoped remote key', async () => {
+  it('preloads scoped remote subpaths and the bare scoped remote key', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-scoped-'));
     const htmlFile = path.join(tempDir, 'index.html');
     fs.writeFileSync(
@@ -800,7 +800,7 @@ describe('pluginAddEntry', () => {
     expect(result?.code).toContain(
       '__mfPreloadRemote("@scope/remote/Button", "@scope/remote/Button")'
     );
-    expect(result?.code).not.toContain('__mfPreloadRemote("@scope/remote",');
+    expect(result?.code).toContain('__mfPreloadRemote("@scope/remote", "@scope/remote")');
     expect(result?.code).toContain('runtime.loadRemote(runtimeRemote)');
     // A preload failure must not abort host bootstrap.
     expect(result?.code).toContain('await Promise.allSettled(__mfRemotePreloads);');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -6,6 +6,7 @@ import { normalizePathForImport, rebaseImport } from '../utils/buildPaths';
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 
 import {
+  findModuleImportSources,
   injectEntryScript,
   rewriteEntryScripts,
   sanitizeDevEntryPath,
@@ -15,7 +16,11 @@ import type { NormalizedModuleFederationOptions } from '../utils/normalizeModule
 import { getNormalizeModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
 import { decodeViteId, toViteEncodedId, VITE_ID_PREFIX } from '../utils/VirtualModule';
-import { getRuntimeRemoteId, getUsedRemotesMap } from '../virtualModules/virtualRemotes';
+import {
+  addUsedRemote,
+  getRuntimeRemoteId,
+  getUsedRemotesMap,
+} from '../virtualModules/virtualRemotes';
 import {
   getRuntimeModuleCacheBootstrapCode,
   getRuntimeRemoteCachePrefix,
@@ -284,15 +289,11 @@ const __mfCurrentScript = document.currentScript;
       (federationOptions ?? getNormalizeModuleFederationOptions())?.shareStrategy !==
         'loaded-first';
 
-    // Keep only sub-path entries (e.g. "remote/App"); skip bare remote keys
-    // ("remote" or scoped "@scope/remote") since they refer to the container
-    // itself, not an exposed module. The previous `includes('/')` check
-    // incorrectly matched scoped names like "@scope/remote".
+    // Bare ids may represent a root (`.`) expose, so preload them too. Failures
+    // remain non-blocking through Promise.allSettled below.
     const remotePreloads = shouldPreloadRemotes
       ? Object.entries(getUsedRemotesMap(federationOptions))
-          .flatMap(([remoteKey, remotes]) =>
-            Array.from(remotes).filter((remote) => remote !== remoteKey)
-          )
+          .flatMap(([, remotes]) => Array.from(remotes))
           .sort()
           .map(
             (remote) =>
@@ -421,6 +422,21 @@ const __mfCurrentScript = document.currentScript;
     }
   }
 
+  function addEntryRemoteImports(entrySrc: string) {
+    if (!federationOptions || /^(?:[a-z]+:)?\/\//i.test(entrySrc)) return;
+    const file = path.resolve(viteConfig.root, stripQueryAndHash(entrySrc).replace(/^\//, ''));
+    if (!fs.existsSync(file)) return;
+    const code = fs.readFileSync(file, 'utf-8');
+    for (const source of findModuleImportSources(code)) {
+      const remote = Object.keys(federationOptions.remotes).find(
+        (name) => source === name || source.startsWith(`${name}/`)
+      );
+      if (remote) {
+        addUsedRemote(remote, source, federationOptions);
+      }
+    }
+  }
+
   return [
     {
       name: 'add-entry',
@@ -500,6 +516,7 @@ const __mfCurrentScript = document.currentScript;
           const stripBase = (p: string) =>
             base && p.startsWith(base + '/') ? p.slice(base.length) : p;
           const html = rewriteEntryScripts(c, (originalSrc) => {
+            addEntryRemoteImports(stripBase(originalSrc));
             const query = new URLSearchParams({
               init: sanitizeDevEntryPath(stripBase(devEntryPath)),
               entry: sanitizeDevEntryPath(stripBase(originalSrc)),

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -1,7 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { injectEntryScript, rewriteEntryScripts, sanitizeDevEntryPath } from '../htmlEntryUtils';
+import {
+  findModuleImportSources,
+  injectEntryScript,
+  rewriteEntryScripts,
+  sanitizeDevEntryPath,
+} from '../htmlEntryUtils';
 
 const INIT_SRC = '/__mf__virtual/hostAutoInit.js';
+
+describe('findModuleImportSources', () => {
+  it('finds static, dynamic, side-effect, and re-export sources', () => {
+    expect(
+      findModuleImportSources(`
+        import { app } from 'remote/App';
+        import 'setup';
+        export { value } from "remote/value";
+        const lazy = import('remote/lazy');
+      `)
+    ).toEqual(['remote/App', 'remote/value', 'remote/lazy', 'setup']);
+  });
+
+  it('ignores import-looking text in comments and strings', () => {
+    expect(
+      findModuleImportSources(`
+        // import { fake } from 'commented';
+        const text = "import('string-value')";
+        import { real } from 'remote';
+      `)
+    ).toEqual(['remote']);
+  });
+});
 
 describe('rewriteEntryScripts', () => {
   it('rewrites a module script tag to a proxy src', () => {

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -1,3 +1,22 @@
+import { createCodePositionMap } from './codePositionMap';
+
+export function findModuleImportSources(code: string): string[] {
+  const codePositions = createCodePositionMap(code);
+  const sources = new Set<string>();
+  const patterns = [
+    /\b(?:import|export)\s+[^;]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']/g,
+    /\bimport\s*["']([^"']+)["']/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of code.matchAll(pattern)) {
+      if (codePositions[match.index!]) sources.add(match[1]);
+    }
+  }
+  return Array.from(sources);
+}
+
 export function sanitizeDevEntryPath(devEntryPath: string): string {
   // devEntryPath is already root-relative at this point (built in pluginAddEntry),
   // just normalize any remaining backslashes for use in HTML/URLs.


### PR DESCRIPTION
Close #961

Preloads root and subpath remote imports before host entry execution, preventing cold-start Promise errors.
