### PR TITLE
chore: add opt-in React island adapters

### DIFF
--- a/src/plugins/__tests__/pluginProxyRemotes.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemotes.test.ts
@@ -204,6 +204,28 @@ describe('pluginProxyRemotes', () => {
     );
   });
 
+  it('generates the opt-in React island adapter without changing the remote id', () => {
+    const { plugin } = getSchedulerPluginAndConfig();
+
+    const result = runResolveId(plugin, 'scheduler/SchedulePanel?mf-island', '/repo/src/App.tsx');
+
+    expect(result).toBe('\0virtual:mf-react-island-server:scheduler%2FSchedulePanel');
+    expect(getRemoteVirtualModuleMock).not.toHaveBeenCalled();
+    expect(addUsedRemoteMock).toHaveBeenCalledWith(
+      'scheduler',
+      'scheduler/SchedulePanel',
+      expect.objectContaining({ name: 'host' })
+    );
+
+    const code = callHook(
+      plugin.load,
+      { meta: createPluginMeta() } as unknown as Rollup.PluginContext,
+      result as string
+    );
+    expect(code).toContain('await shell.renderToHtml(props)');
+    expect(code).toContain('import("scheduler/SchedulePanel")');
+  });
+
   it('still proxies bare remote ids from app importers via resolveId', () => {
     const plugin = pluginProxyRemotes(
       normalizeModuleFederationOptions({

--- a/src/plugins/pluginProxyRemotes.ts
+++ b/src/plugins/pluginProxyRemotes.ts
@@ -5,6 +5,12 @@ import { resolveRemoteConsumer } from '../utils/remoteConsumerTarget';
 import { getSsrCapabilities } from '../utils/ssrCapabilities';
 import { getInstalledPackageEntry } from '../utils/packageUtils';
 import { filterId } from '../utils/pathNormalization';
+import {
+  getReactIslandImportRemoteId,
+  getReactIslandServerImportId,
+  loadReactIslandConsumerModule,
+  resolveReactIslandConsumerId,
+} from '../utils/reactIsland';
 import { addUsedRemote, getRemoteVirtualModule, refreshHostAutoInit } from '../virtualModules';
 
 function isNodeModulesImporter(importer?: string) {
@@ -85,11 +91,29 @@ export default function (options: NormalizedModuleFederationOptions): Plugin {
       ).enableSsrInitBootstrap;
     },
     resolveId(source, importer) {
+      const resolvedIslandConsumerId = resolveReactIslandConsumerId(source);
+      if (resolvedIslandConsumerId) return resolvedIslandConsumerId;
+
+      const islandRemoteId = getReactIslandImportRemoteId(source);
+      if (islandRemoteId) {
+        for (const remoteAlias of Object.keys(remotes)) {
+          if (islandRemoteId !== remoteAlias && !islandRemoteId.startsWith(`${remoteAlias}/`)) {
+            continue;
+          }
+          addUsedRemote(remoteAlias, islandRemoteId, options);
+          refreshHostAutoInit(options);
+          return `\0${getReactIslandServerImportId(islandRemoteId)}`;
+        }
+      }
+
       if (!filterId(source)) return;
       for (const remoteAlias of Object.keys(remotes)) {
         if (source !== remoteAlias && !source.startsWith(`${remoteAlias}/`)) continue;
         return resolveRemoteId(this, source, importer, remoteAlias);
       }
+    },
+    load(id) {
+      return loadReactIslandConsumerModule(id);
     },
   };
 }

--- a/src/utils/__tests__/reactIsland.test.ts
+++ b/src/utils/__tests__/reactIsland.test.ts
@@ -2,7 +2,15 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { getReactIslandExposes, isReactComponentSource } from '../reactIsland';
+import {
+  generateReactIslandConsumerClient,
+  generateReactIslandConsumerServer,
+  getReactIslandImportRemoteId,
+  getReactIslandExposes,
+  isReactComponentSource,
+  loadReactIslandConsumerModule,
+  resolveReactIslandConsumerId,
+} from '../reactIsland';
 import { getDefaultMockOptions } from './helpers';
 
 const temporaryDirectories: string[] = [];
@@ -69,5 +77,34 @@ describe('react island source classification', () => {
       exposes: { './Button': { import: './Button.tsx' } as any },
     });
     expect([...getReactIslandExposes(options, root)]).toEqual([]);
+  });
+});
+
+describe('react island consumer import', () => {
+  it('recognizes only the explicit mf-island query parameter', () => {
+    expect(getReactIslandImportRemoteId('remote/Counter?mf-island')).toBe('remote/Counter');
+    expect(getReactIslandImportRemoteId('remote/Counter?raw&mf-island')).toBe('remote/Counter');
+    expect(getReactIslandImportRemoteId('remote/Counter')).toBeUndefined();
+    expect(getReactIslandImportRemoteId('remote/Counter?raw')).toBeUndefined();
+  });
+
+  it('generates a server component and a separate client hydration boundary', () => {
+    const server = generateReactIslandConsumerServer('remote/Counter');
+    const client = generateReactIslandConsumerClient('remote/Counter');
+
+    expect(server).toContain('await shell.renderToHtml(props)');
+    expect(server).toContain('virtual:mf-react-island-client:remote%2FCounter');
+    expect(client.trimStart()).toMatch(/^"use client"/);
+    expect(client).toContain('shell.hydrate(element, islandProps)');
+    expect(server).toContain('import("remote/Counter")');
+    expect(client).toContain('import("remote/Counter")');
+  });
+
+  it('resolves and loads generated consumer modules', () => {
+    const publicId = 'virtual:mf-react-island-client:remote%2FCounter';
+    const resolvedId = resolveReactIslandConsumerId(publicId);
+
+    expect(resolvedId).toBe(`\0${publicId}`);
+    expect(loadReactIslandConsumerModule(resolvedId!)).toContain('client island capability');
   });
 });

