### PR TITLE
perf: reduce import:false shared consumer chunk size

### DIFF
--- a/integration/fixtures/shared-remote/exposed-namespace.js
+++ b/integration/fixtures/shared-remote/exposed-namespace.js
@@ -1,0 +1,3 @@
+import * as shared from 'mock-shared-dep';
+
+export const sharedNamespace = shared;

--- a/integration/fixtures/shared-remote/exposed-secondary.js
+++ b/integration/fixtures/shared-remote/exposed-secondary.js
@@ -1,0 +1,3 @@
+import { value2 } from 'mock-shared-dep';
+
+export const secondaryValue = value2;

--- a/integration/fixtures/shared-remote/vendor/mock-shared-dep/index.js
+++ b/integration/fixtures/shared-remote/vendor/mock-shared-dep/index.js
@@ -1,1 +1,4 @@
 export const init = 'ready';
+export const value1 = 'one';
+export const value2 = 'two';
+export const value3 = 'three';

--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -111,12 +111,90 @@ describe('shared dependencies', () => {
     expect(allCode).toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');
     expect(loadShare!.code).toContain('pendingShareLoads');
+    expect(loadShare!.code).toContain('exportModule["init"]');
+    expect(loadShare!.code).not.toContain('exportModule["value1"]');
+    expect(loadShare!.code).not.toContain('exportModule["value2"]');
+    expect(loadShare!.code).not.toContain('exportModule["value3"]');
     expect(loadShare!.code).toContain('default:mock-shared-dep');
     expect(loadShare!.code).toContain('mock-shared-dep');
     expect(loadShare!.code).toContain('init');
     expect(loadShare!.code).not.toContain('await initPromise');
     expect(allCode).not.toContain('from"mock-shared-dep"');
     expect(allCode).not.toContain('from "mock-shared-dep"');
+  });
+
+  it('unions import:false named exports across exposed consumers', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: {
+        ...SHARED_BASE_MF_OPTIONS,
+        exposes: {
+          './exposed': resolve(FIXTURES, 'shared-remote', 'exposed-module.js'),
+          './secondary': resolve(FIXTURES, 'shared-remote', 'exposed-secondary.js'),
+        },
+        shared: { 'mock-shared-dep': { import: false, singleton: true } },
+      },
+    });
+    const loadShare = output.output
+      .filter(isRollupChunk)
+      .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
+
+    expect(loadShare).toBeDefined();
+    expect(loadShare!.code).toContain('exportModule["init"]');
+    expect(loadShare!.code).toContain('exportModule["value2"]');
+    expect(loadShare!.code).not.toContain('exportModule["value1"]');
+    expect(loadShare!.code).not.toContain('exportModule["value3"]');
+  });
+
+  it('unions import:false named exports across Rollup inputs and exposed consumers', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: {
+        ...SHARED_BASE_MF_OPTIONS,
+        shared: { 'mock-shared-dep': { import: false, singleton: true } },
+      },
+      viteConfig: {
+        build: {
+          rollupOptions: {
+            input: {
+              main: resolve(FIXTURES, 'shared-remote', 'index.html'),
+              secondary: resolve(FIXTURES, 'shared-remote', 'exposed-secondary.js'),
+            },
+          },
+        },
+      },
+    });
+    const loadShare = output.output
+      .filter(isRollupChunk)
+      .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
+
+    expect(loadShare).toBeDefined();
+    expect(loadShare!.code).toContain('exportModule["init"]');
+    expect(loadShare!.code).toContain('exportModule["value2"]');
+    expect(loadShare!.code).not.toContain('exportModule["value1"]');
+    expect(loadShare!.code).not.toContain('exportModule["value3"]');
+  });
+
+  it('keeps the complete import:false export surface for namespace consumers', async () => {
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: {
+        ...SHARED_BASE_MF_OPTIONS,
+        exposes: {
+          './namespace': resolve(FIXTURES, 'shared-remote', 'exposed-namespace.js'),
+        },
+        shared: { 'mock-shared-dep': { import: false, singleton: true } },
+      },
+    });
+    const loadShare = output.output
+      .filter(isRollupChunk)
+      .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
+
+    expect(loadShare).toBeDefined();
+    expect(loadShare!.code).toContain('exportModule["init"]');
+    expect(loadShare!.code).toContain('exportModule["value1"]');
+    expect(loadShare!.code).toContain('exportModule["value2"]');
+    expect(loadShare!.code).toContain('exportModule["value3"]');
   });
 
   it('includes shared deps in manifest', async () => {

--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -14,6 +14,12 @@ const SHARED_BASE_MF_OPTIONS = {
   dts: false,
 } satisfies Partial<ModuleFederationOptions>;
 
+function getHostProvidedExportAccessPattern(exportName: string) {
+  // Rollup may append a numeric suffix when the generated helper parameter
+  // conflicts with the outer exportModule binding.
+  return new RegExp(`\\bexportModule\\d*\\["${exportName}"\\]`);
+}
+
 describe('shared dependencies', () => {
   it('routes shared dep through loadShare()', async () => {
     const output = await buildFixture({
@@ -111,10 +117,10 @@ describe('shared dependencies', () => {
     expect(allCode).toContain('initRes.loadShare(pkg');
     expect(loadShare!.code).toContain('initPromise.then');
     expect(loadShare!.code).toContain('pendingShareLoads');
-    expect(loadShare!.code).toContain('exportModule["init"]');
-    expect(loadShare!.code).not.toContain('exportModule["value1"]');
-    expect(loadShare!.code).not.toContain('exportModule["value2"]');
-    expect(loadShare!.code).not.toContain('exportModule["value3"]');
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('init'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value1'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value2'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value3'));
     expect(loadShare!.code).toContain('default:mock-shared-dep');
     expect(loadShare!.code).toContain('mock-shared-dep');
     expect(loadShare!.code).toContain('init');
@@ -140,10 +146,10 @@ describe('shared dependencies', () => {
       .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
 
     expect(loadShare).toBeDefined();
-    expect(loadShare!.code).toContain('exportModule["init"]');
-    expect(loadShare!.code).toContain('exportModule["value2"]');
-    expect(loadShare!.code).not.toContain('exportModule["value1"]');
-    expect(loadShare!.code).not.toContain('exportModule["value3"]');
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('init'));
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value2'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value1'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value3'));
   });
 
   it('unions import:false named exports across Rollup inputs and exposed consumers', async () => {
@@ -169,10 +175,10 @@ describe('shared dependencies', () => {
       .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
 
     expect(loadShare).toBeDefined();
-    expect(loadShare!.code).toContain('exportModule["init"]');
-    expect(loadShare!.code).toContain('exportModule["value2"]');
-    expect(loadShare!.code).not.toContain('exportModule["value1"]');
-    expect(loadShare!.code).not.toContain('exportModule["value3"]');
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('init'));
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value2'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value1'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value3'));
   });
 
   it('keeps the complete import:false export surface for namespace consumers', async () => {
@@ -191,10 +197,10 @@ describe('shared dependencies', () => {
       .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
 
     expect(loadShare).toBeDefined();
-    expect(loadShare!.code).toContain('exportModule["init"]');
-    expect(loadShare!.code).toContain('exportModule["value1"]');
-    expect(loadShare!.code).toContain('exportModule["value2"]');
-    expect(loadShare!.code).toContain('exportModule["value3"]');
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('init'));
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value1'));
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value2'));
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value3'));
   });
 
   it('includes shared deps in manifest', async () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -13,7 +13,6 @@ import {
   type ViteBuilder,
 } from 'vite';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { parsePromise } from '../plugins/pluginModuleParseEnd';
 import { callHook } from '../utils/__tests__/viteHookHelpers';
 import type {
   ModuleFederationOptions,
@@ -67,7 +66,12 @@ vi.mock('../utils/logger', async () => {
 
 import { federation } from '../index';
 import VirtualModule from '../utils/VirtualModule';
-import { getPreBuildLibImportId, LOAD_SHARE_TAG, PREBUILD_TAG } from '../virtualModules';
+import {
+  getPreBuildLibImportId,
+  getRemoteEntryId,
+  LOAD_SHARE_TAG,
+  PREBUILD_TAG,
+} from '../virtualModules';
 import { getUsedShares } from '../virtualModules/virtualRemoteEntry';
 import { virtualRuntimeInitStatus } from '../virtualModules/virtualRuntimeInitStatus';
 
@@ -363,22 +367,122 @@ describe('module parse wiring', () => {
     }
     const parseStart = plugins.find((plugin) => plugin.name === 'parseStart');
     const parseEnd = plugins.find((plugin) => plugin.name === 'parseEnd');
-    if (!parseStart || !parseEnd) throw new Error('parse plugins not found');
+    const proxyRemoteEntry = plugins.find((plugin) => plugin.name === 'proxyRemoteEntry');
+    const federationOptionsPlugin = plugins.find(
+      (plugin) => plugin.name === 'module-federation-vite'
+    );
+    if (!parseStart || !parseEnd || !proxyRemoteEntry || !federationOptionsPlugin) {
+      throw new Error('module federation plugins not found');
+    }
     const ctx = {} as any;
+    const federationOptions = (
+      federationOptionsPlugin as Plugin & {
+        _options: NormalizedModuleFederationOptions;
+      }
+    )._options;
 
+    runConfig(proxyRemoteEntry, {} as ConfigPluginContext, {}, { command: 'build', mode: 'test' });
     callHook(parseStart.buildStart, ctx, undefined as never);
     callHook(parseStart.load, ctx, `virtual:mf:host${LOAD_SHARE_TAG}react${LOAD_SHARE_TAG}.js`);
     callHook(parseStart.load, ctx, `virtual:mf:host${PREBUILD_TAG}react${PREBUILD_TAG}.js`);
     callHook(parseStart.load, ctx, '/src/main.ts');
+    const pendingRemoteEntry = callHook(
+      proxyRemoteEntry.load,
+      ctx,
+      getRemoteEntryId(federationOptions)
+    );
 
     callHook(parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(Promise.resolve(pendingRemoteEntry))).toBe(true);
+  });
+
+  it('keeps the complete import:false export surface when parse analysis is incomplete', async () => {
+    const previousNoTestEnvCheck = process.env.MFE_VITE_NO_TEST_ENV_CHECK;
+    process.env.MFE_VITE_NO_TEST_ENV_CHECK = 'true';
+    let plugins: Plugin[];
+    try {
+      plugins = federation({
+        name: 'host',
+        filename: 'remoteEntry.js',
+        shared: {
+          react: {
+            import: false,
+            singleton: true,
+          },
+        },
+      }) as Plugin[];
+    } finally {
+      if (previousNoTestEnvCheck === undefined) {
+        delete process.env.MFE_VITE_NO_TEST_ENV_CHECK;
+      } else {
+        process.env.MFE_VITE_NO_TEST_ENV_CHECK = previousNoTestEnvCheck;
+      }
+    }
+
+    const earlyInitPlugin = plugins.find(
+      (plugin) => plugin.name === 'vite:module-federation-early-init'
+    );
+    const federationConfigPlugin = plugins.find(
+      (plugin) => plugin.name === 'vite:module-federation-config'
+    );
+    const sharedAnalysisPlugin = plugins.find((plugin) => plugin.name === 'proxyPreBuildShared');
+    const parseStart = plugins.find((plugin) => plugin.name === 'parseStart');
+    const parseEnd = plugins.find((plugin) => plugin.name === 'parseEnd');
+    const federationLoadPlugin = plugins.find(
+      (plugin) => plugin.name === 'module-federation-esm-shims'
+    );
+    const federationOptionsPlugin = plugins.find(
+      (plugin) => plugin.name === 'module-federation-vite'
+    );
+    if (
+      !earlyInitPlugin ||
+      !federationConfigPlugin ||
+      !sharedAnalysisPlugin ||
+      !parseStart ||
+      !parseEnd ||
+      !federationLoadPlugin ||
+      !federationOptionsPlugin
+    ) {
+      throw new Error('module federation plugins not found');
+    }
+
+    const config = { root: process.cwd(), build: {} } as UserConfig;
+    const env = { command: 'build', mode: 'test' } as ConfigEnv;
+    const configContext = { meta: {} } as ConfigPluginContext;
+    runConfig(earlyInitPlugin, configContext, config, env);
+    runConfig(federationConfigPlugin, configContext, config, env);
+    runConfig(sharedAnalysisPlugin, configContext, config, env);
+
+    const parseContext = { resolve: async (id: string) => ({ id }) } as any;
+    await callHook(parseStart.buildStart, parseContext, undefined as never);
+    callHook(
+      sharedAnalysisPlugin.transform,
+      {} as any,
+      'import { useState } from "react";',
+      '/src/main.ts'
+    );
+    callHook(parseEnd.buildEnd, parseContext);
+
+    const federationOptions = (
+      federationOptionsPlugin as Plugin & {
+        _options: NormalizedModuleFederationOptions;
+      }
+    )._options;
+    const loadShareId = getLoadShareModulePath('react', false, federationOptions);
+    const result = (await callHook(
+      federationLoadPlugin.load,
+      {} as Rollup.PluginContext,
+      loadShareId
+    )) as { code: string };
+
+    expect(result.code).toContain('exportModule["useState"]');
+    expect(result.code).toContain('exportModule["createElement"]');
   });
 });
 
 describe('shared export condition configuration', () => {
-  it('uses SSR conditions contributed by a later config hook in Vite 5-7 load hooks', () => {
+  it('uses SSR conditions contributed by a later config hook in Vite 5-7 load hooks', async () => {
     const pkg = 'missing-late-conditions-package';
     const plugins = federation({
       name: 'host',
@@ -462,7 +566,9 @@ describe('shared export condition configuration', () => {
       }
     )._options;
     const loadShareId = getLoadShareModulePath(pkg, false, federationOptions);
-    callHook(federationLoadPlugin.load, {} as Rollup.PluginContext, loadShareId, { ssr: true });
+    await callHook(federationLoadPlugin.load, {} as Rollup.PluginContext, loadShareId, {
+      ssr: true,
+    });
 
     expect(getSharedExportConditionsMock).toHaveBeenCalledWith({
       environmentConditions: undefined,

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -72,7 +72,11 @@ import {
   LOAD_SHARE_TAG,
   PREBUILD_TAG,
 } from '../virtualModules';
-import { getUsedShares } from '../virtualModules/virtualRemoteEntry';
+import {
+  getLocalSharedImportMapPath,
+  getResolvedLocalSharedImportMapId,
+  getUsedShares,
+} from '../virtualModules/virtualRemoteEntry';
 import { virtualRuntimeInitStatus } from '../virtualModules/virtualRuntimeInitStatus';
 
 const REACT_EXAMPLE_ROOT = path.join(process.cwd(), 'examples/vite-vite/vite-host');
@@ -346,6 +350,80 @@ describe('federation in test environment', () => {
 });
 
 describe('module parse wiring', () => {
+  it('does not deadlock local shared maps across federation instances', async () => {
+    const previousNoTestEnvCheck = process.env.MFE_VITE_NO_TEST_ENV_CHECK;
+    process.env.MFE_VITE_NO_TEST_ENV_CHECK = 'true';
+    let pluginSets: Plugin[][];
+    try {
+      pluginSets = ['first', 'second'].map(
+        (name) =>
+          federation({
+            name,
+            filename: `${name}-remoteEntry.js`,
+            shared: { react: { import: false } },
+          }) as Plugin[]
+      );
+    } finally {
+      if (previousNoTestEnvCheck === undefined) {
+        delete process.env.MFE_VITE_NO_TEST_ENV_CHECK;
+      } else {
+        process.env.MFE_VITE_NO_TEST_ENV_CHECK = previousNoTestEnvCheck;
+      }
+    }
+
+    const instances = pluginSets.map((plugins) => {
+      const parseStart = plugins.find((plugin) => plugin.name === 'parseStart');
+      const parseEnd = plugins.find((plugin) => plugin.name === 'parseEnd');
+      const localSharedMap = plugins.find(
+        (plugin) => plugin.name === 'generateLocalSharedImportMap'
+      );
+      const federationOptionsPlugin = plugins.find(
+        (plugin) => plugin.name === 'module-federation-vite'
+      );
+      if (!parseStart || !parseEnd || !localSharedMap || !federationOptionsPlugin) {
+        throw new Error('module federation plugins not found');
+      }
+      const options = (
+        federationOptionsPlugin as Plugin & {
+          _options: NormalizedModuleFederationOptions;
+        }
+      )._options;
+      return { localSharedMap, options, parseEnd, parseStart };
+    });
+    const ctx = {} as any;
+
+    for (const instance of instances) {
+      await callHook(instance.parseStart.buildStart, ctx, undefined as never);
+    }
+    for (const observer of instances) {
+      callHook(observer.parseStart.load, ctx, '/src/main.ts');
+      for (const owner of instances) {
+        callHook(observer.parseStart.load, ctx, getResolvedLocalSharedImportMapId(owner.options));
+      }
+      callHook(observer.parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
+    }
+
+    const pendingMaps = instances.map((instance) =>
+      Promise.resolve(
+        callHook(
+          instance.localSharedMap.load,
+          ctx,
+          getResolvedLocalSharedImportMapId(instance.options)
+        )
+      )
+    );
+    const resolved = await Promise.all(pendingMaps.map(resolvesQuickly));
+
+    // Clean up the parse timers without waiting for the production timeout.
+    for (const instance of instances) callHook(instance.parseEnd.buildEnd, ctx);
+    await Promise.all(pendingMaps);
+
+    expect(resolved).toEqual([true, true]);
+    expect(getLocalSharedImportMapPath(instances[0].options)).not.toBe(
+      getLocalSharedImportMapPath(instances[1].options)
+    );
+  });
+
   it('does not wait for generated load-share or prebuild modules', async () => {
     const previousNoTestEnvCheck = process.env.MFE_VITE_NO_TEST_ENV_CHECK;
     process.env.MFE_VITE_NO_TEST_ENV_CHECK = 'true';

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,6 @@ import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualM
 import {
   getHostAutoInitImportId,
   getHostAutoInitPath,
-  getLocalSharedImportMapPath,
   getRemoteEntryId,
   initVirtualModules,
   LOAD_REMOTE_TAG,
@@ -845,7 +844,7 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         id.includes(getHostAutoInitImportId(options)) ||
         id.includes(remoteEntryId) ||
         id.includes(virtualExposesId) ||
-        id.includes(getLocalSharedImportMapPath(options)) ||
+        id.includes('virtual:mf-localSharedImportMap') ||
         id.includes(LOAD_SHARE_TAG) ||
         id.includes(PREBUILD_TAG) ||
         id.includes(TREE_SHAKING_PROVIDER_TAG) ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { checkAliasConflicts } from './plugins/pluginCheckAliasConflicts';
 import pluginDevRemoteHmr, { shouldIgnoreFile } from './plugins/pluginDevRemoteHmr';
 import pluginExternalRuntimeCore from './plugins/pluginExternalRuntimeCore';
 import pluginManifest from './plugins/pluginMFManifest';
-import pluginModuleParseEnd from './plugins/pluginModuleParseEnd';
+import pluginModuleParseEnd, { createModuleParseController } from './plugins/pluginModuleParseEnd';
 import pluginProxyRemoteEntry from './plugins/pluginProxyRemoteEntry';
 import pluginProxyRemotes from './plugins/pluginProxyRemotes';
 import { findSharedKey, proxySharedModule } from './plugins/pluginProxySharedModule_preBuild';
@@ -55,6 +55,7 @@ import {
   applyRuntimeCapabilityDefines,
   getRuntimeCapabilityConfigurationWarnings,
 } from './utils/runtimeCapabilityOptimization';
+import { getSharedExportUsage } from './utils/treeShaking';
 import { getSsrCapabilities } from './utils/ssrCapabilities';
 import {
   getCommonSharedSubpaths,
@@ -837,6 +838,27 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
 
   const remoteEntryId = getRemoteEntryId(options);
   const virtualExposesId = getVirtualExposesId(options);
+  const moduleParseController = createModuleParseController();
+  const moduleParsePlugins = pluginModuleParseEnd(
+    (id: string) => {
+      return (
+        id.includes(getHostAutoInitImportId(options)) ||
+        id.includes(remoteEntryId) ||
+        id.includes(virtualExposesId) ||
+        id.includes(getLocalSharedImportMapPath(options)) ||
+        id.includes(LOAD_SHARE_TAG) ||
+        id.includes(PREBUILD_TAG) ||
+        id.includes(TREE_SHAKING_PROVIDER_TAG) ||
+        id.includes(TREE_SHAKING_GRAPH_QUERY)
+      );
+    },
+    {
+      moduleParseTimeout: options.moduleParseTimeout,
+      moduleParseIdleTimeout: options.moduleParseIdleTimeout,
+      exposedModuleImports: Object.values(options.exposes).map((expose) => expose.import),
+    },
+    moduleParseController
+  );
 
   let command: string;
   let desiredRolldownOutput: OutputNameOptions[] | undefined;
@@ -904,7 +926,8 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
   const refreshLoadShareModuleForEnvironment = (
     id: string,
     context: LoadHookContext,
-    loadOptions?: LoadHookOptions
+    loadOptions?: LoadHookOptions,
+    importFalseExportUsage?: ReturnType<typeof getSharedExportUsage>
   ): SharedVirtualRefreshStatus => {
     const pkg = getCachedLoadSharePkg(id);
     if (!pkg) return 'not-applicable';
@@ -919,9 +942,23 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       command,
       getIsRolldown(context),
       options,
-      getLoadHookExportConditions(context, loadOptions)
+      getLoadHookExportConditions(context, loadOptions),
+      importFalseExportUsage
     );
     return 'refreshed';
+  };
+
+  const getCompleteImportFalseExportUsage = (id: string) => {
+    if (command !== 'build') return undefined;
+    const pkg = getCachedLoadSharePkg(id);
+    if (!pkg) return undefined;
+    const key = findSharedKey(pkg, shared);
+    if (!key || shared[key].shareConfig.import !== false) return undefined;
+
+    return moduleParseController.parsePromise.then((completion) => {
+      if (!completion.complete) return undefined;
+      return getSharedExportUsage(pkg, shared[key], key, options);
+    });
   };
 
   return [
@@ -1079,31 +1116,19 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
       entryPath: virtualExposesId,
       federationOptions: options,
     }),
-    pluginProxyRemoteEntry({ options, remoteEntryId, virtualExposesId }),
+    pluginProxyRemoteEntry({
+      options,
+      remoteEntryId,
+      virtualExposesId,
+      getParsePromise: () => moduleParseController.parsePromise,
+    }),
     pluginProxyRemotes(options),
     pluginRemoteNamedExports(options),
-    ...pluginModuleParseEnd(
-      (id: string) => {
-        return (
-          id.includes(getHostAutoInitImportId(options)) ||
-          id.includes(remoteEntryId) ||
-          id.includes(virtualExposesId) ||
-          id.includes(getLocalSharedImportMapPath(options)) ||
-          id.includes(LOAD_SHARE_TAG) ||
-          id.includes(PREBUILD_TAG) ||
-          id.includes(TREE_SHAKING_PROVIDER_TAG) ||
-          id.includes(TREE_SHAKING_GRAPH_QUERY)
-        );
-      },
-      {
-        moduleParseTimeout: options.moduleParseTimeout,
-        moduleParseIdleTimeout: options.moduleParseIdleTimeout,
-        exposedModuleImports: Object.values(options.exposes).map((expose) => expose.import),
-      }
-    ),
+    ...moduleParsePlugins,
     ...proxySharedModule({
       shared,
       federationOptions: options,
+      getParsePromise: () => moduleParseController.parsePromise,
     }),
     {
       name: 'module-federation-esm-shims',
@@ -1361,11 +1386,18 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         }
       },
       load(id: string, loadOptions?: LoadHookOptions) {
-        if (id.includes(LOAD_SHARE_TAG) || id.includes(LOAD_REMOTE_TAG)) {
+        const loadVirtualModule = (
+          importFalseExportUsage?: ReturnType<typeof getSharedExportUsage>
+        ) => {
+          if (!id.includes(LOAD_SHARE_TAG) && !id.includes(LOAD_REMOTE_TAG)) return;
           if (
             id.includes(LOAD_SHARE_TAG) &&
-            refreshLoadShareModuleForEnvironment(id, this as LoadHookContext, loadOptions) ===
-              'not-owned'
+            refreshLoadShareModuleForEnvironment(
+              id,
+              this as LoadHookContext,
+              loadOptions,
+              importFalseExportUsage
+            ) === 'not-owned'
           ) {
             return;
           }
@@ -1434,7 +1466,15 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
             return { code };
           }
           return { code, syntheticNamedExports: '__moduleExports' };
+        };
+
+        const pendingImportFalseExportUsage = id.includes(LOAD_SHARE_TAG)
+          ? getCompleteImportFalseExportUsage(id)
+          : undefined;
+        if (pendingImportFalseExportUsage) {
+          return pendingImportFalseExportUsage.then(loadVirtualModule);
         }
+        return loadVirtualModule();
       },
       generateBundle(
         _outputOptions: NormalizedOutputOptionsLike,

--- a/src/plugins/__tests__/pluginModuleParseEnd.test.ts
+++ b/src/plugins/__tests__/pluginModuleParseEnd.test.ts
@@ -1,18 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { build as viteBuild } from 'vite';
-import pluginModuleParseEnd, { parsePromise } from '../pluginModuleParseEnd';
+import pluginModuleParseEnd, { createModuleParseController } from '../pluginModuleParseEnd';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 
-function getParsePlugins(excludeFn: (id: string) => boolean, exposedModuleImports?: string[]) {
-  const plugins = pluginModuleParseEnd(excludeFn, {
-    moduleParseTimeout: 10,
-    exposedModuleImports,
-  });
+function getParsePlugins(
+  excludeFn: (id: string) => boolean,
+  exposedModuleImports?: string[],
+  moduleParseIdleTimeout?: number
+) {
+  const controller = createModuleParseController();
+  const plugins = pluginModuleParseEnd(
+    excludeFn,
+    {
+      moduleParseTimeout: 10,
+      moduleParseIdleTimeout,
+      exposedModuleImports,
+    },
+    controller
+  );
 
   const parseStart = plugins.find((plugin) => plugin.name === 'parseStart');
   const parseEnd = plugins.find((plugin) => plugin.name === 'parseEnd');
   if (!parseStart || !parseEnd) throw new Error('parse plugins not found');
-  return { parseStart, parseEnd };
+  return { controller, parseStart, parseEnd };
 }
 
 async function resolvesQuickly(promise: Promise<unknown>) {
@@ -24,18 +34,34 @@ async function resolvesQuickly(promise: Promise<unknown>) {
 
 describe('pluginModuleParseEnd', () => {
   it('resolves parsePromise on buildEnd', async () => {
-    const { parseStart, parseEnd } = getParsePlugins(() => false);
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
     const ctx = {} as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
     callHook(parseStart.load, ctx, '/src/main.ts');
     callHook(parseEnd.buildEnd, ctx);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await controller.parsePromise).toEqual({ complete: false, reason: 'build-end' });
+  });
+
+  it('marks an idle-timeout barrier result as incomplete', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { controller, parseStart } = getParsePlugins(() => false, undefined, 0.001);
+
+      callHook(parseStart.buildStart, {} as any, undefined as never);
+
+      expect(await controller.parsePromise).toEqual({
+        complete: false,
+        reason: 'idle-timeout',
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('does not wait for excluded load-share or prebuild ids', async () => {
-    const { parseStart, parseEnd } = getParsePlugins(
+    const { controller, parseStart, parseEnd } = getParsePlugins(
       (id) => id.includes('__loadShare__') || id.includes('__prebuild__')
     );
     const ctx = {} as any;
@@ -47,11 +73,13 @@ describe('pluginModuleParseEnd', () => {
 
     callHook(parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
   });
 
   it('settles when an excluded barrier module loads after the graph completes', async () => {
-    const { parseStart, parseEnd } = getParsePlugins((id) => id.includes('__loadShare__'));
+    const { controller, parseStart, parseEnd } = getParsePlugins((id) =>
+      id.includes('__loadShare__')
+    );
     const ctx = {} as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
@@ -59,21 +87,21 @@ describe('pluginModuleParseEnd', () => {
     callHook(parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
     callHook(parseStart.load, ctx, 'virtual:mf:app__loadShare__react__loadShare__.js');
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
   });
 
   it('does not settle an empty graph just because an excluded module loads', async () => {
-    const { parseStart } = getParsePlugins((id) => id.includes('__loadShare__'));
+    const { controller, parseStart } = getParsePlugins((id) => id.includes('__loadShare__'));
     const ctx = {} as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
     callHook(parseStart.load, ctx, 'virtual:mf:app__loadShare__react__loadShare__.js');
 
-    expect(await resolvesQuickly(parsePromise)).toBe(false);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
   });
 
   it('settles when parsed modules are a superset of tracked loads', async () => {
-    const { parseStart, parseEnd } = getParsePlugins(() => false);
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
     const ctx = {} as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
@@ -81,11 +109,14 @@ describe('pluginModuleParseEnd', () => {
     callHook(parseEnd.moduleParsed, ctx, { id: '/virtual/internal.ts' } as never);
     callHook(parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await controller.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
   });
 
   it('waits for imported children discovered when an entry is parsed', async () => {
-    const { parseStart, parseEnd } = getParsePlugins(() => false);
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
     const ctx = { getModuleInfo: () => undefined } as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
@@ -98,7 +129,7 @@ describe('pluginModuleParseEnd', () => {
       dynamicallyImportedIdResolutions: [],
     } as never);
     callHook(parseStart.load, ctx, '/src/child.ts');
-    expect(await resolvesQuickly(parsePromise)).toBe(false);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
 
     callHook(parseEnd.moduleParsed, ctx, {
       id: '/src/child.ts',
@@ -108,11 +139,40 @@ describe('pluginModuleParseEnd', () => {
       dynamicallyImportedIdResolutions: [],
     } as never);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
+  });
+
+  it('tracks resolved imported ids when resolution metadata is unavailable', async () => {
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
+    const ctx = {
+      getModuleInfo: () => ({ isExternal: false }),
+    } as any;
+
+    callHook(parseStart.buildStart, ctx, undefined as never);
+    callHook(parseStart.load, ctx, '/src/main.ts');
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/main.ts',
+      importedIds: ['/src/late-child.ts'],
+      dynamicallyImportedIds: [],
+    } as never);
+
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
+
+    callHook(parseStart.load, ctx, '/src/late-child.ts');
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/late-child.ts',
+      importedIds: [],
+      dynamicallyImportedIds: [],
+    } as never);
+
+    expect(await controller.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
   });
 
   it('does not wait for external dependencies discovered during parsing', async () => {
-    const { parseStart, parseEnd } = getParsePlugins(() => false);
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
     const ctx = {} as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
@@ -125,12 +185,14 @@ describe('pluginModuleParseEnd', () => {
       dynamicallyImportedIdResolutions: [],
     } as never);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
   });
 
   it('tracks children of the excluded virtual exposes module', async () => {
     const virtualExposesId = 'virtual:mf:exposes';
-    const { parseStart, parseEnd } = getParsePlugins((id) => id.includes(virtualExposesId));
+    const { controller, parseStart, parseEnd } = getParsePlugins((id) =>
+      id.includes(virtualExposesId)
+    );
     const ctx = {} as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
@@ -148,7 +210,7 @@ describe('pluginModuleParseEnd', () => {
     for (const id of ['/src/expose-a.ts', '/src/expose-b.ts']) {
       callHook(parseStart.load, ctx, id);
     }
-    expect(await resolvesQuickly(parsePromise)).toBe(false);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
 
     for (const id of ['/src/expose-a.ts', '/src/expose-b.ts']) {
       callHook(parseEnd.moduleParsed, ctx, {
@@ -160,18 +222,18 @@ describe('pluginModuleParseEnd', () => {
       } as never);
     }
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
   });
 
   it('waits for configured expose entries even before Rollup loads them', async () => {
     const childId = '/src/expose.ts';
-    const { parseStart, parseEnd } = getParsePlugins(() => false, ['./src/expose.ts']);
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false, ['./src/expose.ts']);
     const ctx = {
       resolve: async (id: string) => ({ id: id === './src/expose.ts' ? childId : id }),
     } as any;
 
     await callHook(parseStart.buildStart, ctx, undefined as never);
-    expect(await resolvesQuickly(parsePromise)).toBe(false);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
 
     callHook(parseStart.load, ctx, childId);
     callHook(parseEnd.moduleParsed, ctx, {
@@ -182,13 +244,111 @@ describe('pluginModuleParseEnd', () => {
       dynamicallyImportedIdResolutions: [],
     } as never);
 
-    expect(await resolvesQuickly(parsePromise)).toBe(true);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
+  });
+
+  it('isolates parse completion across plugin instances', async () => {
+    const {
+      controller: firstController,
+      parseStart: firstStart,
+      parseEnd: firstEnd,
+    } = getParsePlugins(() => false);
+    const {
+      controller: secondController,
+      parseStart: secondStart,
+      parseEnd: secondEnd,
+    } = getParsePlugins(() => false);
+    const ctx = {} as any;
+
+    await callHook(firstStart.buildStart, ctx, undefined as never);
+    await callHook(secondStart.buildStart, ctx, undefined as never);
+    callHook(firstStart.load, ctx, '/src/first.ts');
+    callHook(firstEnd.moduleParsed, ctx, { id: '/src/first.ts' } as never);
+
+    expect(await firstController.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
+    expect(await resolvesQuickly(secondController.parsePromise)).toBe(false);
+
+    callHook(secondStart.load, ctx, '/src/second.ts');
+    callHook(secondEnd.moduleParsed, ctx, { id: '/src/second.ts' } as never);
+    expect(await secondController.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
+  });
+
+  it.each(['rollupOptions', 'rolldownOptions'] as const)(
+    'waits for configured %s inputs before they are loaded',
+    async (inputOption) => {
+      const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
+      const ctx = {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as any;
+
+      const input = {
+        first: 'src/first.ts',
+        second: 'src/second.ts',
+      };
+      callHook(parseStart.configResolved, ctx, {
+        build: {
+          rollupOptions: inputOption === 'rollupOptions' ? { input } : {},
+          ...(inputOption === 'rolldownOptions' ? { rolldownOptions: { input } } : {}),
+        },
+      } as never);
+      await callHook(parseStart.buildStart, ctx, undefined as never);
+
+      callHook(parseStart.load, ctx, '/resolved/src/first.ts');
+      callHook(parseEnd.moduleParsed, ctx, { id: '/resolved/src/first.ts' } as never);
+      expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
+
+      callHook(parseStart.load, ctx, '/resolved/src/second.ts');
+      callHook(parseEnd.moduleParsed, ctx, { id: '/resolved/src/second.ts' } as never);
+      expect(await controller.parsePromise).toEqual({
+        complete: true,
+        reason: 'graph-complete',
+      });
+    }
+  );
+
+  it('resets parse state between consecutive builds', async () => {
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
+    const ctx = {} as any;
+
+    await callHook(parseStart.buildStart, ctx, undefined as never);
+    callHook(parseStart.load, ctx, '/src/first-build.ts');
+    callHook(parseEnd.buildEnd, ctx);
+    expect(await controller.parsePromise).toEqual({
+      complete: false,
+      reason: 'build-end',
+    });
+
+    await callHook(parseStart.buildStart, ctx, undefined as never);
+    callHook(parseStart.load, ctx, '/src/second-build.ts');
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/second-build.ts',
+      importedIds: [],
+      dynamicallyImportedIds: [],
+      importedIdResolutions: [],
+      dynamicallyImportedIdResolutions: [],
+    } as never);
+
+    expect(await controller.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
   });
 
   it('waits for child transforms in a real Vite module graph without resolution metadata', async () => {
-    const parsePlugins = pluginModuleParseEnd(() => false, {
-      moduleParseTimeout: 0,
-    });
+    const controller = createModuleParseController();
+    const parsePlugins = pluginModuleParseEnd(
+      () => false,
+      {
+        moduleParseTimeout: 0,
+      },
+      controller
+    );
     let childTransformed = false;
     let resolvedBeforeChild = false;
 
@@ -200,7 +360,7 @@ describe('pluginModuleParseEnd', () => {
         {
           name: 'parse-barrier-vite-probe',
           buildStart() {
-            void parsePromise.then(() => {
+            void controller.parsePromise.then(() => {
               resolvedBeforeChild = !childTransformed;
             });
           },

--- a/src/plugins/pluginModuleParseEnd.ts
+++ b/src/plugins/pluginModuleParseEnd.ts
@@ -5,89 +5,107 @@
 import type { Plugin } from 'vite';
 import { mfWarn } from '../utils/logger';
 
-let _resolve: ((value: any) => void) | null = null;
-let _parseTimeout: ReturnType<typeof setTimeout> | null = null;
-let _settleTimeout: ReturnType<typeof setTimeout> | null = null;
+type ParseCompletion =
+  | { complete: true; reason: 'graph-complete' }
+  | {
+      complete: false;
+      reason: 'initial' | 'timeout' | 'idle-timeout' | 'build-end';
+    };
 
-let parsePromise = Promise.resolve(1);
+export function createModuleParseController() {
+  return {
+    resolve: null as ((value: ParseCompletion) => void) | null,
+    parseTimeout: null as ReturnType<typeof setTimeout> | null,
+    settleTimeout: null as ReturnType<typeof setTimeout> | null,
+    parsePromise: Promise.resolve<ParseCompletion>({
+      complete: false,
+      reason: 'initial',
+    }),
+    parseStartSet: new Set<string>(),
+    parseEndSet: new Set<string>(),
+    lastLoadedModule: '',
+    lastParsedModule: '',
+  };
+}
 
-let parseStartSet = new Set<string>();
-let parseEndSet = new Set<string>();
-let lastLoadedModule = '';
-let lastParsedModule = '';
+type ModuleParseController = ReturnType<typeof createModuleParseController>;
 
-function clearParseTimeout() {
-  if (_parseTimeout) {
-    clearTimeout(_parseTimeout);
-    _parseTimeout = null;
+function clearParseTimeout(controller: ModuleParseController) {
+  if (controller.parseTimeout) {
+    clearTimeout(controller.parseTimeout);
+    controller.parseTimeout = null;
   }
 }
 
-function clearSettleTimeout() {
-  if (_settleTimeout) {
-    clearTimeout(_settleTimeout);
-    _settleTimeout = null;
+function clearSettleTimeout(controller: ModuleParseController) {
+  if (controller.settleTimeout) {
+    clearTimeout(controller.settleTimeout);
+    controller.settleTimeout = null;
   }
 }
 
-function resetParseState() {
-  clearParseTimeout();
-  clearSettleTimeout();
-  parseStartSet = new Set();
-  parseEndSet = new Set();
-  lastLoadedModule = '';
-  lastParsedModule = '';
-  parsePromise = new Promise((resolve) => {
-    _resolve = (v: any) => {
-      clearParseTimeout();
-      clearSettleTimeout();
-      resolve(v);
+function resetParseState(controller: ModuleParseController) {
+  clearParseTimeout(controller);
+  clearSettleTimeout(controller);
+  controller.parseStartSet = new Set();
+  controller.parseEndSet = new Set();
+  controller.lastLoadedModule = '';
+  controller.lastParsedModule = '';
+  controller.parsePromise = new Promise<ParseCompletion>((resolve) => {
+    controller.resolve = (result) => {
+      clearParseTimeout(controller);
+      clearSettleTimeout(controller);
+      resolve(result);
     };
   });
 }
 
-function setParseTimeout(timeout: number) {
-  if (!_parseTimeout) {
-    _parseTimeout = setTimeout(() => {
+function setParseTimeout(controller: ModuleParseController, timeout: number) {
+  if (!controller.parseTimeout) {
+    controller.parseTimeout = setTimeout(() => {
       mfWarn(`Parse timeout (${timeout}s) - forcing resolve`);
-      _resolve?.(1);
+      controller.resolve?.({ complete: false, reason: 'timeout' });
     }, timeout * 1000);
   }
 }
 
-function resetIdleTimeout(timeout: number) {
-  clearParseTimeout();
-  _parseTimeout = setTimeout(() => {
-    const pendingModules = Array.from(parseStartSet).filter(
-      (moduleId) => !parseEndSet.has(moduleId)
+function resetIdleTimeout(controller: ModuleParseController, timeout: number) {
+  clearParseTimeout(controller);
+  controller.parseTimeout = setTimeout(() => {
+    const pendingModules = Array.from(controller.parseStartSet).filter(
+      (moduleId) => !controller.parseEndSet.has(moduleId)
     );
     mfWarn(
       `moduleParseIdleTimeout: no module activity for ${timeout}s, forcing resolve. ` +
         'Some shared/remote dependencies may be missing. Consider increasing moduleParseIdleTimeout.' +
-        ` Tracked modules: ${parseEndSet.size}/${parseStartSet.size}.` +
-        (lastLoadedModule ? ` Last loaded: ${lastLoadedModule}.` : '') +
-        (lastParsedModule ? ` Last parsed: ${lastParsedModule}.` : '') +
+        ` Tracked modules: ${controller.parseEndSet.size}/${controller.parseStartSet.size}.` +
+        (controller.lastLoadedModule ? ` Last loaded: ${controller.lastLoadedModule}.` : '') +
+        (controller.lastParsedModule ? ` Last parsed: ${controller.lastParsedModule}.` : '') +
         (pendingModules.length ? ` Pending modules: ${pendingModules.slice(0, 10).join(', ')}` : '')
     );
-    _resolve?.(1);
+    controller.resolve?.({ complete: false, reason: 'idle-timeout' });
   }, timeout * 1000);
 }
 
-function scheduleParseCompletionCheck() {
-  clearSettleTimeout();
+function scheduleParseCompletionCheck(controller: ModuleParseController) {
+  clearSettleTimeout(controller);
   // Give Rollup/Vite a short scheduling window to load child modules after
   // parsing an importer. Some environments report moduleParsed before the
   // child load, without exposing resolution metadata on the module object.
-  _settleTimeout = setTimeout(() => {
-    _settleTimeout = null;
+  controller.settleTimeout = setTimeout(() => {
+    controller.settleTimeout = null;
     // Vite/Rolldown can report moduleParsed for cached or internally loaded
     // modules that did not pass through this plugin's load hook. Completion is
     // therefore a subset check: every tracked load must have parsed; additional
     // parsed modules do not keep the barrier open.
     const parseCompleted =
-      parseStartSet.size > 0 &&
-      Array.from(parseStartSet).every((moduleId) => parseEndSet.has(moduleId));
-    if (parseCompleted) _resolve?.(1);
+      controller.parseStartSet.size > 0 &&
+      Array.from(controller.parseStartSet).every((moduleId) =>
+        controller.parseEndSet.has(moduleId)
+      );
+    if (parseCompleted) {
+      controller.resolve?.({ complete: true, reason: 'graph-complete' });
+    }
   }, 10);
 }
 
@@ -97,49 +115,65 @@ interface ModuleParseOptions {
   exposedModuleImports?: string[];
 }
 
-export default function (excludeFn: Function, options: ModuleParseOptions): Plugin[] {
+function getConfiguredInputImports(input: unknown): string[] {
+  if (typeof input === 'string') return [input];
+  if (Array.isArray(input))
+    return input.filter((entry): entry is string => typeof entry === 'string');
+  if (!input || typeof input !== 'object') return [];
+  return Object.values(input).filter((entry): entry is string => typeof entry === 'string');
+}
+
+export default function (
+  excludeFn: Function,
+  options: ModuleParseOptions,
+  controller = createModuleParseController()
+): Plugin[] {
   // Large builds can exceed a fixed total timeout while still making progress.
   // Default to an idle timeout so we only force-resolve after parsing stalls.
   const idleTimeout = options.moduleParseIdleTimeout ?? options.moduleParseTimeout;
+  let configuredInputImports: string[] = [];
   return [
-    {
-      name: '_',
-      apply: 'serve',
-      config() {
-        // No waiting in development mode
-        _resolve?.(1);
-      },
-    },
     {
       enforce: 'pre',
       name: 'parseStart',
       apply: 'build',
+      configResolved(config) {
+        const buildOptions = config.build as typeof config.build & {
+          rolldownOptions?: { input?: unknown };
+        };
+        configuredInputImports = getConfiguredInputImports(
+          buildOptions.rollupOptions.input ?? buildOptions.rolldownOptions?.input
+        );
+      },
       async buildStart() {
-        resetParseState();
+        resetParseState(controller);
         if (idleTimeout) {
-          resetIdleTimeout(idleTimeout);
+          resetIdleTimeout(controller, idleTimeout);
         } else if (options.moduleParseTimeout) {
-          setParseTimeout(options.moduleParseTimeout);
+          setParseTimeout(controller, options.moduleParseTimeout);
         }
-        // Exposed modules are emitted as independent entry chunks rather than
-        // children of the application's entry graph. Seed them up front so an
-        // otherwise-complete entry cannot finalize shared export usage before
-        // Rollup starts loading those expose entries.
-        for (const importSource of options.exposedModuleImports || []) {
+        // Exposed modules and explicit Rollup inputs can be scheduled
+        // independently. Seed every known entry before loading starts so one
+        // fast entry cannot finalize shared export usage ahead of the others.
+        const entryImports = new Set([
+          ...(options.exposedModuleImports || []),
+          ...configuredInputImports,
+        ]);
+        for (const importSource of entryImports) {
           const resolved = await this.resolve(importSource);
           if (resolved && !resolved.external && !excludeFn(resolved.id)) {
-            parseStartSet.add(resolved.id);
+            controller.parseStartSet.add(resolved.id);
           }
         }
       },
       load(id) {
-        lastLoadedModule = id;
+        controller.lastLoadedModule = id;
         if (excludeFn(id)) {
           return;
         }
-        clearSettleTimeout();
-        if (idleTimeout) resetIdleTimeout(idleTimeout);
-        parseStartSet.add(id);
+        clearSettleTimeout(controller);
+        if (idleTimeout) resetIdleTimeout(controller, idleTimeout);
+        controller.parseStartSet.add(id);
       },
     },
     {
@@ -147,12 +181,12 @@ export default function (excludeFn: Function, options: ModuleParseOptions): Plug
       name: 'parseEnd',
       apply: 'build',
       moduleParsed(module) {
-        clearSettleTimeout();
+        clearSettleTimeout(controller);
         const id = module.id;
-        lastParsedModule = id;
+        controller.lastParsedModule = id;
         if (idleTimeout) {
           // Reset idle timer on every module — any activity means the build is still progressing.
-          resetIdleTimeout(idleTimeout);
+          resetIdleTimeout(controller, idleTimeout);
         }
         // Rollup reports moduleParsed for an importer before it necessarily
         // loads/parses that importer's dependencies. Seed the pending set from
@@ -171,21 +205,37 @@ export default function (excludeFn: Function, options: ModuleParseOptions): Plug
         ) => {
           for (const resolution of resolutions || []) {
             if (!resolution.external && !excludeFn(resolution.id)) {
-              parseStartSet.add(resolution.id);
+              controller.parseStartSet.add(resolution.id);
+            }
+          }
+        };
+        const addPendingIds = (ids: string[] | undefined) => {
+          for (const pendingId of ids || []) {
+            const moduleInfo = this.getModuleInfo(pendingId);
+            // External ids have no ModuleInfo. Only seed modules Rollup has
+            // admitted into the graph; unresolved/unknown ids remain covered by
+            // the load hook or make the completion result conservative.
+            if (moduleInfo && !excludeFn(pendingId)) {
+              controller.parseStartSet.add(pendingId);
             }
           }
         };
         addPendingResolutions(parsedModule.importedIdResolutions);
         addPendingResolutions(parsedModule.dynamicallyImportedIdResolutions);
-        if (!excludeFn(id)) {
-          parseEndSet.add(id);
+        if (parsedModule.importedIdResolutions === undefined) {
+          addPendingIds(module.importedIds);
         }
-        scheduleParseCompletionCheck();
+        if (parsedModule.dynamicallyImportedIdResolutions === undefined) {
+          addPendingIds(module.dynamicallyImportedIds);
+        }
+        if (!excludeFn(id)) {
+          controller.parseEndSet.add(id);
+        }
+        scheduleParseCompletionCheck(controller);
       },
       buildEnd() {
-        _resolve?.(1);
+        controller.resolve?.({ complete: false, reason: 'build-end' });
       },
     },
   ];
 }
-export { parsePromise };

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -21,12 +21,12 @@ import {
   getExposesCssMapPlaceholder,
   getHostAutoInitPath,
 } from '../virtualModules';
-import { parsePromise } from './pluginModuleParseEnd';
 
 interface ProxyRemoteEntryParams {
   options: NormalizedModuleFederationOptions;
   remoteEntryId: string;
   virtualExposesId: string;
+  getParsePromise?: () => Promise<unknown>;
 }
 
 function resolveDevHashEntryFileName(fileName: string) {
@@ -42,6 +42,7 @@ export default function ({
   options,
   remoteEntryId,
   virtualExposesId,
+  getParsePromise = () => Promise.resolve(),
 }: ProxyRemoteEntryParams): Plugin {
   let viteConfig: any, _command: string, root: string, originalConfigBase: string | undefined;
   let exposeRemoteDependencies: Record<string, string[]> = {};
@@ -205,7 +206,9 @@ export default function ({
     },
     async load(id: string) {
       if (id === remoteEntryId) {
-        return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
+        return getParsePromise().then((_) =>
+          generateRemoteEntry(options, virtualExposesId, _command)
+        );
       }
       if (id === virtualExposesId) {
         await refreshExposeRemoteDependencies(this);
@@ -219,7 +222,9 @@ export default function ({
       const transformedCode = await (async () => {
         if (!filterId(id)) return;
         if (id.includes(remoteEntryId)) {
-          return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
+          return getParsePromise().then((_) =>
+            generateRemoteEntry(options, virtualExposesId, _command)
+          );
         }
         if (id === virtualExposesId) {
           await refreshExposeRemoteDependencies(this);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -36,6 +36,7 @@ import {
   recordTreeShakingExports,
   resetTreeShakingExports,
   setTreeShakingBuildMode,
+  shouldAnalyzeSharedExports,
 } from '../utils/treeShaking';
 import {
   addUsedShares,
@@ -61,7 +62,6 @@ import {
   refreshTreeShakingModules,
   stripTreeShakingGraphQuery,
 } from '../virtualModules';
-import { parsePromise } from './pluginModuleParseEnd';
 
 function getPrebuildResolutionSource(pkgName: string, shareItem?: ShareItem): string {
   return getConcreteSharedImportSource(pkgName, shareItem) || pkgName;
@@ -256,8 +256,9 @@ export function proxySharedModule(options: {
   include?: string | string[];
   exclude?: string | string[];
   federationOptions?: NormalizedModuleFederationOptions;
+  getParsePromise?: () => Promise<unknown>;
 }): Plugin[] {
-  const { shared = {}, federationOptions } = options;
+  const { shared = {}, federationOptions, getParsePromise = () => Promise.resolve() } = options;
   let _config: ResolvedConfig | undefined;
   let _command = 'serve';
   let useDirectReactImport = false;
@@ -271,6 +272,9 @@ export function proxySharedModule(options: {
   // sources have been materialized so the heavy writes happen at most once each.
   const materializedLoadShareSources = new Set<string>();
   const emittedTreeShakingProviders = new Set<string>();
+  const hasAnalyzableShares = Object.values(shared).some((share) =>
+    shouldAnalyzeSharedExports(share)
+  );
 
   const normalizeTreeShakingOutputPath = (value: string) => {
     const normalized = normalizePathForImport(value);
@@ -345,7 +349,7 @@ export function proxySharedModule(options: {
       },
       load(id) {
         if (id === getResolvedLocalSharedImportMapId(federationOptions)) {
-          return parsePromise.then((_) => {
+          return getParsePromise().then((_) => {
             // Export analysis is additive across the module graph. Materialize
             // and emit optimized providers only when the shared map itself is
             // finalized, immediately before Rollup discovers their imports.
@@ -424,16 +428,10 @@ export function proxySharedModule(options: {
       shouldTransformCachedModule() {
         // Watch builds must revisit cached importers after the per-build usage
         // map is reset, otherwise only changed files contribute usedExports.
-        return (
-          _command === 'build' &&
-          Object.values(shared).some((share) => !!share.shareConfig.treeShaking)
-        );
+        return _command === 'build' && hasAnalyzableShares;
       },
       transform(code, id) {
-        if (
-          _command !== 'build' ||
-          !Object.keys(shared).some((key) => shared[key].shareConfig.treeShaking)
-        ) {
+        if (_command !== 'build' || !hasAnalyzableShares) {
           return;
         }
         collectTreeShakingImports(

--- a/src/utils/__tests__/treeShaking.test.ts
+++ b/src/utils/__tests__/treeShaking.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '../normalizeModuleFederationOptions';
 import {
   collectTreeShakingImports,
+  getSharedExportUsage,
   getTreeShakingExportUsage,
   getTreeShakingUsedExports,
   markTreeShakingPackageUnsafe,
@@ -32,6 +33,15 @@ function createShareItem(treeShaking?: TreeShakingConfig): ShareItem {
 const antdShare = createShareItem({ mode: 'runtime-infer' });
 const lodashPrefixShare = createShareItem({ mode: 'runtime-infer' });
 const notTreeShakenShare = createShareItem();
+const hostProvidedBaseShare = createShareItem();
+const hostProvidedShare: ShareItem = {
+  ...hostProvidedBaseShare,
+  name: 'host-only',
+  shareConfig: {
+    ...hostProvidedBaseShare.shareConfig,
+    import: false,
+  },
+};
 
 function createShared(): NormalizedShared {
   return {
@@ -156,6 +166,30 @@ describe('collectTreeShakingImports', () => {
     `);
 
     expect(recorded).toEqual([]);
+    expect(unsafe).toEqual([]);
+  });
+
+  it('collects host-provided import:false exports without a tree-shaking option', () => {
+    const recorded: RecordedUsage[] = [];
+    const unsafe: UnsafeUsage[] = [];
+    const shared: NormalizedShared = { 'host-only': hostProvidedShare };
+
+    collectTreeShakingImports(
+      `import { value2, value1 as first } from 'host-only';`,
+      '/repo/src/App.js',
+      shared,
+      findSharedKey,
+      (key, names, request) => recorded.push({ key, names, request }),
+      (key, request) => unsafe.push({ key, request })
+    );
+
+    expect(recorded).toEqual([
+      {
+        key: 'host-only',
+        names: ['value2', 'value1'],
+        request: 'host-only',
+      },
+    ]);
     expect(unsafe).toEqual([]);
   });
 
@@ -284,6 +318,16 @@ describe('tree-shaking export usage state', () => {
 
     setTreeShakingBuildMode(true);
     expect(getTreeShakingExportUsage('plain', notTreeShakenShare, 'plain')).toBeUndefined();
+  });
+
+  it('exposes inferred usage for import:false without enabling provider tree shaking', () => {
+    recordTreeShakingExports('host-only', ['value2', 'value1'], 'host-only');
+
+    expect(getSharedExportUsage('host-only', hostProvidedShare, 'host-only')).toEqual({
+      kind: 'exports',
+      usedExports: ['value1', 'value2'],
+    });
+    expect(getTreeShakingExportUsage('host-only', hostProvidedShare, 'host-only')).toBeUndefined();
   });
 
   it('keeps the legacy array accessor for callers that have not migrated yet', () => {

--- a/src/utils/treeShaking.ts
+++ b/src/utils/treeShaking.ts
@@ -24,6 +24,13 @@ export type TreeShakingExportUsage =
   | { kind: 'full' }
   | { kind: 'exports'; usedExports: string[] };
 
+export function shouldAnalyzeSharedExports(shareItem?: ShareItem) {
+  return !!(
+    shareItem &&
+    (shareItem.shareConfig.treeShaking || shareItem.shareConfig.import === false)
+  );
+}
+
 type RecordTreeShakingExports = (sharedKey: string, exports: string[], request?: string) => void;
 type MarkTreeShakingPackageUnsafe = (sharedKey: string, request?: string) => void;
 
@@ -137,19 +144,21 @@ function getExportRecords(
  * fallback lookup across keys keeps aliases/backwards-compatible callers
  * working, while still keeping each concrete request's exports isolated.
  */
-export function getTreeShakingExportUsage(
+export function getSharedExportUsage(
   request: string,
   shareItem?: ShareItem,
   sharedKey?: string,
   options?: NormalizedModuleFederationOptions
 ): TreeShakingExportUsage | undefined {
   const treeShaking = shareItem?.shareConfig.treeShaking;
-  if (!treeShaking || !getTreeShakingState(options).buildMode) return undefined;
+  if (!shouldAnalyzeSharedExports(shareItem) || !getTreeShakingState(options).buildMode) {
+    return undefined;
+  }
 
   const records = getExportRecords(sharedKey, request, options);
   if (records.some((record) => record.requiresFullBundle)) return { kind: 'full' };
 
-  const configured = treeShaking.usedExports ?? [];
+  const configured = treeShaking?.usedExports ?? [];
   const result = new Set(configured);
   records.forEach((record) => record.usedExports.forEach((name) => result.add(name)));
 
@@ -157,6 +166,16 @@ export function getTreeShakingExportUsage(
     return { kind: 'exports', usedExports: [...result].sort() };
   }
   return records.length > 0 ? { kind: 'exports', usedExports: [] } : { kind: 'unknown' };
+}
+
+export function getTreeShakingExportUsage(
+  request: string,
+  shareItem?: ShareItem,
+  sharedKey?: string,
+  options?: NormalizedModuleFederationOptions
+): TreeShakingExportUsage | undefined {
+  if (!shareItem?.shareConfig.treeShaking) return undefined;
+  return getSharedExportUsage(request, shareItem, sharedKey, options);
 }
 
 /**
@@ -331,8 +350,8 @@ function collectReExport(
  *
  * Parsing the module avoids treating import-looking text in comments, strings,
  * templates, or regular expressions as real dependencies. If parsing fails,
- * every configured tree-shaken share is conservatively marked as requiring its
- * full bundle instead of guessing from source text.
+ * every configured share whose exports are analyzed is conservatively marked
+ * as requiring its full export surface instead of guessing from source text.
  *
  * Generated federation wrappers are excluded because their imports describe
  * the wrapper implementation, not the consumer's requirements.
@@ -359,14 +378,14 @@ export function collectTreeShakingImports(
     ast = parseAst(code) as unknown as AstNode;
   } catch {
     Object.entries(shared).forEach(([sharedKey, shareItem]) => {
-      if (shareItem.shareConfig.treeShaking) markUnsafe(sharedKey, '*');
+      if (shouldAnalyzeSharedExports(shareItem)) markUnsafe(sharedKey, '*');
     });
     return;
   }
 
   const matchShared = (source: string) => {
     const sharedKey = findSharedKey(source, shared);
-    return sharedKey && shared[sharedKey]?.shareConfig.treeShaking ? sharedKey : undefined;
+    return sharedKey && shouldAnalyzeSharedExports(shared[sharedKey]) ? sharedKey : undefined;
   };
   const recordSource = (names: string[], source: string) => {
     const sharedKey = matchShared(source);

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2493,6 +2493,86 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('export { __mf_default as default }');
   });
 
+  it('emits only analyzed named exports for a finalized import:false consumer', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, undefined, {
+      kind: 'exports',
+      usedExports: ['default', 'get'],
+    });
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    expect(generatedCode).toContain('exportModule["get"]');
+    expect(generatedCode).toContain('__mf_0 as get');
+    expect(generatedCode).not.toContain('exportModule["delete"]');
+    expect(generatedCode).not.toContain('exportModule["request"]');
+    expect(generatedCode).toContain('export { __mf_default as default }');
+  });
+
+  it.each([{ kind: 'unknown' as const }, { kind: 'full' as const }])(
+    'keeps the complete import:false export surface for $kind analysis',
+    (usage) => {
+      const pkg = 'mock-package-with-reserved';
+      const mockShareItem: ShareItem = {
+        name: pkg,
+        from: '',
+        version: undefined,
+        shareConfig: {
+          import: false,
+          singleton: true,
+          strictVersion: false,
+          requiredVersion: '*',
+        },
+        scope: 'default',
+      };
+
+      writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, undefined, usage);
+
+      const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+      expect(generatedCode).toContain('exportModule["delete"]');
+      expect(generatedCode).toContain('exportModule["get"]');
+      expect(generatedCode).toContain('exportModule["request"]');
+    }
+  );
+
+  it('keeps the complete import:false export surface when analyzed exports are not detected locally', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, undefined, {
+      kind: 'exports',
+      usedExports: ['hostOnlyExport'],
+    });
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    expect(generatedCode).toContain('exportModule["delete"]');
+    expect(generatedCode).toContain('exportModule["get"]');
+    expect(generatedCode).toContain('exportModule["request"]');
+  });
+
   it('prefers browser conditional exports when detecting shared ESM named exports', () => {
     const pkg = 'mock-package-browser-conditional';
     const mockShareItem: ShareItem = {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -32,7 +32,7 @@ import {
   sharedCacheHelperCode,
 } from '../utils/packageUtils';
 import { normalizeNodeModulePath } from '../utils/pathNormalization';
-import { getTreeShakingExportUsage } from '../utils/treeShaking';
+import { getTreeShakingExportUsage, type TreeShakingExportUsage } from '../utils/treeShaking';
 import { findLikelyTypeArgumentEnd } from '../utils/typeArgumentScanner';
 import VirtualModule, { MF_OWNER_INFIX, normalizeVirtualModuleId } from '../utils/VirtualModule';
 import {
@@ -1671,6 +1671,21 @@ function generateDeferredHostProvidedExports(
     export { __mf_default as default };${namedExportLine}`;
 }
 
+function selectImportFalseNamedExports(
+  detectedNamedExports: string[] | undefined,
+  usage?: TreeShakingExportUsage
+) {
+  if (!detectedNamedExports || usage?.kind !== 'exports') {
+    return detectedNamedExports ?? [];
+  }
+
+  const usedNamedExports = new Set(usage.usedExports.filter((name) => name !== 'default'));
+  if ([...usedNamedExports].some((name) => !detectedNamedExports.includes(name))) {
+    return detectedNamedExports;
+  }
+  return detectedNamedExports.filter((name) => usedNamedExports.has(name));
+}
+
 function generateShareModuleUnwrapCode({
   source,
   preserveNamedExports,
@@ -1713,7 +1728,8 @@ export function writeLoadShareModule(
   command: string,
   _isRolldown: boolean,
   options?: NormalizedModuleFederationOptions,
-  exportConditions?: string[]
+  exportConditions?: string[],
+  importFalseExportUsage?: TreeShakingExportUsage
 ) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const { loadShareCacheMap } = getSharedVirtualModuleState(options);
@@ -1735,7 +1751,10 @@ export function writeLoadShareModule(
     // This enables `import { ref } from 'vue'` even though the module is provided by the host.
     // For packages that aren't installed, fall back to default-only export.
     const detectedNamedExports = getPackageNamedExports(pkg, exportConditions);
-    const namedExports = detectedNamedExports ?? [];
+    const namedExports = selectImportFalseNamedExports(
+      detectedNamedExports,
+      importFalseExportUsage
+    );
     let exportLine: string;
     if (namedExports.length > 0) {
       exportLine = generateDeferredHostProvidedExports(


### PR DESCRIPTION
## Summary

Limit the generated ESM consumer module for `import: false` shared dependencies to the named exports confirmed by production module graph analysis. Existing `treeShaking.usedExports` values are included when configured.

Previously, every named export binding detected from the local package was generated even when the application used only a subset. This change removes unused bindings when static analysis is reliable, reducing the consumer chunk size.

No new user-facing option or Module Federation runtime contract change is introduced.

## Changes

- Extend the existing AST-based shared import analysis to `import: false` consumers.
- Union export usage across application modules, exposed modules, and explicit Rollup/Rolldown inputs.
- Remove unused named export bindings only after the production module graph completes successfully.
- Preserve the complete locally detected named-export surface when analysis is not reliable.
- Isolate parse state per federation plugin instance and reset it for every build.

## Behavior

| Usage | Generated result |
| --- | --- |
| Static named imports | Only the union of analyzed exports and configured `usedExports` |
| Namespace, star, or dynamic usage; incomplete or mismatched analysis | Complete locally detected named-export surface |
| Local export detection is unavailable | Existing default-only fallback and warning |

## Tests

- [x] `pnpm test` — 48 files, 990 passed, 1 skipped
- [x] `pnpm exec vitest run integration/shared-deps.test.ts` — 11 passed
- [x] `pnpm typecheck`
- [x] `pnpm build`

The added coverage verifies:

- retaining the used `init` binding while omitting the unused `value1`, `value2`, and `value3` bindings
- unioning export usage across exposes and explicit Rollup inputs
- preserving the complete export surface for namespace usage or incomplete analysis
- isolating parse state across federation plugin instances and resetting it across consecutive builds

## Risk

Export usage is finalized only after successful module graph completion. Incomplete or uncertain analysis retains the complete locally detected export surface.
