### PR TITLE
fix: preserve singleton sharing for TypeScript generic exports

### DIFF
--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -373,7 +373,7 @@ export const getRemoteInfo = (key: object) => ({
       name: 'issue978RemoteOne',
       filename: 'remoteEntry.js',
       manifest: true,
-      exposes: { './info': './src/RemoteOne.ts' },
+      exposes: { './info': path.join(fixtureRoot, 'src/RemoteOne.ts') },
       dts: false,
       shared,
     });
@@ -381,7 +381,7 @@ export const getRemoteInfo = (key: object) => ({
       name: 'issue978RemoteTwo',
       filename: 'remoteEntry.js',
       manifest: true,
-      exposes: { './info': './src/RemoteTwo.ts' },
+      exposes: { './info': path.join(fixtureRoot, 'src/RemoteTwo.ts') },
       dts: false,
       shared,
     });

--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -1,12 +1,12 @@
+import { chromium } from '@playwright/test';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer as createNetServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { chromium } from '@playwright/test';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServer as createViteServer, version as viteVersion } from 'vite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { federation } from '../src';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
@@ -326,9 +326,135 @@ describe(`singleton React dev fallback (Vite ${viteVersion})`, () => {
   }, 60_000);
 });
 
+describe('runtime-registered TypeScript source singleton', () => {
+  it('shares named exports and module state with two registered remotes', async () => {
+    const sharedEntry = path.join(fixtureRoot, 'src/shared-lib.ts');
+    await Promise.all([
+      writeFile(
+        path.join(fixtureRoot, 'index.html'),
+        '<div id="root"></div>\n<script type="module" src="/src/singleton-main.ts"></script>\n'
+      ),
+      writeFile(
+        sharedEntry,
+        `export const MODULE_INSTANCE_ID = Math.random().toString(36);
+export const registry = new WeakMap<object, any>();
+export const registerRef = (key: object, value: any) => registry.set(key, value);
+export const getRef = (key: object) => registry.get(key);
+`
+      ),
+      writeFile(
+        path.join(fixtureRoot, 'src/RemoteOne.ts'),
+        `import { MODULE_INSTANCE_ID, getRef } from 'issue978-shared';
+export const getRemoteInfo = (key: object) => ({
+  instanceId: MODULE_INSTANCE_ID,
+  value: getRef(key),
+});
+`
+      ),
+      writeFile(
+        path.join(fixtureRoot, 'src/RemoteTwo.ts'),
+        `import { MODULE_INSTANCE_ID, getRef } from 'issue978-shared';
+export const getRemoteInfo = (key: object) => ({
+  instanceId: MODULE_INSTANCE_ID,
+  value: getRef(key),
+});
+`
+      ),
+    ]);
+
+    const shared = {
+      'issue978-shared': {
+        import: sharedEntry,
+        singleton: true,
+        requiredVersion: false,
+      },
+    } satisfies Parameters<typeof federation>[0]['shared'];
+    const remoteOne = await createDevServer('issue-978-remote-one', {
+      name: 'issue978RemoteOne',
+      filename: 'remoteEntry.js',
+      manifest: true,
+      exposes: { './info': './src/RemoteOne.ts' },
+      dts: false,
+      shared,
+    });
+    const remoteTwo = await createDevServer('issue-978-remote-two', {
+      name: 'issue978RemoteTwo',
+      filename: 'remoteEntry.js',
+      manifest: true,
+      exposes: { './info': './src/RemoteTwo.ts' },
+      dts: false,
+      shared,
+    });
+
+    await writeFile(
+      path.join(fixtureRoot, 'src/singleton-main.ts'),
+      `import { loadRemote, registerRemotes } from '@module-federation/runtime';
+import { MODULE_INSTANCE_ID, getRef, registerRef } from 'issue978-shared';
+
+const key = {};
+registerRef(key, 'host-value');
+registerRemotes([
+  { name: 'issue978RemoteOne', entry: '${remoteOne.origin}/mf-manifest.json' },
+  { name: 'issue978RemoteTwo', entry: '${remoteTwo.origin}/mf-manifest.json' },
+]);
+
+const [remoteOne, remoteTwo] = await Promise.all([
+  loadRemote('issue978RemoteOne/info'),
+  loadRemote('issue978RemoteTwo/info'),
+]);
+const one = remoteOne.getRemoteInfo(key);
+const two = remoteTwo.getRemoteInfo(key);
+window.__issue978Result = {
+  hostId: MODULE_INSTANCE_ID,
+  remoteOneId: one.instanceId,
+  remoteTwoId: two.instanceId,
+  remoteOneValue: one.value,
+  remoteTwoValue: two.value,
+  hostValue: getRef(key),
+};
+`
+    );
+
+    const host = await createDevServer('issue-978-host', {
+      name: 'issue978Host',
+      remotes: {},
+      dts: false,
+      shared,
+    });
+    const browser = await chromium.launch({ channel: 'chrome', headless: true });
+    cleanupTasks.push(() => browser.close());
+    const page = await browser.newPage();
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+    await page.goto(host.origin, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => window.__issue978Result !== undefined, undefined, {
+      timeout: 15_000,
+    });
+
+    const result = await page.evaluate(() => window.__issue978Result);
+    expect(result).toMatchObject({
+      hostId: expect.any(String),
+      remoteOneValue: 'host-value',
+      remoteTwoValue: 'host-value',
+      hostValue: 'host-value',
+    });
+    expect(result?.remoteOneId).toBe(result?.hostId);
+    expect(result?.remoteTwoId).toBe(result?.hostId);
+    expect(pageErrors).toEqual([]);
+  }, 60_000);
+});
+
 declare global {
   interface Window {
     __issue913HostReact?: unknown;
     __issue913RemoteReact?: unknown;
+    __issue978Result?: {
+      hostId: string;
+      remoteOneId: string;
+      remoteTwoId: string;
+      remoteOneValue: unknown;
+      remoteTwoValue: unknown;
+      hostValue: unknown;
+    };
   }
 }

