### PR TITLE
fix: propagate conditions through re-exports

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -184,6 +184,12 @@ vi.mock('../../utils/packageUtils', () => ({
     if (pkg === 'mock-package-star-dependency') {
       return '/repo/apps/remote/node_modules/mock-package-star-dependency/index.js';
     }
+    if (pkg === 'mock-package-conditional-star-entry') {
+      return '/repo/apps/remote/node_modules/mock-package-conditional-star-entry/index.js';
+    }
+    if (pkg === 'mock-package-cjs-star-entry') {
+      return '/repo/apps/remote/node_modules/mock-package-cjs-star-entry/index.mjs';
+    }
     if (pkg === 'mock-package-esm-only/stores' || pkg === 'mock-package-esm-only') {
       return '/repo/apps/remote/node_modules/mock-package-esm-only/dist/stores.js';
     }
@@ -442,6 +448,12 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-mode-conditional/dist/production.js') ||
       filePath.endsWith('node_modules/mock-package-mode-conditional/dist/default.js') ||
       filePath.endsWith('/mock-package-mode-conditional/dist/default.js') ||
+      filePath.endsWith('node_modules/mock-package-conditional-star-entry/index.js') ||
+      filePath.endsWith('/mock-package-conditional-star-entry/index.js') ||
+      filePath.endsWith('node_modules/mock-package-cjs-star-entry/index.mjs') ||
+      filePath.endsWith('/mock-package-cjs-star-entry/index.mjs') ||
+      filePath.endsWith('node_modules/mock-package-cjs-star-entry/index.cjs') ||
+      filePath.endsWith('/mock-package-cjs-star-entry/index.cjs') ||
       filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-cjs-comment/index.js') ||
@@ -607,6 +619,15 @@ export const buttonBase = 1;`;
     }
     if (filePath.endsWith('node_modules/mock-package-star-dependency/index.js')) {
       return 'export const fromStar = 1; export function anotherFromStar() {}';
+    }
+    if (filePath.endsWith('node_modules/mock-package-conditional-star-entry/index.js')) {
+      return "export * from 'mock-package-browser-conditional';";
+    }
+    if (filePath.endsWith('node_modules/mock-package-cjs-star-entry/index.mjs')) {
+      return "export * from './index.cjs';";
+    }
+    if (filePath.endsWith('node_modules/mock-package-cjs-star-entry/index.cjs')) {
+      return 'module.exports = { fromCommonJs: true };';
     }
     if (
       filePath.endsWith('node_modules/lit/package.json') ||
@@ -906,6 +927,11 @@ vi.mock('module', async (importOriginal) => {
             real: 1,
             default: {},
             __esModule: true,
+          };
+        }
+        if (pkg.endsWith('/mock-package-cjs-star-entry/index.cjs')) {
+          return {
+            fromCommonJs: true,
           };
         }
         if (pkg.endsWith('/react/jsx-runtime.js')) {
@@ -2404,6 +2430,22 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('__mf_0 as serverOnly');
     expect(generatedCode).not.toContain('clientOnly');
     expect(generatedCode).not.toContain('workerOnly');
+  });
+
+  it('preserves node conditions through bare package star re-exports', () => {
+    expect(
+      getSharedNamedExports('mock-package-conditional-star-entry', undefined, [
+        'node',
+        'import',
+        'default',
+      ])
+    ).toEqual(['serverOnly']);
+  });
+
+  it('detects named exports re-exported from a CommonJS entry', () => {
+    expect(
+      getSharedNamedExports('mock-package-cjs-star-entry', undefined, ['node', 'import', 'default'])
+    ).toEqual(['fromCommonJs']);
   });
 
   it('uses worker conditional exports for webworker SSR', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -108,6 +108,8 @@ type NamedExportScanState = {
   complete: boolean;
 };
 
+const DEFAULT_SHARED_EXPORT_CONDITIONS = ['browser', 'import', 'module', 'default'];
+
 function hasCodeMatch(source: string, regex: RegExp, codePositions: boolean[]): boolean {
   regex.lastIndex = 0;
   let match: RegExpExecArray | null;
@@ -127,13 +129,20 @@ function hasCommonJsExports(source: string): boolean {
 }
 
 function inspectSharedExportsFromFile(
-  entryPath: string | undefined
+  entryPath: string | undefined,
+  exportConditions = DEFAULT_SHARED_EXPORT_CONDITIONS
 ): SharedExportInspection | undefined {
   try {
     if (!entryPath) return undefined;
     const source = readFileSync(entryPath, 'utf-8');
     const scanState: NamedExportScanState = { complete: true };
-    const namedExports = getNamedExportsViaRegex(source, entryPath, undefined, scanState);
+    const namedExports = getNamedExportsViaRegex(
+      source,
+      entryPath,
+      undefined,
+      scanState,
+      exportConditions
+    );
     const commonJs = hasCommonJsExports(source);
     return {
       // A complete empty ESM scan is a known default-only export surface. Keep
@@ -145,8 +154,6 @@ function inspectSharedExportsFromFile(
     return undefined;
   }
 }
-
-const DEFAULT_SHARED_EXPORT_CONDITIONS = ['browser', 'import', 'module', 'default'];
 
 function resolveConfiguredImportPath(
   importSource: string,
@@ -211,7 +218,11 @@ function resolveRelativeModule(filePath: string, specifier: string): string | un
   return undefined;
 }
 
-function resolveReExportModule(filePath: string, specifier: string): string | undefined {
+function resolveReExportModule(
+  filePath: string,
+  specifier: string,
+  exportConditions: string[]
+): string | undefined {
   if (specifier.startsWith('.')) return resolveRelativeModule(filePath, specifier);
 
   // Package entry files commonly re-export their public API from another
@@ -220,7 +231,7 @@ function resolveReExportModule(filePath: string, specifier: string): string | un
   // Vite will load, rather than a CommonJS fallback selected by require.
   const esmEntry = getInstalledPackageEntry(specifier, {
     cwd: path.dirname(filePath),
-    conditions: ['browser', 'import', 'module', 'default'],
+    conditions: exportConditions,
     resolveSubpathWithRequire: false,
   });
   if (esmEntry) return esmEntry;
@@ -386,7 +397,8 @@ function getNamedExportsViaRegex(
   source: string,
   filePath?: string,
   visited?: Set<string>,
-  scanState: NamedExportScanState = { complete: true }
+  scanState: NamedExportScanState = { complete: true },
+  exportConditions = DEFAULT_SHARED_EXPORT_CONDITIONS
 ): string[] {
   const names = new Set<string>();
   const codePositions = createCodePositionMap(source);
@@ -508,27 +520,32 @@ function getNamedExportsViaRegex(
       if (!codePositions[match.index]) continue;
       recognizedExportStarts.add(match.index);
       const specifier = match[1];
-      const resolvedPath = resolveReExportModule(filePath, specifier);
+      const resolvedPath = resolveReExportModule(filePath, specifier, exportConditions);
       if (!resolvedPath) {
         scanState.complete = false;
         continue;
       }
       if (visited.has(resolvedPath)) continue;
-      if (path.extname(resolvedPath) === '.cjs') {
-        scanState.complete = false;
-        continue;
-      }
       try {
         const reExportSource = readFileSync(resolvedPath, 'utf-8');
-        if (hasCommonJsExports(reExportSource)) {
-          scanState.complete = false;
+        if (path.extname(resolvedPath) === '.cjs' || hasCommonJsExports(reExportSource)) {
+          // ESM barrels can re-export a CommonJS entry (Vue's Node entry does
+          // this). Preserve its runtime keys so consumers such as vue-demi do
+          // not receive an empty namespace during SSR bundling.
+          const requiredNames = getRequiredNamedExports(resolvedPath);
+          if (!requiredNames?.length) {
+            scanState.complete = false;
+            continue;
+          }
+          for (const name of requiredNames) names.add(name);
           continue;
         }
         const reExportNames = getNamedExportsViaRegex(
           reExportSource,
           resolvedPath,
           visited,
-          scanState
+          scanState,
+          exportConditions
         );
         for (const name of reExportNames) {
           names.add(name);
@@ -590,7 +607,7 @@ function getPackageNamedExports(
     resolveSubpathWithRequire: false,
   });
   if (esmEntryPath) {
-    const inspection = inspectSharedExportsFromFile(esmEntryPath);
+    const inspection = inspectSharedExportsFromFile(esmEntryPath, exportConditions);
 
     // The selected Vite entry may itself be CommonJS. Requiring that exact file
     // gives us its runtime namespace without substituting a different condition.
@@ -617,7 +634,7 @@ export function getSharedNamedExports(
     // The configured source is authoritative. Do not fall back to the package
     // entry when that source is default-only or cannot be inspected: its export
     // shape may intentionally differ from the package root.
-    const inspection = inspectSharedExportsFromFile(configuredImportPath);
+    const inspection = inspectSharedExportsFromFile(configuredImportPath, exportConditions);
     if (
       configuredImportPath &&
       (inspection?.commonJs || path.extname(configuredImportPath) === '.cjs')


### PR DESCRIPTION
Propagates active Vite export conditions through recursive package star re-exports, ensuring SSR and worker builds inspect the same conditional entries that Vite bundles.