### PR TITLE
fix: resolve shared exports using per-environment conditions

### DIFF
--- a/integration/ssr-shared-exports.test.ts
+++ b/integration/ssr-shared-exports.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build, type Plugin, type Rollup } from 'vite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { federation } from '../src';
+
+const outputDirs: string[] = [];
+// Reuse an existing React 19 workspace package so this regression test does not
+// need its own package.json, workspace entry, or lockfile importer.
+const reactWorkspaceRoot = resolve(import.meta.dirname, '../examples/vite-vite/vite-remote');
+const ssrEntryId = 'virtual:ssr-shared-exports-entry';
+const resolvedSsrEntryId = `\0${ssrEntryId}`;
+
+const ssrEntryPlugin: Plugin = {
+  name: 'ssr-shared-exports-entry',
+  resolveId(id) {
+    if (id === ssrEntryId) return resolvedSsrEntryId;
+  },
+  load(id) {
+    if (id === resolvedSsrEntryId) {
+      return "export { renderToPipeableStream } from 'react-dom/server';";
+    }
+  },
+};
+
+afterEach(async () => {
+  await Promise.all(outputDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('SSR shared conditional exports', () => {
+  it('builds and executes the node export surface of react-dom/server', async () => {
+    const outDir = await mkdtemp(resolve(reactWorkspaceRoot, '.mf-vite-ssr-'));
+    outputDirs.push(outDir);
+
+    const result = await build({
+      root: reactWorkspaceRoot,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [
+        ssrEntryPlugin,
+        federation({
+          name: 'ssrHost',
+          shared: {
+            'react-dom': { singleton: true },
+          },
+          dts: false,
+        }),
+      ],
+      build: {
+        ssr: true,
+        outDir,
+        write: true,
+        minify: false,
+        target: 'node20',
+        rollupOptions: {
+          input: ssrEntryId,
+        },
+      },
+    });
+    expect(Array.isArray(result), 'Expected a single RollupOutput, not an array').toBe(false);
+    const output = result as Rollup.RollupOutput;
+
+    const entryChunk = output.output.find(
+      (item): item is Rollup.OutputChunk =>
+        item.type === 'chunk' && item.isEntry && item.facadeModuleId === resolvedSsrEntryId
+    );
+    expect(entryChunk, 'Expected the virtual SSR entry chunk').toBeDefined();
+
+    const serverEntry = await import(
+      `${pathToFileURL(resolve(outDir, entryChunk!.fileName)).href}?test=${Date.now()}`
+    );
+    expect(serverEntry.renderToPipeableStream).toBeTypeOf('function');
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,12 +1,14 @@
 import path from 'node:path';
-import type {
-  ConfigEnv,
-  ConfigPluginContext,
-  MinimalPluginContextWithoutEnvironment,
-  Plugin,
-  Rollup,
-  UserConfig,
-  ViteBuilder,
+import {
+  mergeConfig,
+  type ConfigEnv,
+  type ConfigPluginContext,
+  type MinimalPluginContextWithoutEnvironment,
+  type Plugin,
+  type ResolvedConfig,
+  type Rollup,
+  type UserConfig,
+  type ViteBuilder,
 } from 'vite';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parsePromise } from '../plugins/pluginModuleParseEnd';
@@ -22,10 +24,26 @@ import {
   getLoadShareModulePath,
 } from '../virtualModules/virtualShared_preBuild';
 
-const { hasPackageDependencyMock, mfWarn } = vi.hoisted(() => ({
+const { getSharedExportConditionsMock, hasPackageDependencyMock, mfWarn } = vi.hoisted(() => ({
+  getSharedExportConditionsMock: vi.fn(),
   hasPackageDependencyMock: vi.fn<(dependency: string) => boolean>((_dependency: string) => false),
   mfWarn: vi.fn(),
 }));
+
+vi.mock('../utils/sharedExportConditions', async () => {
+  const actual = await vi.importActual<typeof import('../utils/sharedExportConditions')>(
+    '../utils/sharedExportConditions'
+  );
+  return {
+    ...actual,
+    getSharedExportConditions: (
+      ...args: Parameters<typeof actual.getSharedExportConditions>
+    ): ReturnType<typeof actual.getSharedExportConditions> => {
+      getSharedExportConditionsMock(...args);
+      return actual.getSharedExportConditions(...args);
+    },
+  };
+});
 
 vi.mock('../utils/packageUtils', async () => {
   const actual =
@@ -354,6 +372,104 @@ describe('module parse wiring', () => {
     callHook(parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
 
     expect(await resolvesQuickly(parsePromise)).toBe(true);
+  });
+});
+
+describe('shared export condition configuration', () => {
+  it('uses SSR conditions contributed by a later config hook in Vite 5-7 load hooks', () => {
+    const pkg = 'missing-late-conditions-package';
+    const plugins = federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      shared: {
+        [pkg]: {
+          import: false,
+        },
+      },
+    }) as Plugin[];
+    const earlyInitPlugin = plugins.find(
+      (plugin) => plugin.name === 'vite:module-federation-early-init'
+    );
+    const federationConfigPlugin = plugins.find(
+      (plugin) => plugin.name === 'vite:module-federation-config'
+    );
+    const federationOptionsPlugin = plugins.find(
+      (plugin) => plugin.name === 'module-federation-vite'
+    );
+    const federationLoadPlugin = plugins.find(
+      (plugin) => plugin.name === 'module-federation-esm-shims'
+    );
+    if (
+      !earlyInitPlugin ||
+      !federationConfigPlugin ||
+      !federationOptionsPlugin ||
+      !federationLoadPlugin
+    ) {
+      throw new Error('module federation plugins not found');
+    }
+
+    const config: UserConfig = {
+      root: process.cwd(),
+      build: {
+        ssr: true,
+      },
+    };
+    const env = {
+      command: 'build',
+      mode: 'production',
+    } as ConfigEnv;
+    const configContext = { meta: {} } as ConfigPluginContext;
+
+    runConfig(earlyInitPlugin, configContext, config, env);
+    runConfig(federationConfigPlugin, configContext, config, env);
+
+    const lateConditionsPlugin: Plugin = {
+      name: 'late-ssr-conditions',
+      config() {
+        return {
+          resolve: {
+            conditions: ['late-root-condition'],
+          },
+          ssr: {
+            target: 'webworker',
+            resolve: {
+              conditions: ['late-ssr-condition'],
+            },
+          },
+        };
+      },
+    };
+    const lateConfig = callHook(lateConditionsPlugin.config, configContext, config, env);
+    const resolvedConfig = {
+      ...mergeConfig(config, lateConfig ?? {}),
+      isProduction: true,
+    } as ResolvedConfig;
+
+    callHook(
+      federationConfigPlugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      resolvedConfig
+    );
+
+    // Vite 5-7 load hooks have no `this.environment`, so they use the values
+    // captured from the final ResolvedConfig above.
+    getSharedExportConditionsMock.mockClear();
+    const federationOptions = (
+      federationOptionsPlugin as Plugin & {
+        _options: NonNullable<Parameters<typeof getLoadShareModulePath>[2]>;
+      }
+    )._options;
+    const loadShareId = getLoadShareModulePath(pkg, false, federationOptions);
+    callHook(federationLoadPlugin.load, {} as Rollup.PluginContext, loadShareId, { ssr: true });
+
+    expect(getSharedExportConditionsMock).toHaveBeenCalledWith({
+      environmentConditions: undefined,
+      isProduction: true,
+      isSsr: true,
+      rootConditions: ['late-root-condition'],
+      ssrConditions: ['late-ssr-condition'],
+      ssrTarget: 'webworker',
+    });
   });
 });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -387,15 +387,17 @@ describe('module-federation-esm-shims', () => {
     expect(deps).toEqual(['assets/index.js']);
   });
 
-  it('prepends workspace singleton imports for legacy SSR build load hooks', () => {
-    const plugin = getEsmShimsPlugin();
-    const config: any = {
-      build: { ssr: true },
-    };
-    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+  it.each([true, 'src/entry-server.ts'])(
+    'prepends workspace singleton imports for legacy SSR build load hooks with build.ssr=%s',
+    (ssr) => {
+      const plugin = getEsmShimsPlugin();
+      const config: any = {
+        build: { ssr },
+      };
+      runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    const virtualModule = new VirtualModule('legacy-workspace-singleton', LOAD_SHARE_TAG, '.js');
-    virtualModule.write(`
+      const virtualModule = new VirtualModule('legacy-workspace-singleton', LOAD_SHARE_TAG, '.js');
+      virtualModule.write(`
       let __mf_default;
       const __mfApplyLazyShareExports = (mod) => {
         __mf_default = mod.default ?? mod;
@@ -414,14 +416,15 @@ describe('module-federation-esm-shims', () => {
       export { __mf_default as default };
     `);
 
-    const result = callHook(plugin.load, {} as any, virtualModule.getImportId()) as {
-      code: string;
-    };
+      const result = callHook(plugin.load, {} as any, virtualModule.getImportId()) as {
+        code: string;
+      };
 
-    expect(result.code).toContain(
-      'import * as __mfLocalShare from "/repo/packages/workspace-shared-lib/src/index.tsx";'
-    );
-  });
+      expect(result.code).toContain(
+        'import * as __mfLocalShare from "/repo/packages/workspace-shared-lib/src/index.tsx";'
+      );
+    }
+  );
 
   it('returns null when build load hook cannot resolve a virtual module', () => {
     const plugin = getEsmShimsPlugin();

--- a/src/index.ts
+++ b/src/index.ts
@@ -765,6 +765,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
   let command: string;
   let desiredRolldownOutput: OutputNameOptions[] | undefined;
   let isSsrBuild = false;
+  let isProduction = false;
   let rootResolveConditions: string[] | undefined;
   let ssrResolveConditions: string[] | undefined;
   let ssrTarget: 'node' | 'webworker' = 'node';
@@ -778,6 +779,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       config?: {
         consumer?: string;
         build?: { ssr?: boolean | string };
+        isProduction?: boolean;
         resolve?: { conditions?: string[] };
       };
     };
@@ -794,6 +796,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       environment?.name === 'server';
     return getSharedExportConditions({
       environmentConditions: environment?.config?.resolve?.conditions,
+      isProduction: environment?.config?.isProduction ?? isProduction,
       isSsr,
       rootConditions: rootResolveConditions,
       ssrConditions: ssrResolveConditions,
@@ -936,7 +939,8 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           : undefined;
         ssrTarget = config.ssr?.target ?? 'node';
       },
-      configResolved() {
+      configResolved(config: ResolvedConfig) {
+        isProduction = config.isProduction;
         const ssrCapabilities = getSsrCapabilities(
           parseInt(viteVersion, 10),
           command as 'serve' | 'build',

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from './utils/controlChunkSanitizer';
 import { isTestEnv } from './utils/isTestEnv';
 import { createModuleFederationError, mfWarn } from './utils/logger';
+import { getSharedExportConditions } from './utils/sharedExportConditions';
 import type {
   ModuleFederationOptions,
   NormalizedModuleFederationOptions,
@@ -80,7 +81,10 @@ import { addUsedRemote } from './virtualModules/virtualRemotes';
 import { getRuntimeInitStatusImportId } from './virtualModules/virtualRuntimeInitStatus';
 import {
   findCurrentLoadShareForStaleOwnerId,
+  getCachedLoadSharePkg,
+  getCachedPreBuildPkg,
   getLoadShareModulePath,
+  getPreBuildLibImportId,
   materializeCachedLoadShareModule,
   prependWorkspaceSingletonSsrImport,
   writeLoadShareModule,
@@ -761,7 +765,85 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
   let command: string;
   let desiredRolldownOutput: OutputNameOptions[] | undefined;
   let isSsrBuild = false;
+  let rootResolveConditions: string[] | undefined;
+  let ssrResolveConditions: string[] | undefined;
+  let ssrTarget: 'node' | 'webworker' = 'node';
   const emittedRuntimeCapabilityWarnings = new Set<string>();
+
+  type LoadHookOptions = { ssr?: boolean };
+  type SharedVirtualRefreshStatus = 'refreshed' | 'not-owned' | 'not-applicable';
+  type LoadHookContext = {
+    environment?: {
+      name?: string;
+      config?: {
+        consumer?: string;
+        build?: { ssr?: boolean | string };
+        resolve?: { conditions?: string[] };
+      };
+    };
+  };
+
+  const getLoadHookExportConditions = (context: LoadHookContext, loadOptions?: LoadHookOptions) => {
+    const environment = context.environment;
+    const isSsr =
+      loadOptions?.ssr === true ||
+      isSsrBuild ||
+      environment?.config?.consumer === 'server' ||
+      Boolean(environment?.config?.build?.ssr) ||
+      environment?.name === 'ssr' ||
+      environment?.name === 'server';
+    return getSharedExportConditions({
+      environmentConditions: environment?.config?.resolve?.conditions,
+      isSsr,
+      rootConditions: rootResolveConditions,
+      ssrConditions: ssrResolveConditions,
+      ssrTarget,
+    });
+  };
+
+  const refreshPreBuildModuleForEnvironment = (
+    id: string,
+    context: LoadHookContext,
+    loadOptions?: LoadHookOptions
+  ): SharedVirtualRefreshStatus => {
+    const pkg = getCachedPreBuildPkg(id);
+    if (!pkg) return 'not-applicable';
+    const key = findSharedKey(pkg, shared);
+    if (!key) return 'not-applicable';
+    const requestedModule = VirtualModule.findById(id);
+    const ownedModule = VirtualModule.findById(getPreBuildLibImportId(pkg, options));
+    if (!requestedModule || requestedModule !== ownedModule) return 'not-owned';
+    writePreBuildLibPath(
+      pkg,
+      shared[key],
+      options,
+      getLoadHookExportConditions(context, loadOptions)
+    );
+    return 'refreshed';
+  };
+
+  const refreshLoadShareModuleForEnvironment = (
+    id: string,
+    context: LoadHookContext,
+    loadOptions?: LoadHookOptions
+  ): SharedVirtualRefreshStatus => {
+    const pkg = getCachedLoadSharePkg(id);
+    if (!pkg) return 'not-applicable';
+    const key = findSharedKey(pkg, shared);
+    if (!key) return 'not-applicable';
+    const requestedModule = VirtualModule.findById(id);
+    const ownedModule = VirtualModule.findById(getLoadShareModulePath(pkg, false, options));
+    if (!requestedModule || requestedModule !== ownedModule) return 'not-owned';
+    writeLoadShareModule(
+      pkg,
+      shared[key],
+      command,
+      getIsRolldown(context),
+      options,
+      getLoadHookExportConditions(context, loadOptions)
+    );
+    return 'refreshed';
+  };
 
   return [
     {
@@ -787,7 +869,22 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         if (!virtualModule) return;
         return virtualModule.getResolvedId();
       },
-      load(id: string) {
+      load(id: string, loadOptions?: LoadHookOptions) {
+        if (
+          command !== 'build' &&
+          id.includes(LOAD_SHARE_TAG) &&
+          refreshLoadShareModuleForEnvironment(id, this as LoadHookContext, loadOptions) ===
+            'not-owned'
+        ) {
+          return;
+        }
+        if (
+          id.includes(PREBUILD_TAG) &&
+          refreshPreBuildModuleForEnvironment(id, this as LoadHookContext, loadOptions) ===
+            'not-owned'
+        ) {
+          return;
+        }
         const virtualModule = VirtualModule.findById(id);
         if (!virtualModule) return;
         if (command === 'build' && (id.includes(LOAD_SHARE_TAG) || id.includes(LOAD_REMOTE_TAG))) {
@@ -829,8 +926,15 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
     {
       name: 'vite:module-federation-config',
       enforce: 'pre',
-      config(_config: UserConfig, env: ConfigEnv) {
+      config(config: UserConfig, env: ConfigEnv) {
         command = env.command;
+        rootResolveConditions = config.resolve?.conditions
+          ? [...config.resolve.conditions]
+          : undefined;
+        ssrResolveConditions = config.ssr?.resolve?.conditions
+          ? [...config.ssr.resolve.conditions]
+          : undefined;
+        ssrTarget = config.ssr?.target ?? 'node';
       },
       configResolved() {
         const ssrCapabilities = getSsrCapabilities(
@@ -926,7 +1030,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       enforce: 'pre',
       apply: 'build',
       config(config: UserConfig) {
-        isSsrBuild = config.build?.ssr === true;
+        isSsrBuild = Boolean(config.build?.ssr);
         // Force loadShare modules and runtimeInitStatus into separate chunks.
         //
         // For Vite 8+: loadShare chunks need separate async init barriers
@@ -1176,8 +1280,15 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           };
         }
       },
-      load(id: string) {
+      load(id: string, loadOptions?: LoadHookOptions) {
         if (id.includes(LOAD_SHARE_TAG) || id.includes(LOAD_REMOTE_TAG)) {
+          if (
+            id.includes(LOAD_SHARE_TAG) &&
+            refreshLoadShareModuleForEnvironment(id, this as LoadHookContext, loadOptions) ===
+              'not-owned'
+          ) {
+            return;
+          }
           const virtualModule = VirtualModule.findById(id);
           if (!virtualModule?.code) return null;
           let code = virtualModule.code;
@@ -1330,7 +1441,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       _options: options,
       config(config: UserConfig, { command: _command }: { command: string }) {
         const isRolldown = getIsRolldown(this);
-        isSsrBuild = _command === 'build' && config.build?.ssr === true;
+        isSsrBuild = _command === 'build' && Boolean(config.build?.ssr);
         const needsRuntimeHelpers = Object.keys(options.shared ?? {}).length > 0;
 
         if (needsRuntimeHelpers) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -929,8 +929,10 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
     {
       name: 'vite:module-federation-config',
       enforce: 'pre',
-      config(config: UserConfig, env: ConfigEnv) {
+      config(_config: UserConfig, env: ConfigEnv) {
         command = env.command;
+      },
+      configResolved(config: ResolvedConfig) {
         rootResolveConditions = config.resolve?.conditions
           ? [...config.resolve.conditions]
           : undefined;
@@ -938,8 +940,6 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           ? [...config.ssr.resolve.conditions]
           : undefined;
         ssrTarget = config.ssr?.target ?? 'node';
-      },
-      configResolved(config: ResolvedConfig) {
         isProduction = config.isProduction;
         const ssrCapabilities = getSsrCapabilities(
           parseInt(viteVersion, 10),

--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -116,6 +116,73 @@ describe('getInstalledPackageJson', () => {
     expect(entry).toBe(path.join(packageDir, 'dist/browser.js'));
   });
 
+  it('respects package export key order when multiple conditions are active', () => {
+    const packageName = 'mf-test-conditional-key-order';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-conditional-order-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'dist'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: {
+          '.': {
+            browser: './dist/browser.js',
+            worker: './dist/worker.js',
+            default: './dist/default.js',
+          },
+        },
+      })
+    );
+    writeFileSync(path.join(packageDir, 'dist/browser.js'), 'export const browserOnly = true;');
+    writeFileSync(path.join(packageDir, 'dist/worker.js'), 'export const workerOnly = true;');
+    writeFileSync(path.join(packageDir, 'dist/default.js'), 'export const defaultOnly = true;');
+
+    const entry = getInstalledPackageEntry(packageName, {
+      cwd: hostDir,
+      conditions: ['worker', 'browser', 'import', 'default'],
+    });
+
+    // Conditional exports are matched in package.json key order. Although both
+    // worker and browser are active, browser appears first and must win.
+    expect(entry).toBe(realpathSync(path.join(packageDir, 'dist/browser.js')));
+  });
+
+  it('uses the import entry for default ESM package resolution', () => {
+    const packageName = 'mf-test-default-import-condition';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-default-import-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    mkdirSync(path.join(packageDir, 'dist'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        exports: {
+          '.': {
+            require: './dist/index.cjs',
+            import: './dist/index.js',
+            default: './dist/default.js',
+          },
+        },
+      })
+    );
+    writeFileSync(path.join(packageDir, 'dist/index.cjs'), 'module.exports = {};');
+    writeFileSync(path.join(packageDir, 'dist/index.js'), 'export const esmOnly = true;');
+    writeFileSync(path.join(packageDir, 'dist/default.js'), 'export const defaultOnly = true;');
+
+    const entry = getInstalledPackageEntry(packageName, { cwd: hostDir });
+
+    expect(entry).toBe(realpathSync(path.join(packageDir, 'dist/index.js')));
+  });
+
   it('preserves legacy package subpaths when ESM condition resolution is requested', () => {
     const packageName = 'mf-test-legacy-subpath';
     const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-legacy-subpath-'));

--- a/src/utils/__tests__/sharedExportConditions.test.ts
+++ b/src/utils/__tests__/sharedExportConditions.test.ts
@@ -2,17 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { getSharedExportConditions } from '../sharedExportConditions';
 
 describe('getSharedExportConditions', () => {
-  it('uses the active Vite environment conditions and appends ESM fallbacks', () => {
+  it.each([
+    [true, 'production'],
+    [false, 'development'],
+  ])('expands Vite development|production for isProduction=%s', (isProduction, modeCondition) => {
     expect(
       getSharedExportConditions({
         environmentConditions: ['module', 'node', 'development|production'],
         isSsr: true,
+        isProduction,
       })
-    ).toEqual(['module', 'node', 'development|production', 'import', 'default']);
+    ).toEqual(['module', 'node', modeCondition, 'import', 'default']);
   });
 
   it('preserves the browser-first default when no environment conditions are available', () => {
-    expect(getSharedExportConditions({ isSsr: false })).toEqual([
+    expect(getSharedExportConditions({ isProduction: false, isSsr: false })).toEqual([
       'browser',
       'import',
       'module',
@@ -20,6 +24,7 @@ describe('getSharedExportConditions', () => {
     ]);
     expect(
       getSharedExportConditions({
+        isProduction: false,
         isSsr: false,
         rootConditions: ['custom'],
       })
@@ -27,7 +32,7 @@ describe('getSharedExportConditions', () => {
   });
 
   it('uses node conditions for legacy SSR builds and honors explicit SSR conditions', () => {
-    expect(getSharedExportConditions({ isSsr: true })).toEqual([
+    expect(getSharedExportConditions({ isProduction: true, isSsr: true })).toEqual([
       'node',
       'import',
       'module',
@@ -35,15 +40,27 @@ describe('getSharedExportConditions', () => {
     ]);
     expect(
       getSharedExportConditions({
+        isProduction: true,
         isSsr: true,
         ssrConditions: ['react-server'],
       })
     ).toEqual(['react-server', 'node', 'import', 'module', 'default']);
   });
 
+  it('expands Vite development|production in configured fallback conditions', () => {
+    expect(
+      getSharedExportConditions({
+        isProduction: true,
+        isSsr: true,
+        ssrConditions: ['react-server', 'development|production'],
+      })
+    ).toEqual(['react-server', 'production', 'node', 'import', 'module', 'default']);
+  });
+
   it('keeps webworker SSR on worker/browser conditions instead of node', () => {
     expect(
       getSharedExportConditions({
+        isProduction: true,
         isSsr: true,
         ssrTarget: 'webworker',
       })

--- a/src/utils/__tests__/sharedExportConditions.test.ts
+++ b/src/utils/__tests__/sharedExportConditions.test.ts
@@ -15,7 +15,7 @@ describe('getSharedExportConditions', () => {
     ).toEqual(['module', 'node', modeCondition, 'import', 'default']);
   });
 
-  it('preserves the browser-first default when no environment conditions are available', () => {
+  it('uses client export conditions when no environment conditions are available', () => {
     expect(getSharedExportConditions({ isProduction: false, isSsr: false })).toEqual([
       'browser',
       'import',

--- a/src/utils/__tests__/sharedExportConditions.test.ts
+++ b/src/utils/__tests__/sharedExportConditions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getSharedExportConditions } from '../sharedExportConditions';
+
+describe('getSharedExportConditions', () => {
+  it('uses the active Vite environment conditions and appends ESM fallbacks', () => {
+    expect(
+      getSharedExportConditions({
+        environmentConditions: ['module', 'node', 'development|production'],
+        isSsr: true,
+      })
+    ).toEqual(['module', 'node', 'development|production', 'import', 'default']);
+  });
+
+  it('preserves the browser-first default when no environment conditions are available', () => {
+    expect(getSharedExportConditions({ isSsr: false })).toEqual([
+      'browser',
+      'import',
+      'module',
+      'default',
+    ]);
+    expect(
+      getSharedExportConditions({
+        isSsr: false,
+        rootConditions: ['custom'],
+      })
+    ).toEqual(['custom', 'browser', 'import', 'module', 'default']);
+  });
+
+  it('uses node conditions for legacy SSR builds and honors explicit SSR conditions', () => {
+    expect(getSharedExportConditions({ isSsr: true })).toEqual([
+      'node',
+      'import',
+      'module',
+      'default',
+    ]);
+    expect(
+      getSharedExportConditions({
+        isSsr: true,
+        ssrConditions: ['react-server'],
+      })
+    ).toEqual(['react-server', 'node', 'import', 'module', 'default']);
+  });
+
+  it('keeps webworker SSR on worker/browser conditions instead of node', () => {
+    expect(
+      getSharedExportConditions({
+        isSsr: true,
+        ssrTarget: 'webworker',
+      })
+    ).toEqual(['worker', 'browser', 'import', 'module', 'default']);
+  });
+});

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -61,26 +61,41 @@ type PackageEntryConditions = {
   fromResolvedEntry?: string;
 };
 
-const DEFAULT_EXPORT_CONDITIONS = ['browser', 'import', 'module', 'default', 'require'];
+const DEFAULT_EXPORT_CONDITIONS = ['browser', 'import', 'module', 'default'];
 
 function resolveExportsEntry(
   exportsField: unknown,
   conditions = DEFAULT_EXPORT_CONDITIONS
 ): string | undefined {
+  return resolveExportsEntryWithConditions(exportsField, new Set(conditions));
+}
+
+function resolveExportsEntryWithConditions(
+  exportsField: unknown,
+  conditions: ReadonlySet<string>
+): string | undefined {
   if (typeof exportsField === 'string') return exportsField;
   if (!exportsField || typeof exportsField !== 'object') return undefined;
-  const record = exportsField as Record<string, unknown>;
-  const rootExport = record['.'];
-  if (rootExport) return resolveExportsEntry(rootExport);
 
-  for (const condition of conditions) {
-    const target = resolveExportsEntry(record[condition], conditions);
-    if (target) return target;
+  if (Array.isArray(exportsField)) {
+    for (const target of exportsField) {
+      const resolved = resolveExportsEntryWithConditions(target, conditions);
+      if (resolved) return resolved;
+    }
+    return undefined;
   }
 
-  for (const target of Object.values(record)) {
-    const resolved = resolveExportsEntry(target, conditions);
-    if (resolved) return resolved;
+  const record = exportsField as Record<string, unknown>;
+  const rootExport = record['.'];
+  if (rootExport) return resolveExportsEntryWithConditions(rootExport, conditions);
+
+  // Conditional exports are matched in package.json key order. Conditions
+  // identify the active branches, but their own order does not affect which
+  // branch wins. `default` is always eligible as the universal fallback.
+  for (const [condition, value] of Object.entries(record)) {
+    if (condition !== 'default' && !conditions.has(condition)) continue;
+    const target = resolveExportsEntryWithConditions(value, conditions);
+    if (target) return target;
   }
 
   return undefined;

--- a/src/utils/sharedExportConditions.ts
+++ b/src/utils/sharedExportConditions.ts
@@ -7,9 +7,13 @@ const DEFAULT_WEBWORKER_SSR_EXPORT_CONDITIONS = [
   'module',
   'default',
 ];
+// Vite expands this sentinel immediately before package resolution. Shared
+// export scanning uses its own resolver, so normalize it at this boundary.
+const VITE_DEV_PROD_CONDITION = 'development|production';
 
 type SharedExportConditionOptions = {
   environmentConditions?: readonly string[];
+  isProduction: boolean;
   isSsr: boolean;
   rootConditions?: readonly string[];
   ssrConditions?: readonly string[];
@@ -23,15 +27,30 @@ function appendConditions(
   return [...new Set([...conditions, ...fallbackConditions])];
 }
 
+function resolveViteModeCondition(conditions: readonly string[], isProduction: boolean): string[] {
+  const modeCondition = isProduction ? 'production' : 'development';
+  return [
+    ...new Set(
+      conditions.map((condition) =>
+        condition === VITE_DEV_PROD_CONDITION ? modeCondition : condition
+      )
+    ),
+  ];
+}
+
 export function getSharedExportConditions({
   environmentConditions,
+  isProduction,
   isSsr,
   rootConditions,
   ssrConditions,
   ssrTarget = 'node',
 }: SharedExportConditionOptions): string[] {
   if (environmentConditions !== undefined) {
-    return appendConditions(environmentConditions, ['import', 'default']);
+    return resolveViteModeCondition(
+      appendConditions(environmentConditions, ['import', 'default']),
+      isProduction
+    );
   }
 
   const defaultConditions = isSsr
@@ -42,7 +61,10 @@ export function getSharedExportConditions({
   const configuredConditions = isSsr ? (ssrConditions ?? rootConditions) : rootConditions;
 
   if (configuredConditions !== undefined) {
-    return appendConditions(configuredConditions, defaultConditions);
+    return resolveViteModeCondition(
+      appendConditions(configuredConditions, defaultConditions),
+      isProduction
+    );
   }
   return [...defaultConditions];
 }

--- a/src/utils/sharedExportConditions.ts
+++ b/src/utils/sharedExportConditions.ts
@@ -1,0 +1,48 @@
+const DEFAULT_CLIENT_EXPORT_CONDITIONS = ['browser', 'import', 'module', 'default'];
+const DEFAULT_NODE_SSR_EXPORT_CONDITIONS = ['node', 'import', 'module', 'default'];
+const DEFAULT_WEBWORKER_SSR_EXPORT_CONDITIONS = [
+  'worker',
+  'browser',
+  'import',
+  'module',
+  'default',
+];
+
+type SharedExportConditionOptions = {
+  environmentConditions?: readonly string[];
+  isSsr: boolean;
+  rootConditions?: readonly string[];
+  ssrConditions?: readonly string[];
+  ssrTarget?: 'node' | 'webworker';
+};
+
+function appendConditions(
+  conditions: readonly string[],
+  fallbackConditions: readonly string[]
+): string[] {
+  return [...new Set([...conditions, ...fallbackConditions])];
+}
+
+export function getSharedExportConditions({
+  environmentConditions,
+  isSsr,
+  rootConditions,
+  ssrConditions,
+  ssrTarget = 'node',
+}: SharedExportConditionOptions): string[] {
+  if (environmentConditions !== undefined) {
+    return appendConditions(environmentConditions, ['import', 'default']);
+  }
+
+  const defaultConditions = isSsr
+    ? ssrTarget === 'webworker'
+      ? DEFAULT_WEBWORKER_SSR_EXPORT_CONDITIONS
+      : DEFAULT_NODE_SSR_EXPORT_CONDITIONS
+    : DEFAULT_CLIENT_EXPORT_CONDITIONS;
+  const configuredConditions = isSsr ? (ssrConditions ?? rootConditions) : rootConditions;
+
+  if (configuredConditions !== undefined) {
+    return appendConditions(configuredConditions, defaultConditions);
+  }
+  return [...defaultConditions];
+}

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { normalizePathForImport } from '../../utils/buildPaths';
+import { getSharedExportConditions } from '../../utils/sharedExportConditions';
 import {
   normalizeModuleFederationOptions,
   ShareItem,
@@ -8,6 +9,7 @@ import {
   addTreeShakingGraphQuery,
   getConcreteSharedImportSource,
   getProjectResolvedImportPath,
+  getSharedNamedExports,
   getTreeShakingGraphToken,
   getTreeShakingSharedProviderImportId,
   hasTreeShakingSharedProvider,
@@ -225,6 +227,15 @@ vi.mock('../../utils/packageUtils', () => ({
       }
       return '/repo/apps/remote/node_modules/mock-package-browser-conditional/dist/browser.js';
     }
+    if (pkg === 'mock-package-mode-conditional') {
+      if (opts?.conditions?.includes('production')) {
+        return '/repo/apps/remote/node_modules/mock-package-mode-conditional/dist/production.js';
+      }
+      if (opts?.conditions?.includes('development')) {
+        return '/repo/apps/remote/node_modules/mock-package-mode-conditional/dist/development.js';
+      }
+      return '/repo/apps/remote/node_modules/mock-package-mode-conditional/dist/default.js';
+    }
     if (pkg === 'mock-package-dual-shape') {
       return '/repo/apps/remote/node_modules/mock-package-dual-shape/dist/browser.js';
     }
@@ -425,6 +436,12 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-browser-conditional/dist/server.js') ||
       filePath.endsWith('node_modules/mock-package-browser-conditional/dist/worker.js') ||
       filePath.endsWith('/mock-package-browser-conditional/dist/worker.js') ||
+      filePath.endsWith('node_modules/mock-package-mode-conditional/dist/development.js') ||
+      filePath.endsWith('/mock-package-mode-conditional/dist/development.js') ||
+      filePath.endsWith('node_modules/mock-package-mode-conditional/dist/production.js') ||
+      filePath.endsWith('/mock-package-mode-conditional/dist/production.js') ||
+      filePath.endsWith('node_modules/mock-package-mode-conditional/dist/default.js') ||
+      filePath.endsWith('/mock-package-mode-conditional/dist/default.js') ||
       filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-cjs-comment/index.js') ||
@@ -738,6 +755,15 @@ export const [firstItem, ...restItems] = tuple;`;
     }
     if (filePath.endsWith('node_modules/mock-package-browser-conditional/dist/worker.js')) {
       return 'export const workerOnly = true;';
+    }
+    if (filePath.endsWith('node_modules/mock-package-mode-conditional/dist/development.js')) {
+      return 'export const developmentOnly = true;';
+    }
+    if (filePath.endsWith('node_modules/mock-package-mode-conditional/dist/production.js')) {
+      return 'export const productionOnly = true;';
+    }
+    if (filePath.endsWith('node_modules/mock-package-mode-conditional/dist/default.js')) {
+      return 'export const defaultOnly = true;';
     }
     if (filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js')) {
       return 'export const browserNamed = true;';
@@ -2314,6 +2340,24 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('__mf_0 as workerOnly');
     expect(generatedCode).not.toContain('serverOnly');
   });
+
+  it.each([
+    ['production', true, 'productionOnly'],
+    ['development', false, 'developmentOnly'],
+  ])(
+    'inspects the %s mode entry after expanding Vite development|production',
+    (_mode, isProduction, expectedExport) => {
+      const exportConditions = getSharedExportConditions({
+        environmentConditions: ['module', 'node', 'development|production'],
+        isProduction,
+        isSsr: true,
+      });
+
+      expect(
+        getSharedNamedExports('mock-package-mode-conditional', undefined, exportConditions)
+      ).toEqual([expectedExport]);
+    }
+  );
 
   it('uses the same export conditions for shareConfig.import package sources', () => {
     const pkg = 'conditional-package-alias';

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -175,7 +175,7 @@ vi.mock('../../utils/packageUtils', () => ({
   hasPackageDependency: hasPackageDependencyMock,
   getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
   resolveImportPath: vi.fn(() => '/repo/node_modules/@module-federation/runtime/dist/index.js'),
-  getInstalledPackageEntry: vi.fn((pkg: string, opts?: { cwd?: string }) => {
+  getInstalledPackageEntry: vi.fn((pkg: string, opts?: { cwd?: string; conditions?: string[] }) => {
     if (pkg === 'react/jsx-runtime') {
       return '/repo/apps/remote/node_modules/react/jsx-runtime.js';
     }
@@ -217,6 +217,12 @@ vi.mock('../../utils/packageUtils', () => ({
       pkg === 'mock-package-browser-conditional' ||
       pkg.startsWith('mock-package-browser-conditional/')
     ) {
+      if (opts?.conditions?.includes('node')) {
+        return '/repo/apps/remote/node_modules/mock-package-browser-conditional/dist/server.js';
+      }
+      if (opts?.conditions?.includes('worker')) {
+        return '/repo/apps/remote/node_modules/mock-package-browser-conditional/dist/worker.js';
+      }
       return '/repo/apps/remote/node_modules/mock-package-browser-conditional/dist/browser.js';
     }
     if (pkg === 'mock-package-dual-shape') {
@@ -343,8 +349,11 @@ vi.mock('../../utils/packageUtils', () => ({
           name: 'mock-package-browser-conditional',
           exports: {
             '.': {
-              worker: {
+              node: {
                 import: './dist/server.js',
+              },
+              worker: {
+                import: './dist/worker.js',
               },
               browser: {
                 import: './dist/browser.js',
@@ -414,6 +423,8 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-browser-conditional/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-browser-conditional/dist/server.js') ||
       filePath.endsWith('/mock-package-browser-conditional/dist/server.js') ||
+      filePath.endsWith('node_modules/mock-package-browser-conditional/dist/worker.js') ||
+      filePath.endsWith('/mock-package-browser-conditional/dist/worker.js') ||
       filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-cjs-comment/index.js') ||
@@ -705,8 +716,11 @@ export const [firstItem, ...restItems] = tuple;`;
         name: 'mock-package-browser-conditional',
         exports: {
           '.': {
-            worker: {
+            node: {
               import: './dist/server.js',
+            },
+            worker: {
+              import: './dist/worker.js',
             },
             browser: {
               import: './dist/browser.js',
@@ -721,6 +735,9 @@ export const [firstItem, ...restItems] = tuple;`;
     }
     if (filePath.endsWith('node_modules/mock-package-browser-conditional/dist/server.js')) {
       return 'export const serverOnly = true;';
+    }
+    if (filePath.endsWith('node_modules/mock-package-browser-conditional/dist/worker.js')) {
+      return 'export const workerOnly = true;';
     }
     if (filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js')) {
       return 'export const browserNamed = true;';
@@ -2242,6 +2259,89 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('serverOnly');
   });
 
+  it('uses node conditional exports when detecting shared ESM named exports for SSR', () => {
+    const pkg = 'mock-package-browser-conditional';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, [
+      'node',
+      'import',
+      'default',
+    ]);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('__mf_0 as serverOnly');
+    expect(generatedCode).not.toContain('clientOnly');
+    expect(generatedCode).not.toContain('workerOnly');
+  });
+
+  it('uses worker conditional exports for webworker SSR', () => {
+    const pkg = 'mock-package-browser-conditional';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, [
+      'worker',
+      'browser',
+      'import',
+      'default',
+    ]);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('__mf_0 as workerOnly');
+    expect(generatedCode).not.toContain('serverOnly');
+  });
+
+  it('uses the same export conditions for shareConfig.import package sources', () => {
+    const pkg = 'conditional-package-alias';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: 'mock-package-browser-conditional',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, [
+      'node',
+      'import',
+      'default',
+    ]);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('__mf_0 as serverOnly');
+    expect(generatedCode).not.toContain('clientOnly');
+  });
+
   it('uses the Vite import entry when the require condition has a different shape', () => {
     const pkg = 'mock-package-dual-shape';
     const mockShareItem: ShareItem = {
@@ -3201,6 +3301,20 @@ describe('writePreBuildLibPath', () => {
       'export default Reflect.get(__mfPrebuildNamespace, "default") ?? __mfPrebuildNamespace;'
     );
     expect(generatedCode).not.toMatch(/export default __mfPrebuildExports;\s*$/m);
+  });
+
+  it('uses node conditional exports for SSR prebuild wrappers', () => {
+    writePreBuildLibPath('mock-package-browser-conditional', undefined, undefined, [
+      'node',
+      'import',
+      'default',
+    ]);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('__mf_0 as serverOnly');
+    expect(generatedCode).not.toContain('clientOnly');
+    expect(generatedCode).not.toContain('workerOnly');
   });
 
   // ── pendingShareLoads: deferred export assignment ──────────────────────────

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -145,7 +145,12 @@ function inspectSharedExportsFromFile(
   }
 }
 
-function resolveConfiguredImportPath(importSource: string): string | undefined {
+const DEFAULT_SHARED_EXPORT_CONDITIONS = ['browser', 'import', 'module', 'default'];
+
+function resolveConfiguredImportPath(
+  importSource: string,
+  exportConditions = DEFAULT_SHARED_EXPORT_CONDITIONS
+): string | undefined {
   if (path.isAbsolute(importSource)) {
     return resolveFileLikeModule(importSource);
   }
@@ -156,7 +161,7 @@ function resolveConfiguredImportPath(importSource: string): string | undefined {
   }
 
   const esmEntry = getInstalledPackageEntry(importSource, {
-    conditions: ['browser', 'import', 'module', 'default'],
+    conditions: exportConditions,
     resolveSubpathWithRequire: false,
   });
   if (esmEntry) return esmEntry;
@@ -558,12 +563,15 @@ function getRequiredNamedExports(specifier: string): string[] | undefined {
   }
 }
 
-function getPackageNamedExports(pkg: string): string[] | undefined {
-  // Inspect the browser/import entry that Vite will bundle before considering
-  // the package's require condition. Dual-format packages can expose different
-  // APIs from those two entry points.
+function getPackageNamedExports(
+  pkg: string,
+  exportConditions = DEFAULT_SHARED_EXPORT_CONDITIONS
+): string[] | undefined {
+  // Inspect the entry selected by the active Vite environment before
+  // considering the package's require condition. Dual-format and
+  // browser/server packages can expose different APIs from those entry points.
   const esmEntryPath = getInstalledPackageEntry(pkg, {
-    conditions: ['browser', 'import', 'module', 'default'],
+    conditions: exportConditions,
     resolveSubpathWithRequire: false,
   });
   if (esmEntryPath) {
@@ -583,10 +591,14 @@ function getPackageNamedExports(pkg: string): string[] | undefined {
   return getRequiredNamedExports(pkg);
 }
 
-export function getSharedNamedExports(pkg: string, shareItem?: ShareItem): string[] | undefined {
+export function getSharedNamedExports(
+  pkg: string,
+  shareItem?: ShareItem,
+  exportConditions = DEFAULT_SHARED_EXPORT_CONDITIONS
+): string[] | undefined {
   const configuredImport = shareItem?.shareConfig.import;
   if (typeof configuredImport === 'string') {
-    const configuredImportPath = resolveConfiguredImportPath(configuredImport);
+    const configuredImportPath = resolveConfiguredImportPath(configuredImport, exportConditions);
     // The configured source is authoritative. Do not fall back to the package
     // entry when that source is default-only or cannot be inspected: its export
     // shape may intentionally differ from the package root.
@@ -601,7 +613,7 @@ export function getSharedNamedExports(pkg: string, shareItem?: ShareItem): strin
     return undefined;
   }
 
-  return getPackageNamedExports(pkg);
+  return getPackageNamedExports(pkg, exportConditions);
 }
 
 export function getLocalProviderImportPath(pkg: string): string | undefined {
@@ -1048,7 +1060,8 @@ export default { get, init };
 export function writePreBuildLibPath(
   pkg: string,
   shareItem?: ShareItem,
-  options?: NormalizedModuleFederationOptions
+  options?: NormalizedModuleFederationOptions,
+  exportConditions?: string[]
 ) {
   const { preBuildCacheMap, preBuildShareItemMap } = getSharedVirtualModuleState(options);
   if (!preBuildCacheMap[pkg]) {
@@ -1113,7 +1126,7 @@ export function writePreBuildLibPath(
     );
     return;
   }
-  const namedExports = getSharedNamedExports(pkg, shareItem) ?? [];
+  const namedExports = getSharedNamedExports(pkg, shareItem, exportConditions) ?? [];
   if (namedExports.length > 0) {
     const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
     const declarations = namedExports
@@ -1219,21 +1232,29 @@ export function getLoadShareModulePath(
   return filepath;
 }
 
-export function getCachedLoadSharePkg(id: string): string | undefined {
-  // Most resolved ids are not loadShare virtual ids. Fast reject before
+function getCachedSharedVirtualPkg(id: string, tag: string): string | undefined {
+  // Most resolved ids are not shared virtual ids. Fast reject before
   // normalization/decoding work on the resolveId hot path.
-  if (!id.includes(LOAD_SHARE_TAG)) return;
+  if (!id.includes(tag)) return;
   const normalized = normalizeVirtualModuleId(id);
   if (!normalized.startsWith('virtual:mf:')) return;
 
-  const start = normalized.indexOf(LOAD_SHARE_TAG);
+  const start = normalized.indexOf(tag);
   if (start === -1) return;
 
-  const encodedPkgStart = start + LOAD_SHARE_TAG.length;
-  const end = normalized.indexOf(LOAD_SHARE_TAG, encodedPkgStart);
+  const encodedPkgStart = start + tag.length;
+  const end = normalized.indexOf(tag, encodedPkgStart);
   if (end === -1) return;
 
   return packageNameDecode(normalized.slice(encodedPkgStart, end));
+}
+
+export function getCachedPreBuildPkg(id: string): string | undefined {
+  return getCachedSharedVirtualPkg(id, PREBUILD_TAG);
+}
+
+export function getCachedLoadSharePkg(id: string): string | undefined {
+  return getCachedSharedVirtualPkg(id, LOAD_SHARE_TAG);
 }
 
 export function materializeCachedLoadShareModule(options: {
@@ -1512,7 +1533,8 @@ export function writeLoadShareModule(
   shareItem: ShareItem,
   command: string,
   _isRolldown: boolean,
-  options?: NormalizedModuleFederationOptions
+  options?: NormalizedModuleFederationOptions,
+  exportConditions?: string[]
 ) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const { loadShareCacheMap } = getSharedVirtualModuleState(options);
@@ -1533,7 +1555,7 @@ export function writeLoadShareModule(
     // Try to detect named exports from locally installed devDependencies.
     // This enables `import { ref } from 'vue'` even though the module is provided by the host.
     // For packages that aren't installed, fall back to default-only export.
-    const detectedNamedExports = getPackageNamedExports(pkg);
+    const detectedNamedExports = getPackageNamedExports(pkg, exportConditions);
     const namedExports = detectedNamedExports ?? [];
     let exportLine: string;
     if (namedExports.length > 0) {
@@ -1584,7 +1606,7 @@ export function writeLoadShareModule(
       ? concreteSharedImportSource || localProviderPath || devImportSource
       : concreteSharedImportSource || localProviderPath || sharedImportSource;
   const skipServePrebuildWarmup = command !== 'build' && (pkg === 'lit' || pkg.startsWith('lit/'));
-  const detectedNamedExports = getSharedNamedExports(pkg, shareItem);
+  const detectedNamedExports = getSharedNamedExports(pkg, shareItem, exportConditions);
   const namedExports = detectedNamedExports ?? [];
   const hasCompleteExportCoverage = detectedNamedExports !== undefined;
   const isWorkspaceSingleton = isWorkspacePackage && shareItem.shareConfig.singleton === true;


### PR DESCRIPTION
### Summary

This PR makes shared named-export analysis use the export conditions of the active Vite build environment.

Node SSR builds now inspect the Node entry of conditional packages such as `react-dom/server`, while client and webworker graphs retain their respective condition sets. The change is internal and does not add plugin options or alter the public API.

### Problem

Shared proxy generation always inspected packages with:

```ts
['browser', 'import', 'module', 'default']
```

During a Node SSR production build, this caused the plugin to analyze `react-dom/server.browser.js` even though Vite bundled `react-dom/server.node.js`.

As a result, the generated shared proxy omitted `renderToPipeableStream`, causing the SSR build or emitted server module to fail.

### Root cause

Shared virtual modules were generated and cached without being scoped to the active build environment. As a result, a module first generated with client conditions could be reused by an SSR graph.

This is especially visible with Vite's Environment API, where client and SSR graphs can coexist in the same process.

### Changes

- Select shared export conditions from the active Vite environment.
  - Vite 8: use `this.environment.config.resolve.conditions`.
  - Vite 5–7: derive conditions from `build.ssr`, `ssr.target`, and configured resolve conditions.
- Treat both boolean and entry-string forms of `build.ssr` as SSR builds.
- Regenerate owned `loadShare` and prebuild virtual modules when they are loaded, preventing one environment from reusing another environment's export surface.
- Apply the same conditions to package roots and `shareConfig.import` package sources.
- Preserve the existing browser-first behavior when no environment conditions are supplied.
- Use worker/browser fallback conditions for webworker SSR instead of Node conditions.
- Add a React 19 production SSR regression test by reusing an existing workspace package, without changing workspace configuration, dependencies, or the lockfile.

### Review guide

1. `src/utils/sharedExportConditions.ts`
   - Condition selection for Vite environments and Vite 5–7 fallback behavior.
2. `src/virtualModules/virtualShared_preBuild.ts`
   - Condition-aware package entry resolution and named-export analysis.
3. `src/index.ts`
   - Per-environment virtual-module refresh and ownership checks.
4. Tests
   - Unit coverage for client, Node SSR, webworker SSR, `shareConfig.import`, and string-valued `build.ssr`.
   - Integration coverage that builds and imports a React 19 SSR bundle and verifies `renderToPipeableStream`.

### Validation

- `pnpm test` — 937 passed, 1 skipped
- `pnpm test:integration` — 52 passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm fmt.check`
- `pnpm exec oxfmt --check integration/ssr-shared-exports.test.ts`
- React 19 SSR regression passed with:
  - Vite 5.4.21
  - Vite 6.4.2
  - Vite 7.3.2
  - Vite 8.1.0