--- a/src/utils/__tests__/typeArgumentScanner.test.ts
+++ b/src/utils/__tests__/typeArgumentScanner.test.ts
@@ -27,6 +27,12 @@ describe('findLikelyTypeArgumentEnd', () => {
     );
   });
 
+  it('finds nested type arguments in a TypeScript angle-bracket assertion', () => {
+    expect(findTypeArgumentRange('const registry = <Map<object, any>>new Map();')).toBe(
+      '<Map<object, any>>'
+    );
+  });
+
   it.each([
     'const value = left < right;',
     'const first = left < right, second = value > fallback;',

--- a/src/utils/__tests__/typeArgumentScanner.test.ts
+++ b/src/utils/__tests__/typeArgumentScanner.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createCodePositionMap } from '../codePositionMap';
+import { findLikelyTypeArgumentEnd } from '../typeArgumentScanner';
+
+function findTypeArgumentRange(source: string): string | undefined {
+  const start = source.indexOf('<');
+  const end = findLikelyTypeArgumentEnd(source, start, createCodePositionMap(source));
+  return end === undefined ? undefined : source.slice(start, end + 1);
+}
+
+describe('findLikelyTypeArgumentEnd', () => {
+  it.each([
+    ['const registry = new WeakMap<object, any>();', '<object, any>'],
+    ['const value = factory<Result, Options>();', '<Result, Options>'],
+    [
+      'const registry: Map<string, WeakMap<object, any>> = new Map();',
+      '<string, WeakMap<object, any>>',
+    ],
+    ['const identity = <T = string, U = number>(value: T) => value;', '<T = string, U = number>'],
+  ])('finds a balanced type argument range in %s', (source, expected) => {
+    expect(findTypeArgumentRange(source)).toBe(expected);
+  });
+
+  it('allows TypeScript assertion keywords after the range', () => {
+    expect(findTypeArgumentRange('const value = factory<Result, Options> as unknown;')).toBe(
+      '<Result, Options>'
+    );
+  });
+
+  it.each([
+    'const value = left < right;',
+    'const first = left < right, second = value > fallback;',
+    'const value = factory<Result, Options;',
+  ])('fails closed for ambiguous syntax in %s', (source) => {
+    expect(findTypeArgumentRange(source)).toBeUndefined();
+  });
+});

--- a/src/utils/typeArgumentScanner.ts
+++ b/src/utils/typeArgumentScanner.ts
@@ -1,0 +1,129 @@
+type TypeArgumentScanState = {
+  angleDepth: number;
+  groupDepth: number;
+  sawTypeComma: boolean;
+};
+
+type TypeArgumentScanAction = 'handled' | 'invalid' | 'closed' | undefined;
+
+function getTypeArgumentStartContext(
+  source: string,
+  start: number
+): { followsNamedExpression: boolean } | undefined {
+  let previous = start - 1;
+  while (previous >= 0 && /\s/.test(source[previous])) previous--;
+  const previousChar = source[previous] || '';
+  const followsNamedExpression = /[$_\u200C\u200D\p{ID_Continue})\]>]/u.test(previousChar);
+  const startsStandaloneGeneric = previousChar !== '' && '=([{,:'.includes(previousChar);
+  if (!followsNamedExpression && !startsStandaloneGeneric) return undefined;
+
+  return { followsNamedExpression };
+}
+
+function updateTypeArgumentGroupDepth(
+  char: string,
+  state: TypeArgumentScanState
+): TypeArgumentScanAction {
+  if (char === '(' || char === '[' || char === '{') {
+    state.groupDepth++;
+    return 'handled';
+  }
+  if (char !== ')' && char !== ']' && char !== '}') return undefined;
+  if (state.groupDepth === 0) return 'invalid';
+
+  state.groupDepth--;
+  return 'handled';
+}
+
+function updateTypeArgumentAngleDepth(
+  source: string,
+  index: number,
+  state: TypeArgumentScanState
+): TypeArgumentScanAction {
+  const char = source[index];
+  if (char === '<') {
+    if (source[index + 1] === '=' || source[index + 1] === '<') return 'invalid';
+    state.angleDepth++;
+    return 'handled';
+  }
+  if (char !== '>') return undefined;
+  if (source[index - 1] === '=' || source[index + 1] === '=') return 'handled';
+
+  state.angleDepth--;
+  return state.angleDepth === 0 ? 'closed' : 'handled';
+}
+
+function hasLikelyTypeArgumentFollower(
+  source: string,
+  end: number,
+  codePositions: boolean[]
+): boolean {
+  let next = end + 1;
+  while (next < source.length && (!codePositions[next] || /\s/.test(source[next]))) next++;
+  if (next >= source.length || /[([.!?=;,)\]}:|&]/.test(source[next])) return true;
+
+  const followingToken = source
+    .slice(next)
+    .match(/^[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*/u)?.[0];
+  return followingToken === 'as' || followingToken === 'satisfies';
+}
+
+function isInvalidTypeArgumentTerminator(
+  source: string,
+  index: number,
+  followsNamedExpression: boolean
+): boolean {
+  const char = source[index];
+  return char === ';' || (char === '=' && source[index + 1] !== '>' && followsNamedExpression);
+}
+
+/**
+ * Finds the end of a balanced, type-like angle-bracket range that contains a
+ * comma. Ambiguous syntax returns `undefined` so callers can fail closed.
+ */
+export function findLikelyTypeArgumentEnd(
+  source: string,
+  start: number,
+  codePositions: boolean[]
+): number | undefined {
+  const context = getTypeArgumentStartContext(source, start);
+  if (!context) return undefined;
+
+  const state: TypeArgumentScanState = {
+    angleDepth: 1,
+    groupDepth: 0,
+    sawTypeComma: false,
+  };
+
+  for (let index = start + 1; index < source.length; index++) {
+    if (!codePositions[index]) continue;
+    const char = source[index];
+
+    const groupAction = updateTypeArgumentGroupDepth(char, state);
+    if (groupAction === 'invalid') return undefined;
+    if (groupAction === 'handled') continue;
+
+    const angleAction = updateTypeArgumentAngleDepth(source, index, state);
+    if (angleAction === 'invalid') return undefined;
+    if (angleAction === 'closed') {
+      return state.sawTypeComma && hasLikelyTypeArgumentFollower(source, index, codePositions)
+        ? index
+        : undefined;
+    }
+    if (angleAction === 'handled') continue;
+
+    if (char === ',' && state.groupDepth === 0) {
+      state.sawTypeComma = true;
+      continue;
+    }
+    if (
+      state.angleDepth === 1 &&
+      state.groupDepth === 0 &&
+      isInvalidTypeArgumentTerminator(source, index, context.followsNamedExpression)
+    ) {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}

--- a/src/utils/typeArgumentScanner.ts
+++ b/src/utils/typeArgumentScanner.ts
@@ -56,7 +56,8 @@ function updateTypeArgumentAngleDepth(
 function hasLikelyTypeArgumentFollower(
   source: string,
   end: number,
-  codePositions: boolean[]
+  codePositions: boolean[],
+  followsNamedExpression: boolean
 ): boolean {
   let next = end + 1;
   while (next < source.length && (!codePositions[next] || /\s/.test(source[next]))) next++;
@@ -65,7 +66,11 @@ function hasLikelyTypeArgumentFollower(
   const followingToken = source
     .slice(next)
     .match(/^[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*/u)?.[0];
-  return followingToken === 'as' || followingToken === 'satisfies';
+  return (
+    followingToken === 'as' ||
+    followingToken === 'satisfies' ||
+    (!followsNamedExpression && followingToken !== undefined)
+  );
 }
 
 function isInvalidTypeArgumentTerminator(
@@ -106,7 +111,8 @@ export function findLikelyTypeArgumentEnd(
     const angleAction = updateTypeArgumentAngleDepth(source, index, state);
     if (angleAction === 'invalid') return undefined;
     if (angleAction === 'closed') {
-      return state.sawTypeComma && hasLikelyTypeArgumentFollower(source, index, codePositions)
+      return state.sawTypeComma &&
+        hasLikelyTypeArgumentFollower(source, index, codePositions, context.followsNamedExpression)
         ? index
         : undefined;
     }

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeModuleFederationOptions,
   ShareItem,
 } from '../../utils/normalizeModuleFederationOptions';
+import { setTreeShakingBuildMode } from '../../utils/treeShaking';
 import {
   addTreeShakingGraphQuery,
   getConcreteSharedImportSource,
@@ -11,11 +12,10 @@ import {
   getTreeShakingGraphToken,
   getTreeShakingSharedProviderImportId,
   hasTreeShakingSharedProvider,
+  stripTreeShakingGraphQuery,
   writeLoadShareModule,
   writePreBuildLibPath,
-  stripTreeShakingGraphQuery,
 } from '../virtualShared_preBuild';
-import { setTreeShakingBuildMode } from '../../utils/treeShaking';
 
 const { writeSyncSpy, mfWarnSpy } = vi.hoisted(() => ({
   writeSyncSpy: vi.fn(),
@@ -443,6 +443,9 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/partial-with-unknown-star.js') ||
       filePath.endsWith('/repo/packages/barrel-with-cjs-star.js') ||
       filePath.endsWith('/repo/packages/hidden.cjs') ||
+      filePath.endsWith('/repo/packages/generic-initializer.ts') ||
+      filePath.endsWith('/repo/packages/generic-and-multi.ts') ||
+      filePath.endsWith('/repo/packages/relational-multi-declarator.ts') ||
       filePath.endsWith('/repo/packages/multi-declarator.js') ||
       filePath.endsWith('/repo/packages/postfix-multi-declarator.js') ||
       filePath.endsWith('/repo/packages/string-export-list.js') ||
@@ -524,6 +527,18 @@ Object.keys(dependency).forEach(function (key) {
     }
     if (filePath.endsWith('/repo/packages/hidden.cjs')) {
       return "module['exports'] = { hidden: 1 };";
+    }
+    if (filePath.endsWith('/repo/packages/generic-initializer.ts')) {
+      return `export const definitionRefRegistry = new WeakMap<object, any>();
+export const createThing = factory<Result, Options>();
+export const nestedRegistry: Map<string, WeakMap<object, any>> = new Map();
+export const identity = <T = string, U = number>(value: T) => value;`;
+    }
+    if (filePath.endsWith('/repo/packages/generic-and-multi.ts')) {
+      return 'export const first = factory<Result, Options>(), second = 2;';
+    }
+    if (filePath.endsWith('/repo/packages/relational-multi-declarator.ts')) {
+      return 'export const first = left < right, second = value > (fallback);';
     }
     if (filePath.endsWith('/repo/packages/multi-declarator.js')) {
       return `export const first =
@@ -1622,6 +1637,82 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).toContain('let current = __mfLocalShare;');
     expect(generatedCode).toContain('export * from "/repo/packages/barrel-with-cjs-star.js"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+  });
+
+  it('keeps TypeScript generic commas inside a single exported declarator', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/generic-initializer.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expectLiveSingletonProxy(generatedCode, pkg, [
+      'definitionRefRegistry',
+      'createThing',
+      'nestedRegistry',
+      'identity',
+    ]);
+    expect(generatedCode).not.toContain('export * from "/repo/packages/generic-initializer.ts"');
+  });
+
+  it('still detects a real declarator comma after a generic initializer', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/generic-and-multi.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('export * from "/repo/packages/generic-and-multi.ts"');
+    expect(generatedCode).not.toContain('__mfApplySharedExports');
+  });
+
+  it('does not confuse relational expressions with TypeScript type arguments', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/relational-multi-declarator.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'export * from "/repo/packages/relational-multi-declarator.ts"'
+    );
     expect(generatedCode).not.toContain('__mfApplySharedExports');
   });
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -532,7 +532,8 @@ Object.keys(dependency).forEach(function (key) {
       return `export const definitionRefRegistry = new WeakMap<object, any>();
 export const createThing = factory<Result, Options>();
 export const nestedRegistry: Map<string, WeakMap<object, any>> = new Map();
-export const identity = <T = string, U = number>(value: T) => value;`;
+export const identity = <T = string, U = number>(value: T) => value;
+export const assertedRegistry = <Map<object, any>>new Map();`;
     }
     if (filePath.endsWith('/repo/packages/generic-and-multi.ts')) {
       return 'export const first = factory<Result, Options>(), second = 2;';
@@ -1664,6 +1665,7 @@ describe('writeLoadShareModule', () => {
       'createThing',
       'nestedRegistry',
       'identity',
+      'assertedRegistry',
     ]);
     expect(generatedCode).not.toContain('export * from "/repo/packages/generic-initializer.ts"');
   });

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -33,6 +33,7 @@ import {
 } from '../utils/packageUtils';
 import { normalizeNodeModulePath } from '../utils/pathNormalization';
 import { getTreeShakingExportUsage } from '../utils/treeShaking';
+import { findLikelyTypeArgumentEnd } from '../utils/typeArgumentScanner';
 import VirtualModule, { MF_OWNER_INFIX, normalizeVirtualModuleId } from '../utils/VirtualModule';
 import {
   getRuntimeInitPromiseBootstrapCode,
@@ -226,7 +227,11 @@ function resolveReExportModule(filePath: string, specifier: string): string | un
   }
 }
 
-function hasTopLevelDeclaratorComma(source: string, start: number): boolean {
+function hasTopLevelDeclaratorComma(
+  source: string,
+  start: number,
+  codePositions: boolean[]
+): boolean {
   let depth = 0;
   let quote: string | undefined;
   let escaped = false;
@@ -317,6 +322,14 @@ function hasTopLevelDeclaratorComma(source: string, start: number): boolean {
     if (char === '!' && source[index + 1] !== '=') {
       continue;
     }
+    if (char === '<') {
+      const typeArgumentEnd = findLikelyTypeArgumentEnd(source, index, codePositions);
+      if (typeArgumentEnd !== undefined) {
+        index = typeArgumentEnd;
+        canStartRegex = false;
+        continue;
+      }
+    }
     if (char === '(' || char === '[' || char === '{') {
       depth++;
       canStartRegex = true;
@@ -396,7 +409,9 @@ function getNamedExportsViaRegex(
   const exportedVariableDeclarationRegex = /export\s+(?:const|let|var)\s+/g;
   while ((match = exportedVariableDeclarationRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
-    if (hasTopLevelDeclaratorComma(source, exportedVariableDeclarationRegex.lastIndex)) {
+    if (
+      hasTopLevelDeclaratorComma(source, exportedVariableDeclarationRegex.lastIndex, codePositions)
+    ) {
       scanState.complete = false;
     }
     if (hasUnsupportedBindingPattern(source, exportedVariableDeclarationRegex.lastIndex)) {


### PR DESCRIPTION
## Summary

Fixes singleton duplication when a shared TypeScript source exports a variable initialized with generic syntax containing a comma, for example:

```ts
export const registry = new WeakMap<object, any>();
```

Closes #978.

## Root cause

The regex-based named-export scan uses `hasTopLevelDeclaratorComma` to determine whether an exported variable statement contains multiple declarators.

The scanner tracked `()`, `[]`, and `{}`, but did not account for TypeScript type arguments. As a result, the comma in `<object, any>` was interpreted as a top-level variable declarator separator.

This marked named-export detection as incomplete and made the shared proxy fall back to:

```ts
export * from "<local module>";
```

That fallback bypassed the live named-export bridge backed by the runtime-selected shared instance, allowing the host and runtime-registered remotes to evaluate separate copies of the shared module.

## Changes

- Add an internal `typeArgumentScanner` utility that recognizes balanced, type-like `<...>` ranges containing commas.
- Reuse the existing `createCodePositionMap` result so strings, comments, template literals, and regular expressions remain excluded from syntax scanning.
- Skip generic commas while scanning exported variable declarations.
- Preserve the existing fail-closed behavior for:
  - actual multi-declarator exports;
  - relational `<` and `>` expressions;
  - incomplete or ambiguous angle-bracket syntax.
- Add focused utility tests covering:
  - generic constructors and function calls;
  - nested type arguments;
  - generic arrow functions;
  - TypeScript assertion keywords;
  - relational and malformed syntax.
- Add generated-proxy regression coverage.
- Add a dev integration test with one host and two runtime-registered remotes sharing the same module ID and `WeakMap` state.

No dependencies or lockfile entries were added.

## Why this approach

- It fixes the incorrect comma classification at the scanner boundary instead of special-casing `WeakMap`.
- It avoids introducing a TypeScript parser dependency for this synchronous source-inspection path.
- The scanner is intentionally conservative: uncertain syntax returns `undefined`, preserving the existing safe fallback.
- The syntax-specific logic is isolated in `src/utils/typeArgumentScanner.ts`; `virtualShared_preBuild.ts` only integrates the result.
- There are no public API, configuration, or type-surface changes.

## Review guide

The change can be reviewed in this order:

1. `src/utils/typeArgumentScanner.ts`
   - Start-context validation.
   - Balanced group and angle-bracket tracking.
   - Valid follower checks.
   - Fail-closed exits for ambiguous syntax.
2. `src/virtualModules/virtualShared_preBuild.ts`
   - The scanner is invoked only when `<` appears while checking an exported variable declaration.
   - A recognized type-argument range is skipped before top-level comma detection continues.
3. `src/utils/__tests__/typeArgumentScanner.test.ts`
   - Direct scanner contract and ambiguity coverage.
4. `src/virtualModules/__tests__/virtualShared_preBuild.test.ts`
   - Generated shared-proxy behavior and real declarator fallback.
5. `integration/dev-singleton-react.test.ts`
   - End-to-end module identity and shared `WeakMap` state across the host and two registered remotes.

## Verification

- `pnpm test`
  - 45 test files passed.
  - 939 tests passed, 1 skipped.
- `pnpm typecheck`
- `pnpm build`
- `npx oxfmt --check src`
- Targeted integration regression:

```sh
pnpm exec vitest run integration/dev-singleton-react.test.ts \
  -t "runtime-registered TypeScript source singleton"
```

The integration test verifies that:

- the host and both remotes observe the same module instance ID;
- both remotes read the value registered in the host's `WeakMap`;
- no browser runtime errors are emitted.