### PR TITLE
fix: fix React DOM optimizer race

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -551,6 +551,8 @@ export default __mfShared.default ?? __mfShared;`,
               addUsedShares(subpath, options);
               if (canResolveSubpath) {
                 optimizeDeps.include.push(subpath);
+                // Prevent subpaths like react-dom/client from using a later, incompatible optimizer generation.
+                if (key === 'react-dom') optimizeDeps.include.push(`${key} > ${subpath}`);
               } else {
                 optimizeDeps.exclude.push(subpath);
               }


### PR DESCRIPTION
Close #962 

Ensures react-dom and subpaths like react-dom/client are optimized together, preventing incompatible dependency generations during cold starts.