### PR TITLE
fix: cache normalized federation options per config

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -22,10 +22,15 @@ import {
   getLoadShareModulePath,
 } from '../virtualModules/virtualShared_preBuild';
 
-const { hasPackageDependencyMock, mfWarn } = vi.hoisted(() => ({
-  hasPackageDependencyMock: vi.fn<(dependency: string) => boolean>((_dependency: string) => false),
-  mfWarn: vi.fn(),
-}));
+const { hasPackageDependencyMock, mfWarn, normalizeModuleFederationOptionsMock } = vi.hoisted(
+  () => ({
+    hasPackageDependencyMock: vi.fn<(dependency: string) => boolean>(
+      (_dependency: string) => false
+    ),
+    mfWarn: vi.fn(),
+    normalizeModuleFederationOptionsMock: vi.fn(),
+  })
+);
 
 vi.mock('../utils/packageUtils', async () => {
   const actual =
@@ -42,6 +47,15 @@ vi.mock('../utils/logger', async () => {
   return {
     ...actual,
     mfWarn,
+  };
+});
+
+vi.mock('../utils/normalizeModuleFederationOptions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/normalizeModuleFederationOptions')>();
+  normalizeModuleFederationOptionsMock.mockImplementation(actual.normalizeModuleFederationOptions);
+  return {
+    ...actual,
+    normalizeModuleFederationOptions: normalizeModuleFederationOptionsMock,
   };
 });
 
@@ -318,6 +332,17 @@ describe('federation in test environment', () => {
       filename: 'remoteEntry.js',
     });
     expect(plugins.length).toBeGreaterThan(0);
+  });
+
+  it('normalizes the same user config only once', () => {
+    normalizeModuleFederationOptionsMock.mockClear();
+    process.env.MFE_VITE_NO_TEST_ENV_CHECK = 'true';
+    const options = { name: 'cached-federation-options' };
+
+    federation(options);
+    federation(options);
+
+    expect(normalizeModuleFederationOptionsMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,10 @@ import {
 } from './virtualModules/virtualShared_preBuild';
 
 const patchedManualChunks = new WeakSet<Function>();
+const normalizedOptionsByInput = new WeakMap<
+  ModuleFederationOptions,
+  NormalizedModuleFederationOptions
+>();
 
 // Rolldown injects the `__vite_preload` helper as a special runtime module and,
 // left to automatic chunking, hoists it into whichever loadShare chunk first uses
@@ -744,7 +748,9 @@ function applyExternalRuntimeExperiments(options: NormalizedModuleFederationOpti
 
 function federation(mfUserOptions: ModuleFederationOptions): any[] {
   if (isTestEnv()) return [];
-  const options = normalizeModuleFederationOptions(mfUserOptions);
+  const options =
+    normalizedOptionsByInput.get(mfUserOptions) ?? normalizeModuleFederationOptions(mfUserOptions);
+  normalizedOptionsByInput.set(mfUserOptions, options);
   applyExternalRuntimeExperiments(options);
 
   const isVinext = hasPackageDependency('vinext');


### PR DESCRIPTION
Close #970

Prevents duplicate federation owners during Vite dependency optimization by reusing normalized options for the same configuration.