--- a/src/utils/reactIsland.ts
+++ b/src/utils/reactIsland.ts
@@ -157,3 +157,123 @@ export function generateReactIslandSSRDefinition(enabled: boolean): string {
             }
           }`;
 }
+
+export const REACT_ISLAND_IMPORT_QUERY = 'mf-island';
+export const REACT_ISLAND_CLIENT_ID_PREFIX = 'virtual:mf-react-island-client:';
+export const REACT_ISLAND_SERVER_ID_PREFIX = 'virtual:mf-react-island-server:';
+
+const RESOLVED_REACT_ISLAND_CLIENT_ID_PREFIX = `\0${REACT_ISLAND_CLIENT_ID_PREFIX}`;
+const RESOLVED_REACT_ISLAND_SERVER_ID_PREFIX = `\0${REACT_ISLAND_SERVER_ID_PREFIX}`;
+
+function encodeIslandRemoteId(remoteId: string) {
+  return encodeURIComponent(remoteId);
+}
+
+function decodeIslandRemoteId(encodedRemoteId: string) {
+  return decodeURIComponent(encodedRemoteId);
+}
+
+export function getReactIslandImportRemoteId(source: string): string | undefined {
+  const queryIndex = source.indexOf('?');
+  if (queryIndex === -1) return;
+
+  const query = new URLSearchParams(source.slice(queryIndex + 1));
+  if (!query.has(REACT_ISLAND_IMPORT_QUERY)) return;
+  return source.slice(0, queryIndex);
+}
+
+export function getReactIslandServerImportId(remoteId: string) {
+  return `${REACT_ISLAND_SERVER_ID_PREFIX}${encodeIslandRemoteId(remoteId)}`;
+}
+
+export function getReactIslandClientImportId(remoteId: string) {
+  return `${REACT_ISLAND_CLIENT_ID_PREFIX}${encodeIslandRemoteId(remoteId)}`;
+}
+
+export function resolveReactIslandConsumerId(id: string): string | undefined {
+  if (id.startsWith(REACT_ISLAND_SERVER_ID_PREFIX)) return `\0${id}`;
+  if (id.startsWith(REACT_ISLAND_CLIENT_ID_PREFIX)) return `\0${id}`;
+}
+
+function remoteIdFromResolvedIslandId(id: string, prefix: string) {
+  if (!id.startsWith(prefix)) return;
+  return decodeIslandRemoteId(id.slice(prefix.length));
+}
+
+/** Generates the server half of the opt-in `?mf-island` consumer component. */
+export function generateReactIslandConsumerServer(remoteId: string): string {
+  const source = JSON.stringify(remoteId);
+  const clientSource = JSON.stringify(getReactIslandClientImportId(remoteId));
+  return `import * as React from "react";
+import IslandClient from ${clientSource};
+
+const islandModulePromise = import(${source});
+
+async function loadIslandModule() {
+  const namespace = await islandModulePromise;
+  const pending = namespace && namespace.__mf_remote_pending;
+  if (pending && typeof pending.then === "function") return pending;
+  return namespace && namespace.__moduleExports || namespace;
+}
+
+export default async function ModuleFederationIsland(props) {
+  const remoteModule = await loadIslandModule();
+  const shell = remoteModule && remoteModule.__mf_island;
+  if (!shell || typeof shell.renderToHtml !== "function") {
+    throw new Error(${JSON.stringify(
+      `[Module Federation] ${remoteId} does not expose an SSR island capability`
+    )});
+  }
+  const html = await shell.renderToHtml(props);
+  return React.createElement(IslandClient, { html, islandProps: props });
+}`;
+}
+
+/** Generates the client boundary which hydrates with the remote-owned React. */
+export function generateReactIslandConsumerClient(remoteId: string): string {
+  const source = JSON.stringify(remoteId);
+  return `"use client";
+
+import * as React from "react";
+
+const islandModulePromise = import(${source});
+
+async function loadIslandModule() {
+  const namespace = await islandModulePromise;
+  const pending = namespace && namespace.__mf_remote_pending;
+  if (pending && typeof pending.then === "function") return pending;
+  return namespace && namespace.__moduleExports || namespace;
+}
+
+export default function ModuleFederationIslandClient({ html, islandProps }) {
+  const ref = React.useRef(null);
+
+  React.useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    void loadIslandModule().then((remoteModule) => {
+      const shell = remoteModule && remoteModule.__mf_island;
+      if (!shell || typeof shell.hydrate !== "function") {
+        throw new Error(${JSON.stringify(
+          `[Module Federation] ${remoteId} does not expose a client island capability`
+        )});
+      }
+      return shell.hydrate(element, islandProps);
+    });
+  }, []);
+
+  return React.createElement("div", {
+    ref,
+    suppressHydrationWarning: true,
+    dangerouslySetInnerHTML: { __html: html },
+  });
+}`;
+}
+
+export function loadReactIslandConsumerModule(id: string): string | undefined {
+  const serverRemoteId = remoteIdFromResolvedIslandId(id, RESOLVED_REACT_ISLAND_SERVER_ID_PREFIX);
+  if (serverRemoteId !== undefined) return generateReactIslandConsumerServer(serverRemoteId);
+
+  const clientRemoteId = remoteIdFromResolvedIslandId(id, RESOLVED_REACT_ISLAND_CLIENT_ID_PREFIX);
+  if (clientRemoteId !== undefined) return generateReactIslandConsumerClient(clientRemoteId);
+}


### PR DESCRIPTION
Improve experimental React SSR islands with server rendering and client hydration. 

> [!CAUTION] 
> Do not use in production; the API will change.