### PR TITLE
fix: optimize ESM-only shared singletons in dev (avoid raw CommonJS)

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type {
   ConfigEnv,
@@ -1584,6 +1586,58 @@ describe('vite:module-federation-early-init', () => {
     // leaves it permanently unresolved from the optimizer's perspective.
     expect(config.optimizeDeps.include).not.toContain('@test-issue/theme/provider');
     expect(config.optimizeDeps.exclude).toContain('@test-issue/theme/provider');
+  });
+
+  it('includes an ESM-only shared singleton (exports map without a "require" condition) in dev optimizeDeps', () => {
+    // A package whose package.json `exports` only declares an `import` condition makes
+    // Node's require.resolve throw ERR_PACKAGE_PATH_NOT_EXPORTED, even though Vite's own
+    // resolver can resolve it. It must NOT be excluded from dev optimization — otherwise
+    // its generated prebuild imports the raw package source and its transitive CommonJS
+    // deps are served raw to the browser, which blanks the app.
+    // https://github.com/module-federation/vite/issues/974
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-esm-only-'));
+    try {
+      writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({ name: 'host', dependencies: { '@fixture/esm-ui': '1.0.0' } })
+      );
+      const pkgDir = path.join(root, 'node_modules', '@fixture', 'esm-ui');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        path.join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@fixture/esm-ui',
+          version: '1.0.0',
+          type: 'module',
+          // Only an `import` condition — no `require`/`default` — so CJS require.resolve
+          // throws ERR_PACKAGE_PATH_NOT_EXPORTED while Vite can still resolve it.
+          exports: { '.': { import: './index.js' } },
+        })
+      );
+      writeFileSync(path.join(pkgDir, 'index.js'), 'export const marker = 1;\n');
+
+      const earlyInitPlugin = (
+        federation({
+          name: 'host',
+          filename: 'remoteEntry.js',
+          shared: { '@fixture/esm-ui': { singleton: true } },
+        }) as Plugin[]
+      ).find((entry) => entry.name === 'vite:module-federation-early-init');
+      if (!earlyInitPlugin) {
+        throw new Error('vite:module-federation-early-init plugin not found');
+      }
+
+      const config: any = { root, optimizeDeps: { include: [], exclude: [] } };
+      runConfig(earlyInitPlugin, {} as ConfigPluginContext, config, {
+        command: 'serve',
+        mode: 'test',
+      });
+
+      expect(config.optimizeDeps.include).toContain('@fixture/esm-ui');
+      expect(config.optimizeDeps.exclude).not.toContain('@fixture/esm-ui');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('pre-seeds transitive shared dependencies for the dev optimizer', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1640,6 +1640,68 @@ describe('vite:module-federation-early-init', () => {
     }
   });
 
