### PR TITLE
fix: resolve virtual html entries in dev bootstrap

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -953,6 +953,59 @@ describe('pluginAddEntry', () => {
     expect(result).not.toContain('<script type="module">');
   });
 
+  it('resolves virtual dev html entries through Vite before bootstrapping', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-html-virtual-entry-'));
+    fs.writeFileSync(path.join(tempDir, 'index.html'), '<html></html>');
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: 'virtual:mf-host-init',
+      inject: 'html',
+    });
+    const servePlugin = plugins[0];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(servePlugin, {
+      base: '/',
+      root: tempDir,
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = await runTransformIndexHtml(
+      servePlugin,
+      '<html><head></head><body><script type="module" src="virtual:/@storybook/builder-vite/vite-app.js"></script></body></html>',
+      {
+        filename: path.join(tempDir, 'index.html'),
+        path: '/index.html',
+        server: undefined,
+        originalUrl: '/index.html',
+      }
+    );
+
+    expect(typeof result).toBe('string');
+    if (typeof result !== 'string') throw new Error('transformIndexHtml should return html string');
+
+    const proxyPrefix = toViteEncodedId('virtual:mf-html-entry-proxy?');
+    const proxyIdMatch = result.match(
+      new RegExp(`src="(${proxyPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*)"`)
+    );
+    expect(proxyIdMatch).not.toBeNull();
+
+    const proxyId = decodeURIComponent(proxyIdMatch![1]).replace(/&amp;/g, '&');
+    const code = await runLoad(servePlugin, proxyId);
+    expect(code).toContain(
+      `const __mfEntryUrl = ${JSON.stringify(
+        toViteEncodedId('virtual:/@storybook/builder-vite/vite-app.js')
+      )};`
+    );
+    expect(code).toContain('})().then(() => import(/* @vite-ignore */ __mfEntryUrl));');
+  });
+
   it('rewrites entry scripts and resolves proxy imports with non-root base (#590)', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-html-base-'));
     fs.writeFileSync(path.join(tempDir, 'index.html'), '<html></html>');

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -15,7 +15,12 @@ import { mfWarn } from '../utils/logger';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { getNormalizeModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
-import { decodeViteId, toViteEncodedId, VITE_ID_PREFIX } from '../utils/VirtualModule';
+import {
+  decodeViteId,
+  toViteEncodedId,
+  VITE_ENCODED_NULL_BYTE_PREFIX,
+  VITE_ID_PREFIX,
+} from '../utils/VirtualModule';
 import {
   addUsedRemote,
   getRuntimeRemoteId,
@@ -277,6 +282,18 @@ const __mfCurrentScript = document.currentScript;
       useSystemImportFallback
         ? `__mfImport(${JSON.stringify(src)})`
         : `import(${JSON.stringify(src)})`;
+    // Vite resolves literal dynamic imports during transform. An encoded virtual
+    // module URL is already browser-resolvable through Vite's dev server, but
+    // it is not resolvable relative to this in-memory proxy module. Preserve it
+    // for the browser instead of asking Vite to resolve it a second time.
+    const isEncodedVirtualEntry = entrySrc.startsWith(VITE_ENCODED_NULL_BYTE_PREFIX);
+    const entryImportDeclaration = isEncodedVirtualEntry
+      ? `const __mfEntryUrl = ${JSON.stringify(entrySrc)};
+`
+      : '';
+    const entryImportExpression = isEncodedVirtualEntry
+      ? 'import(/* @vite-ignore */ __mfEntryUrl)'
+      : importExpression(entrySrc);
 
     // Eagerly preloading remotes mirrors the federation runtime's own
     // `version-first` behaviour, where `ShareHandler.initializeSharing()` loads
@@ -360,10 +377,15 @@ const __mfCurrentScript = document.currentScript;
   await __mfHostInit.__tla;
   const { initHost } = __mfHostInit;
   ${preloadBlock}${pendingShareLoadsAwait}
-})().then(() => ${importExpression(entrySrc)});
+})().then(() => ${entryImportExpression});
 `;
 
-    return [getRuntimeModuleCacheBootstrapCode(), importHelper, importCode].join('\n');
+    return [
+      getRuntimeModuleCacheBootstrapCode(),
+      importHelper,
+      entryImportDeclaration,
+      importCode,
+    ].join('\n');
   }
 
   function getSystemBootstrapSource(initSrc: string, entrySrc: string) {
@@ -517,10 +539,17 @@ const __mfCurrentScript = document.currentScript;
           const stripBase = (p: string) =>
             base && p.startsWith(base + '/') ? p.slice(base.length) : p;
           const html = rewriteEntryScripts(c, (originalSrc) => {
-            addEntryRemoteImports(stripBase(originalSrc));
+            const entrySrc = stripBase(originalSrc);
+            addEntryRemoteImports(entrySrc);
+            // `virtual:` is a Vite plugin identifier, not a browser-supported
+            // URL scheme. The bootstrap runs in the browser, so route virtual
+            // entries through Vite's encoded module URL before dynamic import.
+            const resolvedEntrySrc = entrySrc.startsWith('virtual:')
+              ? toViteEncodedId(entrySrc)
+              : entrySrc;
             const query = new URLSearchParams({
               init: sanitizeDevEntryPath(stripBase(devEntryPath)),
-              entry: sanitizeDevEntryPath(stripBase(originalSrc)),
+              entry: sanitizeDevEntryPath(resolvedEntrySrc),
             }).toString();
             return toViteEncodedId(`${DEV_HTML_PROXY_PREFIX}${query}`);
           });


### PR DESCRIPTION
## Summary

Fixes the dev bootstrap when an HTML entry script is a Vite virtual module, such as Storybook builder-vite's `virtual:/@storybook/builder-vite/vite-app.js`.

Closes #968

## Changes

- Convert `virtual:` HTML entry IDs to Vite's browser-resolvable encoded module URL.
- Use a variable with `/* @vite-ignore */` for the encoded virtual entry import so Vite does not try to resolve it again from the in-memory bootstrap proxy.
- Preserve the latest main branch behavior that detects remote imports from file-based HTML entries.
- Add a regression test covering Storybook's virtual Vite entry.

## Verification

- `pnpm test`
  - 922 passed, 1 skipped
- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm build`
- Verified with the issue reproduction project using `@storybook/vue3-vite`:
  - The generated bootstrap imports the encoded Vite URL.
  - The encoded Storybook virtual entry returns HTTP 200.
  - No Vite pre-transform error is emitted after loading the proxy module.