### PR TITLE
chore: support React SSR islands

### DIFF
--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -12,6 +12,7 @@ import {
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
+import { getReactIslandExposes } from '../utils/reactIsland';
 import { filterId, resolvePublicPath } from '../utils/pathNormalization';
 import {
   generateExposes,
@@ -47,6 +48,7 @@ export default function ({
   let exposeRemoteDependenciesDirty = true;
   let refreshPromise: Promise<void> | undefined;
   let dependencyInvalidationVersion = 0;
+  let reactIslandExposes: ReadonlySet<string> = new Set();
 
   const isHostAutoInitId = (id: string) => {
     const cleanId = id.split('?')[0];
@@ -144,6 +146,7 @@ export default function ({
     configResolved(config) {
       viteConfig = config;
       root = config.root;
+      reactIslandExposes = getReactIslandExposes(options, root);
     },
     config(config, { command }) {
       _command = command;
@@ -206,7 +209,7 @@ export default function ({
       }
       if (id === virtualExposesId) {
         await refreshExposeRemoteDependencies(this);
-        return generateExposes(options, exposeRemoteDependencies, _command);
+        return generateExposes(options, exposeRemoteDependencies, _command, reactIslandExposes);
       }
       if (_command === 'serve' && isHostAutoInitId(id)) {
         return id;
@@ -220,7 +223,7 @@ export default function ({
         }
         if (id === virtualExposesId) {
           await refreshExposeRemoteDependencies(this);
-          return generateExposes(options, exposeRemoteDependencies, _command);
+          return generateExposes(options, exposeRemoteDependencies, _command, reactIslandExposes);
         }
         if (isHostAutoInitId(id)) {
           if (_command === 'serve') {

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { Plugin, ResolvedConfig } from 'vite';
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { getIsRolldown, isNuxtProjectRoot } from '../utils/packageUtils';
+import { getReactIslandExposes } from '../utils/reactIsland';
 import { getBasePath, isNuxtClientBase } from '../utils/pathNormalization';
 import { decodeViteId } from '../utils/VirtualModule';
 import { generateExposesSSR, getVirtualExposesSSRId } from '../virtualModules/virtualExposesSSR';
@@ -246,6 +247,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let isServe = false;
   let viteConfig: ResolvedConfig | undefined;
   let isNuxtProject = false;
+  let reactIslandExposes: ReadonlySet<string> = new Set();
 
   const findNuxtExposesChunk = (
     bundle: Record<string, { type: string; fileName: string; code?: string }>
@@ -332,6 +334,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
       configResolved(config) {
         viteConfig = config;
         isNuxtProject = isNuxtProjectRoot(config.root);
+        reactIslandExposes = getReactIslandExposes(options, config.root);
       },
 
       configureServer(server) {
@@ -463,7 +466,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         server.middlewares.use(exposesPath, (_req, res) => {
           res.setHeader('Content-Type', 'application/javascript');
           res.setHeader('Access-Control-Allow-Origin', '*');
-          res.end(generateExposesSSR(options));
+          res.end(generateExposesSSR(options, reactIslandExposes));
         });
       },
 
@@ -486,7 +489,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
           return generateRemoteEntrySSR(options);
         }
         if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) {
-          return generateExposesSSR(options);
+          return generateExposesSSR(options, reactIslandExposes);
         }
       },
 

--- a/src/utils/__tests__/helpers.ts
+++ b/src/utils/__tests__/helpers.ts
@@ -24,6 +24,7 @@ export function getDefaultMockOptions(
     experiments: {
       externalRuntime: false,
       provideExternalRuntime: false,
+      ssrMode: undefined,
     },
     ...overrides,
   };

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -62,8 +62,35 @@ describe('normalizeModuleFederationOption', () => {
       experiments: {
         externalRuntime: false,
         provideExternalRuntime: false,
+        ssrMode: undefined,
       },
     });
+  });
+
+  it('normalizes experiments.ssrMode as an explicit island opt-in', () => {
+    expect(normalizeModuleFederationOptions(minimalOptions).experiments.ssrMode).toBeUndefined();
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        experiments: { ssrMode: 'ISLAND' },
+      }).experiments.ssrMode
+    ).toBe('ISLAND');
+  });
+
+  it('warns when island mode is combined with shared React', () => {
+    mfWarnSpy.mockClear();
+
+    normalizeModuleFederationOptions({
+      ...minimalOptions,
+      experiments: { ssrMode: 'ISLAND' },
+      shared: { react: { singleton: true } },
+    });
+
+    expect(mfWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Island expose generation is disabled because experiments.ssrMode is "ISLAND" and React is configured as shared'
+      )
+    );
   });
 
   it('normalizes experiments.externalRuntime and provideExternalRuntime', () => {

--- a/src/utils/__tests__/reactIsland.test.ts
+++ b/src/utils/__tests__/reactIsland.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getReactIslandExposes, isReactComponentSource } from '../reactIsland';
+import { getDefaultMockOptions } from './helpers';
+
+const temporaryDirectories: string[] = [];
+
+function temporaryProject() {
+  const directory = mkdtempSync(path.join(tmpdir(), 'mf-react-island-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('react island source classification', () => {
+  it('recognizes default React components but not non-UI or named-only modules', () => {
+    expect(
+      isReactComponentSource(
+        `import React from 'react'; export default function Button() { return <button /> }`,
+        'Button.tsx'
+      )
+    ).toBe(true);
+    expect(
+      isReactComponentSource(`export default function value() { return 42 }`, 'value.ts')
+    ).toBe(false);
+    expect(
+      isReactComponentSource(`export function Button() { return <button /> }`, 'Button.tsx')
+    ).toBe(false);
+  });
+
+  it('follows a simple local default re-export in island mode and disables islands when react is shared', () => {
+    const root = temporaryProject();
+    writeFileSync(
+      path.join(root, 'Button.tsx'),
+      `export default function Button() { return <button /> }`
+    );
+    writeFileSync(path.join(root, 'index.ts'), `export { default } from './Button'`);
+
+    const options = getDefaultMockOptions({
+      exposes: { './Button': { import: './index.ts' } as any },
+      experiments: {
+        externalRuntime: false,
+        provideExternalRuntime: false,
+        ssrMode: 'ISLAND',
+      },
+    });
+    expect([...getReactIslandExposes(options, root)]).toEqual(['./Button']);
+
+    options.shared.react = {} as any;
+    expect([...getReactIslandExposes(options, root)]).toEqual([]);
+  });
+
+  it('does not classify exposes when experiments.ssrMode is absent', () => {
+    const root = temporaryProject();
+    writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'plain-vite-remote' }));
+    writeFileSync(
+      path.join(root, 'Button.tsx'),
+      `export default function Button() { return <button /> }`
+    );
+
+    const options = getDefaultMockOptions({
+      exposes: { './Button': { import: './Button.tsx' } as any },
+    });
+    expect([...getReactIslandExposes(options, root)]).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -1196,27 +1196,29 @@ describe('ssrEntryLoaderPlugin — code transformation', () => {
 // ---------------------------------------------------------------------------
 
 /**
- * freshLoaderWithRunner — like freshLoader but also configures vite/module-runner
- * via vi.doMock (not hoisted) so per-test ModuleRunner behaviour can be injected.
+ * freshLoaderWithRunner — like freshLoader but configures Node's createRequire
+ * so per-test ModuleRunner behaviour can be injected.
  */
 async function freshLoaderWithRunner(
   runnerFactory: () => { import: (id: string) => Promise<unknown> } | null
 ) {
   vi.resetModules();
+  const impl = runnerFactory();
+  const runnerModule =
+    impl === null
+      ? null
+      : {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ModuleRunner: vi.fn(function (this: any) {
+            return impl;
+          }),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ESModulesEvaluator: vi.fn(function (this: any) {
+            return {};
+          }),
+        };
   vi.doMock('vite/module-runner', () => {
-    const impl = runnerFactory();
-    if (impl === null) throw new Error('module not found');
-    // Must use regular functions (not arrow functions) so they're newable.
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ModuleRunner: vi.fn(function (this: any) {
-        return impl;
-      }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ESModulesEvaluator: vi.fn(function (this: any) {
-        return {};
-      }),
-    };
+    throw new Error('the transformed dynamic import must not be used');
   });
   vi.doMock('path', () => ({
     default: {
@@ -1236,10 +1238,11 @@ async function freshLoaderWithRunner(
     const hash = { update: vi.fn().mockReturnThis(), digest: vi.fn(() => 'abc123def456789') };
     return { default: { createHash: vi.fn(() => hash) }, createHash: vi.fn(() => hash) };
   });
-  vi.doMock('module', () => ({
-    default: { createRequire: vi.fn() },
-    createRequire: vi.fn(),
-  }));
+  const createRequire = vi.fn(() => (id: string) => {
+    if (id !== 'vite/module-runner' || runnerModule === null) throw new Error('module not found');
+    return runnerModule;
+  });
+  vi.doMock('module', () => ({ default: { createRequire }, createRequire }));
   const { default: factory } = await import('../ssrEntryLoader');
   return factory;
 }

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -458,6 +458,7 @@ function normalizeExperiments(
   return {
     externalRuntime: experiments?.externalRuntime === true,
     provideExternalRuntime: experiments?.provideExternalRuntime === true,
+    ssrMode: experiments?.ssrMode === 'ISLAND' ? 'ISLAND' : undefined,
   };
 }
 
@@ -585,11 +586,14 @@ export interface PluginExperimentsOptions {
    * publishes `runtime-core` on `globalThis._FEDERATION_RUNTIME_CORE`.
    */
   provideExternalRuntime?: boolean;
+  /** Generate the React SSR/hydration island capability for eligible exposes. */
+  ssrMode?: 'ISLAND';
 }
 
 export interface NormalizedExperimentsOptions {
   externalRuntime: boolean;
   provideExternalRuntime: boolean;
+  ssrMode: 'ISLAND' | undefined;
 }
 
 export interface NormalizedModuleFederationOptions extends Omit<
@@ -806,6 +810,15 @@ export function normalizeModuleFederationOptions(
     disableSnapshot: options.disableSnapshot,
     experiments: normalizeExperiments(options.experiments),
   };
+  if (
+    normalized.experiments.ssrMode === 'ISLAND' &&
+    Object.prototype.hasOwnProperty.call(normalized.shared, 'react')
+  ) {
+    mfWarn(
+      'Island expose generation is disabled because experiments.ssrMode is "ISLAND" and React is configured as shared. ' +
+        'Remove "react" from shared to generate island exposes, or remove ssrMode to use standard shared rendering.'
+    );
+  }
   explicitSharedKeysByOptions.set(normalized, new Set(explicitSharedKeys));
   return (config = normalized);
 }

--- a/src/utils/reactIsland.ts
+++ b/src/utils/reactIsland.ts
@@ -1,0 +1,159 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { NormalizedModuleFederationOptions } from './normalizeModuleFederationOptions';
+
+const SOURCE_EXTENSIONS = ['.tsx', '.jsx', '.ts', '.js', '.mts', '.mjs', '.cts', '.cjs'];
+
+function stripQueryAndHash(id: string) {
+  return id.split(/[?#]/, 1)[0];
+}
+
+function resolveSourceFile(importPath: string, root: string): string | undefined {
+  const cleanImport = stripQueryAndHash(importPath);
+  if (!cleanImport.startsWith('.') && !path.isAbsolute(cleanImport)) return;
+
+  const candidate = path.isAbsolute(cleanImport) ? cleanImport : path.resolve(root, cleanImport);
+  const candidates = [
+    candidate,
+    ...SOURCE_EXTENSIONS.map((extension) => `${candidate}${extension}`),
+    ...SOURCE_EXTENSIONS.map((extension) => path.join(candidate, `index${extension}`)),
+  ];
+  return candidates.find((filePath) => {
+    try {
+      return fs.statSync(filePath).isFile();
+    } catch {
+      return false;
+    }
+  });
+}
+
+function localDefaultReexport(source: string): string | undefined {
+  const match = source.match(
+    /export\s*{\s*(?:default(?:\s+as\s+default)?|[A-Za-z_$][\w$]*\s+as\s+default)\s*}\s*from\s*["']([^"']+)["']/
+  );
+  return match?.[1]?.startsWith('.') ? match[1] : undefined;
+}
+
+export function isReactComponentSource(source: string, filePath = 'component.tsx'): boolean {
+  const hasDefaultExport =
+    /\bexport\s+default\b/.test(source) ||
+    /\bexport\s*{[^}]*\bdefault\b[^}]*}(?:\s*from\s*["'][^"']+["'])?/.test(source);
+  if (!hasDefaultExport) return false;
+
+  const extension = path.extname(stripQueryAndHash(filePath)).toLowerCase();
+  const canContainJsx = extension === '.tsx' || extension === '.jsx';
+  const hasJsx = /<>|<\s*[A-Za-z][\w.:-]*(?:\s[^<>]*?)?\s*\/?>/.test(source);
+  const importsReact = /\bfrom\s*["']react["']|\brequire\(\s*["']react["']\s*\)/.test(source);
+  const usesReactApi = /\b(?:React\.)?(?:createElement|jsx|jsxs)\s*\(/.test(source);
+  const isClientModule = /^\s*["']use client["']\s*;?/m.test(source);
+
+  return (canContainJsx && hasJsx) || (importsReact && (hasJsx || usesReactApi || isClientModule));
+}
+
+function isReactComponentFile(filePath: string, seen = new Set<string>()): boolean {
+  const normalizedPath = path.resolve(filePath);
+  if (seen.has(normalizedPath)) return false;
+  seen.add(normalizedPath);
+
+  let source: string;
+  try {
+    source = fs.readFileSync(normalizedPath, 'utf8');
+  } catch {
+    return false;
+  }
+  if (isReactComponentSource(source, normalizedPath)) return true;
+
+  const reexport = localDefaultReexport(source);
+  if (!reexport) return false;
+  const reexportPath = resolveSourceFile(reexport, path.dirname(normalizedPath));
+  return reexportPath ? isReactComponentFile(reexportPath, seen) : false;
+}
+
+/**
+ * React is shared by the normal MF runtime when explicitly configured. When it
+ * is local, UI exposes can safely advertise an island capability in addition
+ * to their unchanged default export.
+ */
+export function getReactIslandExposes(
+  options: Pick<NormalizedModuleFederationOptions, 'experiments' | 'exposes' | 'shared'>,
+  root: string
+): ReadonlySet<string> {
+  if (options.experiments.ssrMode !== 'ISLAND') return new Set();
+  if (Object.prototype.hasOwnProperty.call(options.shared, 'react')) return new Set();
+
+  const islandExposes = new Set<string>();
+  for (const [key, expose] of Object.entries(options.exposes)) {
+    const sourceFile = resolveSourceFile(expose.import, root);
+    if (sourceFile && isReactComponentFile(sourceFile)) islandExposes.add(key);
+  }
+  return islandExposes;
+}
+
+export function generateReactIslandBrowserDefinition(enabled: boolean): string {
+  if (!enabled) return '';
+
+  return `
+          exportModule.__mf_island = {
+            version: 1,
+            renderToHtml() {
+              return Promise.reject(new Error("[Module Federation] renderToHtml is only available in the SSR remote entry"));
+            },
+            hydrate(element, props) {
+              const root = element && element.hasAttribute && element.hasAttribute("data-mf-island-state")
+                ? element
+                : element && element.querySelector
+                  ? element.querySelector("[data-mf-island-state]") || element
+                  : element;
+              if (!root) {
+                return Promise.reject(new Error("[Module Federation] Cannot hydrate an island without a root element"));
+              }
+              let serverProps = {};
+              const encodedState = root.getAttribute && root.getAttribute("data-mf-island-state");
+              if (encodedState) {
+                try {
+                  serverProps = JSON.parse(decodeURIComponent(encodedState));
+                } catch {
+                  serverProps = {};
+                }
+              }
+              const finalProps = Object.assign({}, serverProps, props || {});
+              return Promise.all([import("react"), import("react-dom/client")]).then(([React, ReactDOMClient]) => {
+                if (typeof ReactDOMClient.hydrateRoot !== "function") {
+                  throw new Error("[Module Federation] react-dom/client does not provide hydrateRoot");
+                }
+                return ReactDOMClient.hydrateRoot(
+                  root,
+                  React.createElement(importModule.default, finalProps)
+                );
+              });
+            }
+          }`;
+}
+
+export function generateReactIslandSSRDefinition(enabled: boolean): string {
+  if (!enabled) return '';
+
+  return `
+          exportModule.__mf_island = {
+            version: 1,
+            async renderToHtml(props) {
+              if (typeof importModule.default !== "function" && typeof importModule.default !== "object") {
+                throw new Error("[Module Federation] A React island expose must have a default component export");
+              }
+              const loadedProps = typeof importModule.load === "function" ? await importModule.load() : {};
+              const finalProps = Object.assign({}, loadedProps || {}, props || {});
+              const [React, ReactDOMServer] = await Promise.all([
+                import("react"),
+                import("react-dom/server")
+              ]);
+              const body = ReactDOMServer.renderToString(
+                React.createElement(importModule.default, finalProps)
+              );
+              const state = encodeURIComponent(JSON.stringify(finalProps));
+              return '<div data-mf-island-state="' + state + '">' + body + '</div>';
+            },
+            hydrate() {
+              return Promise.reject(new Error("[Module Federation] hydrate is only available in the browser remote entry"));
+            }
+          }`;
+}

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -59,9 +59,8 @@ const isNodeServer = (): boolean =>
 const runnerCache = new Map<string, Promise<unknown>>();
 
 /**
- * Import `vite/module-runner` dynamically. Returns null on Vite < 8 where the
- * subpath doesn't exist. Uses a plain dynamic import (not nodeImport) so that
- * Vitest can intercept it with vi.mock in tests.
+ * Load `vite/module-runner`. Returns null on Vite < 8 where the subpath doesn't
+ * exist.
  */
 async function getModuleRunnerModule(): Promise<{
   ModuleRunner: new (
@@ -79,10 +78,17 @@ async function getModuleRunnerModule(): Promise<{
   ) => { import: (id: string) => Promise<unknown> };
   ESModulesEvaluator: new () => unknown;
 } | null> {
+  // Prefer Node's loader. When this plugin itself runs inside another Vite
+  // ModuleRunner (for example Vinext RSC), a regular import lets the host
+  // transform Vite's own module-runner and breaks its internal import(filepath).
   try {
-    // Dynamic import without @vite-ignore so Vitest can intercept via vi.mock.
-    // This module is server-side only (guarded by window check in loadEntry)
-    // so it's safe to import here without worrying about browser bundles.
+    const { createRequire } = (await nodeImport('module')) as typeof import('module');
+    const require = createRequire(import.meta.url);
+    return require('vite/module-runner') as Awaited<ReturnType<typeof getModuleRunnerModule>>;
+  } catch {
+    // Retain an ESM fallback for releases which cannot be required and tests.
+  }
+  try {
     return (await import('vite/module-runner')) as Awaited<
       ReturnType<typeof getModuleRunnerModule>
     >;

--- a/src/virtualModules/__tests__/virtualExposes.test.ts
+++ b/src/virtualModules/__tests__/virtualExposes.test.ts
@@ -66,6 +66,41 @@ describe('virtualExposes', () => {
     expect(cssBundleCode).toContain(`const cssAssetMap = "${getExposesCssMapPlaceholder()}";`);
   });
 
+  it('adds a lazy browser hydration capability without changing the default export', async () => {
+    const code = generateExposes(
+      getDefaultMockOptions({
+        exposes: { './Button': { import: './Button.tsx' } as any },
+      }),
+      {},
+      'build',
+      new Set(['./Button'])
+    );
+    const hydrateRoot = vi.fn(() => ({ hydrated: true }));
+    const dynamicImport = vi.fn((id: string) => {
+      if (id === './Button.tsx') return Promise.resolve({ default: 'Button' });
+      if (id === 'react') return Promise.resolve({ createElement: vi.fn(() => 'element') });
+      if (id === 'react-dom/client') return Promise.resolve({ hydrateRoot });
+      return Promise.reject(new Error(`unexpected import: ${id}`));
+    });
+    const exposes = await toRunnableModule(code)(
+      undefined,
+      URL,
+      dynamicImport,
+      'file:///repo/remoteEntry.js'
+    );
+    const module = (await exposes['./Button']()) as any;
+
+    expect(module.default).toBe('Button');
+    expect(module.__mf_island.version).toBe(1);
+    const root = {
+      hasAttribute: () => true,
+      getAttribute: () => encodeURIComponent(JSON.stringify({ fromServer: true })),
+    };
+    await module.__mf_island.hydrate(root, { fromClient: true });
+    expect(hydrateRoot).toHaveBeenCalledWith(root, 'element');
+    expect(code.trimStart()).toMatch(/^const\s/);
+  });
+
   it('injects css once and serializes module imports across concurrent expose loads', async () => {
     const code = generateExposes(
       getDefaultMockOptions({

--- a/src/virtualModules/__tests__/virtualExposesSSR.test.ts
+++ b/src/virtualModules/__tests__/virtualExposesSSR.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getDefaultMockOptions } from '../../utils/__tests__/helpers';
+import { generateExposesSSR } from '../virtualExposesSSR';
+
+function toRunnableModule(code: string) {
+  const transformed = code
+    .replace('export default', 'return')
+    .replace(/import\((".*?")\)/g, '__dynamicImport($1)');
+  return new Function('__dynamicImport', `return (async () => {${transformed}\n})();`) as (
+    dynamicImport: (id: string) => Promise<unknown>
+  ) => Promise<Record<string, () => Promise<unknown>>>;
+}
+
+describe('virtualExposesSSR', () => {
+  it('renders a local React expose as serialized island HTML without top-level await', async () => {
+    const code = generateExposesSSR(
+      getDefaultMockOptions({
+        exposes: { './Counter': { import: './Counter.tsx' } as any },
+      }),
+      new Set(['./Counter'])
+    );
+    const createElement = vi.fn((_component, props) => ({ props }));
+    const dynamicImport = vi.fn((id: string) => {
+      if (id === './Counter.tsx') {
+        return Promise.resolve({ default: () => null, load: async () => ({ loaded: true }) });
+      }
+      if (id === 'react') return Promise.resolve({ createElement });
+      if (id === 'react-dom/server') {
+        return Promise.resolve({ renderToString: (element: unknown) => JSON.stringify(element) });
+      }
+      return Promise.reject(new Error(`unexpected import: ${id}`));
+    });
+    const exposes = await toRunnableModule(code)(dynamicImport);
+    const module = (await exposes['./Counter']()) as any;
+    const html = await module.__mf_island.renderToHtml({ count: 2 });
+
+    expect(decodeURIComponent(html.match(/data-mf-island-state="([^"]+)"/)![1])).toBe(
+      JSON.stringify({ loaded: true, count: 2 })
+    );
+    expect(html).toContain('{"props":{"loaded":true,"count":2}}');
+    expect(code.trimStart()).toMatch(/^export default\s/);
+  });
+
+  it('does not add island code to ordinary exposes', () => {
+    const code = generateExposesSSR(
+      getDefaultMockOptions({ exposes: { './data': { import: './data.ts' } as any } })
+    );
+    expect(code).not.toContain('__mf_island');
+    expect(code).not.toContain('react-dom/server');
+  });
+});

--- a/src/virtualModules/virtualExposes.ts
+++ b/src/virtualModules/virtualExposes.ts
@@ -1,4 +1,5 @@
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import { generateReactIslandBrowserDefinition } from '../utils/reactIsland';
 import { getRemoteVirtualModule } from './virtualRemotes';
 
 const EXPOSES_CSS_MAP_PLACEHOLDER = '__MF_EXPOSES_CSS_MAP__';
@@ -17,7 +18,8 @@ export function getVirtualExposesId(
 export function generateExposes(
   options: NormalizedModuleFederationOptions,
   remoteDependencyMap: Record<string, string[]> = {},
-  command = 'build'
+  command = 'build',
+  reactIslandExposes: ReadonlySet<string> = new Set()
 ) {
   return `
     const cssAssetMap = ${JSON.stringify(options.bundleAllCSS ? EXPOSES_CSS_MAP_PLACEHOLDER : {})};
@@ -103,6 +105,7 @@ export function generateExposes(
           }
           const exportModule = {}
           Object.assign(exportModule, importModule)
+          ${generateReactIslandBrowserDefinition(reactIslandExposes.has(key))}
           Object.defineProperty(exportModule, "__esModule", {
             value: true,
             enumerable: false

--- a/src/virtualModules/virtualExposesSSR.ts
+++ b/src/virtualModules/virtualExposesSSR.ts
@@ -1,4 +1,5 @@
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import { generateReactIslandSSRDefinition } from '../utils/reactIsland';
 
 /**
  * Virtual module ID for the SSR exposes map.
@@ -21,7 +22,10 @@ export function getVirtualExposesSSRId(
  *   build so Node resolves them via its own module cache — this is what
  *   guarantees the React singleton is shared with react-dom/server.
  */
-export function generateExposesSSR(options: NormalizedModuleFederationOptions) {
+export function generateExposesSSR(
+  options: NormalizedModuleFederationOptions,
+  reactIslandExposes: ReadonlySet<string> = new Set()
+) {
   return `
     export default {
     ${Object.keys(options.exposes)
@@ -31,6 +35,7 @@ export function generateExposesSSR(options: NormalizedModuleFederationOptions) {
           const importModule = await import(${JSON.stringify(options.exposes[key].import)})
           const exportModule = {}
           Object.assign(exportModule, importModule)
+          ${generateReactIslandSSRDefinition(reactIslandExposes.has(key))}
           Object.defineProperty(exportModule, "__esModule", {
             value: true,
             enumerable: false


### PR DESCRIPTION
Adds experimental React SSR islands with server rendering and client hydration. 

> [!CAUTION] 
> Do not use in production; the API will change.