### PR TITLE
fix: tolerate trailing commas in export lists during named-export detection

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -494,6 +494,7 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/multi-declarator.js') ||
       filePath.endsWith('/repo/packages/postfix-multi-declarator.js') ||
       filePath.endsWith('/repo/packages/string-export-list.js') ||
+      filePath.endsWith('/repo/packages/trailing-comma-export-list.js') ||
       filePath.endsWith('/repo/packages/default-reexport-list.js') ||
       filePath.endsWith('/repo/packages/string-namespace-export.js') ||
       filePath.endsWith('/repo/packages/nested-destructuring.js') ||
@@ -596,6 +597,14 @@ export const assertedRegistry = <Map<object, any>>new Map();`;
     }
     if (filePath.endsWith('/repo/packages/string-export-list.js')) {
       return 'const foo = 1; export { foo as "a-b", foo as valid };';
+    }
+    if (filePath.endsWith('/repo/packages/trailing-comma-export-list.js')) {
+      // Prettier's default `trailingComma` formatting for a multi-line export list.
+      return `export const first = 1;
+export const second = 2;
+export {
+  first as alias,
+};`;
     }
     if (filePath.endsWith('/repo/packages/default-reexport-list.js')) {
       // MUI's per-component barrel shape: a bare `export { default }` re-export
@@ -1900,6 +1909,33 @@ describe('writeLoadShareModule', () => {
     // buttonBase (declaration) + buttonClasses (`as` alias) are detected; the bare
     // `default` is skipped rather than marking the scan incomplete.
     expectLiveSingletonProxy(generatedCode, pkg, ['buttonBase', 'buttonClasses']);
+    expect(generatedCode).not.toContain(`export * from ${JSON.stringify(importPath)}`);
+  });
+
+  it('keeps an export list with a trailing comma as complete', () => {
+    const pkg = 'mock-package-with-reserved';
+    const importPath = '/repo/packages/trailing-comma-export-list.js';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: importPath,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    // Regression (#990): a trailing comma in a multi-line export list (Prettier's
+    // default formatting) produces an empty specifier when the list is split on
+    // commas; it must be skipped rather than marking the scan incomplete.
+    expectLiveSingletonProxy(generatedCode, pkg, ['first', 'second', 'alias']);
     expect(generatedCode).not.toContain(`export * from ${JSON.stringify(importPath)}`);
   });
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -500,6 +500,10 @@ function getNamedExportsViaRegex(
     const specifiers = match[1].split(',');
     for (const specifier of specifiers) {
       const trimmed = specifier.trim();
+      if (!trimmed) {
+        // empty specifier from a trailing comma in the export list — valid syntax, not a scan gap
+        continue;
+      }
       if (typeOnlySpecifierRegex.test(trimmed)) {
         continue;
       }


### PR DESCRIPTION
Fixes #990

## Problem

Since 1.17.1, named-export detection marks the scan incomplete when an `export { ... }` list contains a trailing comma — Prettier's default formatting for multi-line lists (`trailingComma: "all"`). Splitting the specifier list on `","` yields an empty final specifier, which fails the specifier regex and lands in the branch that sets `scanState.complete = false`, discarding an otherwise fully detected export list. For `import: false` shares this surfaces as `MISSING_EXPORT` build errors plus a misleading "is not installed locally" warning.

Through 1.17.0 the same branch was `if (!asMatch) continue;`, so trailing commas were tolerated.

## Fix

Skip empty specifiers before matching, so a trailing comma is treated as the valid syntax it is, while genuinely unparseable specifiers still mark the scan incomplete.

Includes a regression test with a Prettier-shaped fixture (`export {\n  first as alias,\n};`) asserting the export list is still detected as complete.
