### PR TITLE
fix: heal stale owner loadShare ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import { addUsedShares } from './virtualModules/virtualRemoteEntry';
 import { addUsedRemote } from './virtualModules/virtualRemotes';
 import { getRuntimeInitStatusImportId } from './virtualModules/virtualRuntimeInitStatus';
 import {
+  findCurrentLoadShareForStaleOwnerId,
   getLoadShareModulePath,
   materializeCachedLoadShareModule,
   prependWorkspaceSingletonSsrImport,
@@ -779,7 +780,9 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
             writeLocalSharedImportMap: () => writeLocalSharedImportMap(options),
             federationOptions: options,
           });
-          virtualModule = VirtualModule.findById(id);
+          virtualModule =
+            VirtualModule.findById(id) ??
+            findCurrentLoadShareForStaleOwnerId(id, options.shared, findSharedKey, options);
         }
         if (!virtualModule) return;
         return virtualModule.getResolvedId();

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -139,6 +139,7 @@ vi.mock('../../utils/packageUtils', () => ({
 }));
 
 vi.mock('../../utils/VirtualModule', () => ({
+  MF_OWNER_INFIX: '__mf_owner__',
   default: class MockVirtualModule {
     static findModule(tag: string, value: string) {
       const [, name] = value.split(tag);

--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -32,6 +32,10 @@ export const VITE_ID_PREFIX = '/@id/';
 export const VITE_NULL_BYTE_PLACEHOLDER = '__x00__';
 export const VITE_ENCODED_NULL_BYTE_PREFIX = `${VITE_ID_PREFIX}${VITE_NULL_BYTE_PLACEHOLDER}`;
 
+// Separates a federation instance's internalName from its per-generation
+// owner id inside scoped virtual module names.
+export const MF_OWNER_INFIX = '__mf_owner__';
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -289,6 +289,7 @@ function getRuntimeDeferredResolutionCode(code: string) {
 
 vi.mock('../../utils/VirtualModule', () => {
   return {
+    MF_OWNER_INFIX: '__mf_owner__',
     default: class MockVirtualModule {
       name: string;
 

--- a/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
+++ b/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
@@ -5,6 +5,7 @@ const { writeSyncSpy } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../utils/VirtualModule', () => ({
+  MF_OWNER_INFIX: '__mf_owner__',
   default: class MockVirtualModule {
     getImportId() {
       return 'virtual:runtimeInit';

--- a/src/virtualModules/__tests__/virtualSharedInstanceIsolation.test.ts
+++ b/src/virtualModules/__tests__/virtualSharedInstanceIsolation.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import VirtualModule from '../../utils/VirtualModule';
+import { findSharedKey } from '../../plugins/pluginProxySharedModule_preBuild';
 import {
   normalizeModuleFederationOptions,
+  type NormalizedShared,
   type ShareItem,
 } from '../../utils/normalizeModuleFederationOptions';
 import {
+  findCurrentLoadShareForStaleOwnerId,
   getLoadShareModulePath,
   getPreBuildLibImportId,
   getTreeShakingSharedProviderImportId,
@@ -15,9 +18,9 @@ import { generateRemoteEntry } from '../virtualRemoteEntry';
 import { getRuntimeInitStatusImportId, writeRuntimeInitStatus } from '../virtualRuntimeInitStatus';
 import { recordTreeShakingExports, setTreeShakingBuildMode } from '../../utils/treeShaking';
 
-function makeOptions() {
+function makeOptions(name = 'same-name-host') {
   return normalizeModuleFederationOptions({
-    name: 'same-name-host',
+    name,
     shared: {},
   });
 }
@@ -145,5 +148,121 @@ describe('shared virtual module instance isolation', () => {
     expect(providerA).not.toContain('useState as __mfTreeShaken_0');
     expect(providerB).toContain('useState as __mfTreeShaken_0');
     expect(providerB).not.toContain('createElement as __mfTreeShaken_0');
+  });
+});
+
+function makePkgShareItem(pkg: string): ShareItem {
+  return {
+    name: pkg,
+    from: 'stale-owner-host',
+    version: '19.1.0',
+    scope: 'default',
+    shareConfig: {
+      import: pkg,
+      singleton: true,
+      requiredVersion: '^19.0.0',
+    },
+  };
+}
+
+function makeShared(pkg: string): NormalizedShared {
+  return { [pkg]: makePkgShareItem(pkg) } as NormalizedShared;
+}
+
+// The flip side of instance isolation: owner keys embed a process-wide
+// generation counter, but Vite persists loadShare ids into the dep-optimizer
+// cache (node_modules/.vite). Ids minted by an earlier generation of the SAME
+// instance must resolve to the current generation, while other instances' ids
+// stay isolated (#970).
+describe('stale owner loadShare resolution', () => {
+  it('redirects loadShare ids minted by a previous generation of the same instance', () => {
+    const previousGen = makeOptions('stale-owner-host');
+    const currentGen = makeOptions('stale-owner-host');
+    const shared = makeShared('react');
+
+    writeLoadShareModule('react', shared['react'], 'serve', false, previousGen);
+    writeLoadShareModule('react', shared['react'], 'serve', false, currentGen);
+    const staleId = getLoadShareModulePath('react', false, previousGen);
+    const currentId = getLoadShareModulePath('react', false, currentGen);
+    expect(staleId).not.toBe(currentId);
+
+    const healed = findCurrentLoadShareForStaleOwnerId(staleId, shared, findSharedKey, currentGen);
+    expect(healed?.getImportId()).toBe(currentId);
+  });
+
+  it('redirects stale ids for encoded package subpaths', () => {
+    const previousGen = makeOptions('stale-owner-host');
+    const currentGen = makeOptions('stale-owner-host');
+    const shared = makeShared('react-dom/client');
+
+    writeLoadShareModule(
+      'react-dom/client',
+      shared['react-dom/client'],
+      'serve',
+      false,
+      previousGen
+    );
+    writeLoadShareModule(
+      'react-dom/client',
+      shared['react-dom/client'],
+      'serve',
+      false,
+      currentGen
+    );
+    const staleId = getLoadShareModulePath('react-dom/client', false, previousGen);
+
+    const healed = findCurrentLoadShareForStaleOwnerId(staleId, shared, findSharedKey, currentGen);
+    expect(healed?.getImportId()).toBe(
+      getLoadShareModulePath('react-dom/client', false, currentGen)
+    );
+  });
+
+  it('does not reclaim ids minted by a different federation instance', () => {
+    const otherInstance = makeOptions('other-host');
+    const currentGen = makeOptions('stale-owner-host');
+    const shared = makeShared('react');
+
+    writeLoadShareModule('react', shared['react'], 'serve', false, otherInstance);
+    writeLoadShareModule('react', shared['react'], 'serve', false, currentGen);
+    const foreignId = getLoadShareModulePath('react', false, otherInstance);
+
+    expect(findCurrentLoadShareForStaleOwnerId(foreignId, shared, findSharedKey, currentGen)).toBe(
+      undefined
+    );
+  });
+
+  it('does not reclaim ids of instances whose name is a prefix of another', () => {
+    // "host" is a prefix of "hostSecondary": slicing at __mf_owner__ must
+    // compare the full instance name, not a startsWith match.
+    const secondary = makeOptions('hostSecondary');
+    const primary = makeOptions('host');
+    const shared = makeShared('react');
+
+    writeLoadShareModule('react', shared['react'], 'serve', false, secondary);
+    writeLoadShareModule('react', shared['react'], 'serve', false, primary);
+    const secondaryId = getLoadShareModulePath('react', false, secondary);
+
+    expect(findCurrentLoadShareForStaleOwnerId(secondaryId, shared, findSharedKey, primary)).toBe(
+      undefined
+    );
+  });
+
+  it('does not resolve packages that are no longer shared', () => {
+    const previousGen = makeOptions('stale-owner-host');
+    const currentGen = makeOptions('stale-owner-host');
+
+    writeLoadShareModule('react', makePkgShareItem('react'), 'serve', false, previousGen);
+    const staleId = getLoadShareModulePath('react', false, previousGen);
+
+    expect(
+      findCurrentLoadShareForStaleOwnerId(staleId, makeShared('vue'), findSharedKey, currentGen)
+    ).toBe(undefined);
+  });
+
+  it('ignores ids that are not loadShare virtual modules', () => {
+    const currentGen = makeOptions('stale-owner-host');
+    expect(
+      findCurrentLoadShareForStaleOwnerId('react', makeShared('react'), findSharedKey, currentGen)
+    ).toBe(undefined);
   });
 });

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -377,6 +377,7 @@ vi.mock('../../utils/packageUtils', () => ({
 // Mock VirtualModule to capture written code
 vi.mock('../../utils/VirtualModule', () => {
   return {
+    MF_OWNER_INFIX: '__mf_owner__',
     default: class MockVirtualModule {
       getPath = vi.fn(() => '/mock/path.js');
       getImportId = vi.fn(() => 'mock-import-id');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -14,7 +14,7 @@ import {
   sharedCacheHelperCode,
 } from '../utils/packageUtils';
 import { serializeRuntimeOptions } from '../utils/serializeRuntimeOptions';
-import VirtualModule from '../utils/VirtualModule';
+import VirtualModule, { MF_OWNER_INFIX } from '../utils/VirtualModule';
 import { getVirtualExposesId } from './virtualExposes';
 import { getUsedRemotesMap } from './virtualRemotes';
 import {
@@ -66,7 +66,7 @@ function getLocalOwnerKey(options: NormalizedModuleFederationOptions) {
     ownerId = nextLocalOwnerId++;
     localOwnerIds.set(options, ownerId);
   }
-  return `${options.internalName}__mf_owner__${ownerId}`;
+  return `${options.internalName}${MF_OWNER_INFIX}${ownerId}`;
 }
 
 export function getLocalSharedImportMapPath(options?: NormalizedModuleFederationOptions) {

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -5,7 +5,7 @@ import {
 } from '../utils/normalizeModuleFederationOptions';
 import type { RemoteConsumer } from '../utils/remoteConsumerTarget';
 import { SERVER_ENV_GUARD } from '../utils/ssrCapabilities';
-import VirtualModule from '../utils/VirtualModule';
+import VirtualModule, { MF_OWNER_INFIX } from '../utils/VirtualModule';
 import { getHostAutoInitPath } from './virtualRemoteEntry';
 import {
   getRuntimeInitBootstrapCode,
@@ -49,7 +49,7 @@ export function getRemoteVirtualModule(
     // code (notably without the client host-init import). Keep the historical
     // id for legacy/unified graphs.
     const consumerName = consumer === 'unified' ? remote : `${remote}__mf_consumer__${consumer}`;
-    const virtualName = `${consumerName}__mf_owner__${getRemoteOptionsId(options)}`;
+    const virtualName = `${consumerName}${MF_OWNER_INFIX}${getRemoteOptionsId(options)}`;
     const virtual = new VirtualModule(virtualName, LOAD_REMOTE_TAG, '.js', options.internalName);
     virtual.writeSync(generateRemotes(remote, command, enableSsrInit, consumer, options));
     instanceCache.set(cacheKey, virtual);

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -1,4 +1,4 @@
-import VirtualModule from '../utils/VirtualModule';
+import VirtualModule, { MF_OWNER_INFIX } from '../utils/VirtualModule';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { SERVER_ENV_GUARD } from '../utils/ssrCapabilities';
 
@@ -26,7 +26,7 @@ function getRuntimeInitModule(options?: NormalizedModuleFederationOptions) {
       'runtimeInit',
       '__mf_v__',
       '',
-      `${options.internalName}__mf_owner__${ownerId}`
+      `${options.internalName}${MF_OWNER_INFIX}${ownerId}`
     );
     runtimeInitModules.set(options, runtimeInitModule);
   }
@@ -43,7 +43,7 @@ export function getRuntimeRemoteCachePrefix(options?: NormalizedModuleFederation
 
 export function getRuntimeRemoteAlias(alias: string, options?: NormalizedModuleFederationOptions) {
   if (!options) return alias;
-  return `${options.internalName}__mf_owner__${getRuntimeInitOwnerId(options)}__${alias}`;
+  return `${options.internalName}${MF_OWNER_INFIX}${getRuntimeInitOwnerId(options)}__${alias}`;
 }
 
 export function getRuntimeInitGlobalKey(ownerImportId?: string) {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -13,8 +13,8 @@ import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL } from 'url';
-import { mfWarn } from '../utils/logger';
 import { createCodePositionMap } from '../utils/codePositionMap';
+import { mfWarn } from '../utils/logger';
 import {
   getNormalizeModuleFederationOptions,
   type NormalizedModuleFederationOptions,
@@ -26,19 +26,19 @@ import {
   getInstalledPackageJson,
   getPackageDetectionCwd,
   getPackageName,
-  packageNameEncode,
-  packageNameDecode,
   getSharedCacheDescriptor,
+  packageNameDecode,
+  packageNameEncode,
   sharedCacheHelperCode,
 } from '../utils/packageUtils';
-import VirtualModule, { normalizeVirtualModuleId } from '../utils/VirtualModule';
 import { normalizeNodeModulePath } from '../utils/pathNormalization';
+import { getTreeShakingExportUsage } from '../utils/treeShaking';
+import VirtualModule, { MF_OWNER_INFIX, normalizeVirtualModuleId } from '../utils/VirtualModule';
 import {
   getRuntimeInitPromiseBootstrapCode,
   getRuntimeInitStatusImportId,
   getRuntimeModuleCacheBootstrapCode,
 } from './virtualRuntimeInitStatus';
-import { getTreeShakingExportUsage } from '../utils/treeShaking';
 
 const JS_IDENTIFIER_REGEX = new RegExp(
   '^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$',
@@ -850,7 +850,7 @@ function getSharedVirtualModuleState(options?: NormalizedModuleFederationOptions
       treeShakingProviderCacheMap: {},
       materializedTreeShakingProviders: new Set(),
       loadShareCacheMap: {},
-      ownerKey: `${options.internalName}__mf_owner__${nextSharedVirtualModuleOwnerId++}`,
+      ownerKey: `${options.internalName}${MF_OWNER_INFIX}${nextSharedVirtualModuleOwnerId++}`,
     };
     sharedVirtualModuleStates.set(options, state);
   }
@@ -1264,6 +1264,33 @@ export function materializeCachedLoadShareModule(options: {
   }
   options.addUsedShares(pkg);
   options.writeLocalSharedImportMap();
+}
+
+// Owner keys embed a process-wide generation counter, so a loadShare id is
+// only resolvable in the process (and config generation) that minted it. But
+// Vite's dependency optimizer persists these ids inside node_modules/.vite:
+// a config re-evaluation or a fresh dev-server process mints new generations,
+// and cached deps referencing the old owner would fail to resolve until the
+// cache is deleted. When a stale id was minted by an earlier generation
+// of THIS instance, redirect it to the current generation's module instead.
+export function findCurrentLoadShareForStaleOwnerId(
+  id: string,
+  shared: NormalizedShared,
+  findSharedKey: (source: string, shared: NormalizedShared) => string | undefined,
+  options: NormalizedModuleFederationOptions
+): VirtualModule | undefined {
+  const pkg = getCachedLoadSharePkg(id);
+  if (!pkg) return;
+  const normalized = normalizeVirtualModuleId(id);
+  if (!normalized.startsWith('virtual:mf:')) return;
+  const encodedKey = normalized.slice('virtual:mf:'.length);
+  const ownerStart = encodedKey.indexOf(MF_OWNER_INFIX);
+  if (ownerStart === -1) return;
+  // Owner keys are scoped per federation instance; only reclaim ids this
+  // instance minted. Other instances' resolveId hooks handle their own.
+  if (encodedKey.slice(0, ownerStart) !== packageNameEncode(options.internalName)) return;
+  if (!findSharedKey(pkg, shared)) return;
+  return getSharedVirtualModuleState(options).loadShareCacheMap[pkg];
 }
 
 function getSharedCacheReadExpression(cacheDescriptor: string, treeShakingConsumer?: string) {


### PR DESCRIPTION
Close #970 

When resolveId receives a loadShare id whose owner generation no longer exists, it now extracts the instance name and package from the id.
It verifies both belong to the current federation instance, and resolves to that instance's current loadShare module instead of failing.
Ids minted by a different federation instance are never touched, so instance isolation is preserved.