+  it.each([
+    {
+      name: 'has no main export',
+      packageName: '@fixture/no-main-export',
+      exports: { './feature': { import: './feature.js' } },
+      // Keep the conventional fallback on disk to prove an exports map without
+      // "." is not accidentally treated as exporting index.js.
+      entry: 'index.js',
+    },
+    {
+      name: 'has a non-optimizable ESM-only main entry',
+      packageName: '@fixture/esm-tsx-entry',
+      exports: { '.': { import: './index.tsx' } },
+      entry: 'index.tsx',
+    },
+  ])(
+    'excludes a shared singleton that $name from dev optimizeDeps',
+    ({ packageName, exports, entry }) => {
+      const root = mkdtempSync(path.join(tmpdir(), 'mf-unoptimizable-esm-'));
+      try {
+        writeFileSync(
+          path.join(root, 'package.json'),
+          JSON.stringify({ name: 'host', dependencies: { [packageName]: '1.0.0' } })
+        );
+        const pkgDir = path.join(root, 'node_modules', ...packageName.split('/'));
+        mkdirSync(pkgDir, { recursive: true });
+        writeFileSync(
+          path.join(pkgDir, 'package.json'),
+          JSON.stringify({
+            name: packageName,
+            version: '1.0.0',
+            type: 'module',
+            exports,
+          })
+        );
+        writeFileSync(path.join(pkgDir, entry), 'export const marker = 1;\n');
+
+        const earlyInitPlugin = (
+          federation({
+            name: 'host',
+            filename: 'remoteEntry.js',
+            shared: { [packageName]: { singleton: true } },
+          }) as Plugin[]
+        ).find((plugin) => plugin.name === 'vite:module-federation-early-init');
+        if (!earlyInitPlugin) {
+          throw new Error('vite:module-federation-early-init plugin not found');
+        }
+
+        const config: any = { root, optimizeDeps: { include: [], exclude: [] } };
+        runConfig(earlyInitPlugin, {} as ConfigPluginContext, config, {
+          command: 'serve',
+          mode: 'test',
+        });
+
+        expect(config.optimizeDeps.include).not.toContain(packageName);
+        expect(config.optimizeDeps.exclude).toContain(packageName);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  );
+
   it('pre-seeds transitive shared dependencies for the dev optimizer', () => {
     const plugin = (
       federation({

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,8 +278,8 @@ function canResolveSharedSubpath(subpath: string, projectRoot: string): boolean 
     // condition) makes Node's require.resolve throw ERR_PACKAGE_PATH_NOT_EXPORTED even
     // though Vite's own resolver can resolve it. Excluding such a package from dependency
     // optimization serves its raw CommonJS sub-dependencies to the browser in dev, which
-    // blanks the app. Treat it as optimizable so Vite pre-bundles it (and its transitive
-    // CJS deps) with interop.
+    // blanks the app. Resolve its import target and let Vite pre-bundle it (and its
+    // transitive CJS deps) with interop when the target is optimizable.
     //
     // Only apply this to a package's main entry (a bare specifier). A *subpath* can throw
     // the same code simply because it isn't exported at all (e.g. react/compiler-runtime
@@ -289,10 +289,62 @@ function canResolveSharedSubpath(subpath: string, projectRoot: string): boolean 
       (error as NodeJS.ErrnoException)?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' &&
       !isBarePackageSubpath(subpath)
     ) {
-      return true;
+      const entry = resolveViteImportPackageEntry(subpath, projectRoot);
+      return entry !== undefined && existsSync(entry) && isViteOptimizableEntry(entry);
     }
     return false;
   }
+}
+
+const VITE_DEV_IMPORT_CONDITIONS = new Set([
+  'browser',
+  'development',
+  'import',
+  'module',
+  'default',
+]);
+
+function resolveConditionalExportTarget(target: unknown): string | undefined {
+  if (typeof target === 'string') return target;
+  if (Array.isArray(target)) {
+    for (const candidate of target) {
+      const resolved = resolveConditionalExportTarget(candidate);
+      if (resolved) return resolved;
+    }
+    return undefined;
+  }
+  if (!target || typeof target !== 'object') return undefined;
+
+  for (const [condition, candidate] of Object.entries(target)) {
+    if (!VITE_DEV_IMPORT_CONDITIONS.has(condition)) continue;
+    const resolved = resolveConditionalExportTarget(candidate);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+function resolveViteImportPackageEntry(
+  packageName: string,
+  projectRoot: string
+): string | undefined {
+  const installed = getInstalledPackageJson(packageName, { cwd: projectRoot });
+  if (!installed) return undefined;
+
+  const exportsField = installed.packageJson.exports;
+  let rootExport: unknown = exportsField;
+  if (exportsField && typeof exportsField === 'object' && !Array.isArray(exportsField)) {
+    const exportsRecord = exportsField as Record<string, unknown>;
+    if (Object.keys(exportsRecord).some((key) => key.startsWith('.'))) {
+      rootExport = exportsRecord['.'];
+    }
+  }
+
+  const target = resolveConditionalExportTarget(rootExport);
+  if (!target?.startsWith('./')) return undefined;
+  const resolved = path.resolve(installed.dir, target);
+  const relative = path.relative(installed.dir, resolved);
+  if (relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return undefined;
+  return resolved;
 }
 
 // True when `specifier` addresses a subpath of a package (e.g. `react/compiler-runtime`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,9 +273,33 @@ function canResolveSharedSubpath(subpath: string, projectRoot: string): boolean 
   try {
     const req = createRequire(pathToFileURL(path.join(projectRoot, 'package.json')));
     return isViteOptimizableEntry(req.resolve(subpath));
-  } catch {
+  } catch (error) {
+    // An ESM-only package (an `exports` map with no CommonJS `require`/`default`
+    // condition) makes Node's require.resolve throw ERR_PACKAGE_PATH_NOT_EXPORTED even
+    // though Vite's own resolver can resolve it. Excluding such a package from dependency
+    // optimization serves its raw CommonJS sub-dependencies to the browser in dev, which
+    // blanks the app. Treat it as optimizable so Vite pre-bundles it (and its transitive
+    // CJS deps) with interop.
+    //
+    // Only apply this to a package's main entry (a bare specifier). A *subpath* can throw
+    // the same code simply because it isn't exported at all (e.g. react/compiler-runtime
+    // on React versions that predate it), which genuinely cannot be optimized and must
+    // stay excluded. https://github.com/module-federation/vite/issues/974
+    if (
+      (error as NodeJS.ErrnoException)?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' &&
+      !isBarePackageSubpath(subpath)
+    ) {
+      return true;
+    }
     return false;
   }
+}
+
+// True when `specifier` addresses a subpath of a package (e.g. `react/compiler-runtime`)
+// rather than its main entry (e.g. `react` or `@scope/pkg`).
+function isBarePackageSubpath(specifier: string): boolean {
+  const segments = specifier.split('/');
+  return specifier.startsWith('@') ? segments.length > 2 : segments.length > 1;
 }
 
 /**


### PR DESCRIPTION
## What

Fixes #974.

`canResolveSharedSubpath()` decides whether a shared dependency stays in Vite's dev dependency optimization. It resolves the entry with Node's **CJS** `require.resolve()`:

```ts
return isViteOptimizableEntry(createRequire(...).resolve(subpath));
```

For an **ESM-only package** — one whose `package.json` `exports` map declares only an `import` condition (no `require`/`default`) — `require.resolve()` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, so the current `catch { return false }` reports it as unresolvable. The shared singleton is then pushed to `optimizeDeps.exclude` and served as **raw CommonJS**, and its transitive CommonJS dependencies (e.g. `react-aria`/`react-stately` → `use-sync-external-store`) are served raw too. In dev the shared scope never populates, `initHost()` rejects, and the app blanks. The production build is unaffected. Vite's own resolver handles these packages fine — only this CJS gate rejects them.

This is the ESM-only variant of the same class as #913 / #914 (which handled `react`).

## Fix

Treat a package **main entry** that throws `ERR_PACKAGE_PATH_NOT_EXPORTED` as optimizable, so Vite pre-bundles it (and its transitive CJS deps) with interop.

The scope matters: the same error code is thrown both for an ESM-only package that *does* exist and for a **subpath that isn't exported at all** (e.g. `react/compiler-runtime` on React versions that predate it), which genuinely can't be optimized and must stay excluded. Node's stable `import.meta.resolve` can't resolve from an arbitrary project root, so the fix is scoped to **bare specifiers** — a package's main entry — leaving missing subpaths conservatively excluded (preserving the existing `does not register react/compiler-runtime …` behavior).

## Test

`src/__tests__/index.test.ts`: a config-level test that creates a temp ESM-only package (`exports: { ".": { "import": "./index.js" } }`, so CJS `require.resolve` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`) and asserts it lands in `optimizeDeps.include`, not `exclude`. The full file passes (82/82), including the existing `react/compiler-runtime` exclusion test.

Verified end-to-end against a real host + federated remote using `@module-federation/vite@1.19.1`, React 19, and an ESM-only design-system singleton under bun's isolated `node_modules`: with the change the shared scope populates and both the host and the remote render in dev, with no `optimizeDeps.include` workaround.
