### PR TITLE
fix: preserve base path in development

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -207,6 +207,42 @@ describe('pluginAddEntry', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  it('serves html proxy imports with the configured base', () => {
+    const [servePlugin] = addEntry({
+      entryName: 'hostInit',
+      entryPath: 'virtual:mf-host-init',
+      inject: 'html',
+    });
+    const handlers: Function[] = [];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(servePlugin, {
+      root: '/repo',
+      base: '/subpath/',
+    } as unknown as ResolvedConfig);
+    runConfigureServer(servePlugin, {
+      middlewares: { use: (handler: Function) => handlers.push(handler) },
+    } as unknown as ViteDevServer);
+
+    const end = vi.fn();
+    handlers[0](
+      {
+        url: `${toViteEncodedId('virtual:mf-html-entry-proxy')}?init=%2F%40id%2Fvirtual%3Amf-host-init&entry=%2Fsrc%2Fmain.tsx`,
+      },
+      { setHeader: vi.fn(), end },
+      vi.fn()
+    );
+
+    const code = end.mock.calls[0][0] as string;
+    expect(code).toContain('import("/subpath/@id/virtual:mf-host-init")');
+    expect(code).toContain('import("/subpath/src/main.tsx")');
+  });
+
   it('injects host init into html-script entry during serve when inject is entry', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-'));
     const htmlFile = path.join(tempDir, 'index.html');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -473,9 +473,10 @@ const __mfCurrentScript = document.currentScript;
             const initSrc = params.get('init');
             const entrySrc = params.get('entry');
             if (initSrc && entrySrc) {
+              const withBase = (src: string) => viteConfig.base + src.replace(/^\//, '');
               res.statusCode = 200;
               res.setHeader('Content-Type', 'application/javascript');
-              res.end(getBootstrapSource(initSrc, entrySrc));
+              res.end(getBootstrapSource(withBase(initSrc), withBase(entrySrc)));
               return;
             }
           }


### PR DESCRIPTION
Close #966

Preserve Vite’s configured base path in dev HTML proxy imports.