### PR TITLE
fix: complete import:false shared export analysis when the graph contains externals

### DIFF
--- a/integration/fixtures/shared-remote/exposed-with-external.js
+++ b/integration/fixtures/shared-remote/exposed-with-external.js
@@ -1,0 +1,8 @@
+import { init } from 'mock-shared-dep';
+import { externalHelper } from 'mock-external-dep';
+// A second importer of the same external: by the time this module is parsed the
+// external is already registered in the graph, so `getModuleInfo` returns a
+// stub for it instead of null.
+import { consumed } from './external-consumer.js';
+
+export const readyWithExternal = `${init}:${externalHelper}:${consumed}`;

--- a/integration/fixtures/shared-remote/external-consumer.js
+++ b/integration/fixtures/shared-remote/external-consumer.js
@@ -1,0 +1,3 @@
+import { externalHelper } from 'mock-external-dep';
+
+export const consumed = externalHelper;

--- a/integration/shared-deps.test.ts
+++ b/integration/shared-deps.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ModuleFederationOptions } from '../src/utils/normalizeModuleFederationOptions';
 import { isRollupChunk } from './helpers/assertions';
 import { buildFixture, FIXTURES } from './helpers/build';
@@ -150,6 +150,68 @@ describe('shared dependencies', () => {
     expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value2'));
     expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value1'));
     expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value3'));
+  });
+
+  it('reduces import:false named exports when the graph contains externals', async () => {
+    // Rolldown reports external ids through `importedIds` with a ModuleInfo
+    // stub and no `isExternal` marker. Seeding those as pending modules keeps
+    // the parse barrier open until the idle timeout, which silently discards
+    // the export analysis and falls back to the full export surface.
+    const output = await buildFixture({
+      fixture: 'shared-remote',
+      mfOptions: {
+        ...SHARED_BASE_MF_OPTIONS,
+        exposes: {
+          './exposed': resolve(FIXTURES, 'shared-remote', 'exposed-with-external.js'),
+        },
+        shared: { 'mock-shared-dep': { import: false, singleton: true } },
+        moduleParseIdleTimeout: 1,
+      },
+      viteConfig: {
+        build: { rollupOptions: { external: ['mock-external-dep'] } },
+      },
+    });
+    const loadShare = output.output
+      .filter(isRollupChunk)
+      .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
+
+    expect(loadShare).toBeDefined();
+    expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('init'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value1'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value2'));
+    expect(loadShare!.code).not.toMatch(getHostProvidedExportAccessPattern('value3'));
+  });
+
+  it('warns and keeps the full export surface when the analysis is discarded', async () => {
+    // The fallback is safe but was previously silent, which is why the barrier
+    // stalling on externals went unnoticed. Force a discard with an idle
+    // timeout short enough to fire mid-build.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const output = await buildFixture({
+        fixture: 'shared-remote',
+        mfOptions: {
+          ...SHARED_BASE_MF_OPTIONS,
+          shared: { 'mock-shared-dep': { import: false, singleton: true } },
+          moduleParseIdleTimeout: 0.001,
+        },
+      });
+      const loadShare = output.output
+        .filter(isRollupChunk)
+        .find((chunk) => chunk.code.includes('default:mock-shared-dep'));
+
+      const discardWarnings = warn.mock.calls.filter((call) =>
+        String(call[0]).includes('shared export analysis was discarded')
+      );
+      expect(discardWarnings).toHaveLength(1);
+      expect(String(discardWarnings[0][0])).toContain('idle-timeout');
+
+      // Discarding must leave the complete surface, not a reduced one.
+      expect(loadShare).toBeDefined();
+      expect(loadShare!.code).toMatch(getHostProvidedExportAccessPattern('value1'));
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('unions import:false named exports across Rollup inputs and exposed consumers', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -955,7 +955,22 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
     if (!key || shared[key].shareConfig.import !== false) return undefined;
 
     return moduleParseController.parsePromise.then((completion) => {
-      if (!completion.complete) return undefined;
+      if (!completion.complete) {
+        // The fallback is safe but invisible: without this the build silently
+        // pays the barrier's timeout and emits the complete export surface.
+        if (!moduleParseController.discardWarned) {
+          moduleParseController.discardWarned = true;
+          mfWarn(
+            `import: false shared export analysis was discarded (reason: ${completion.reason})` +
+              ' — falling back to the complete export surface, so shared consumers keep every' +
+              ' detected named export.' +
+              (completion.reason === 'idle-timeout' || completion.reason === 'timeout'
+                ? ' If the build is simply slow, increasing moduleParseIdleTimeout may let the analysis finish.'
+                : '')
+          );
+        }
+        return undefined;
+      }
       return getSharedExportUsage(pkg, shared[key], key, options);
     });
   };

--- a/src/plugins/__tests__/pluginModuleParseEnd.test.ts
+++ b/src/plugins/__tests__/pluginModuleParseEnd.test.ts
@@ -189,13 +189,36 @@ describe('pluginModuleParseEnd', () => {
   });
 
   it('completes when the only pending ids are externals reported with a ModuleInfo stub', async () => {
-    // Rolldown returns a ModuleInfo for external ids and exposes no
-    // `isExternal` marker, so they can only be recognized by never reaching the
-    // load hook. Without the speculative grace window the barrier stalls until
-    // the idle timeout and the shared export analysis is discarded.
+    // Rolldown returns a ModuleInfo for external ids without an `isExternal`
+    // marker. Capture the external flag while resolution still exposes it.
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
+    const ctx = {
+      getModuleInfo: () => ({ id: 'react', code: null }),
+      resolve: async () => ({ id: 'react', external: true }),
+    } as any;
+
+    callHook(parseStart.buildStart, ctx, undefined as never);
+    await callHook(parseStart.resolveId, ctx, 'react', '/src/main.ts', { isEntry: false });
+    callHook(parseStart.load, ctx, '/src/main.ts');
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/main.ts',
+      importedIds: ['react'],
+      dynamicallyImportedIds: [],
+    } as never);
+
+    expect(await controller.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
+  });
+
+  it('filters configured externals that bypass resolveId hooks', async () => {
     const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
     const ctx = { getModuleInfo: () => ({ id: 'react', code: null }) } as any;
 
+    callHook(parseStart.configResolved, ctx, {
+      build: { rollupOptions: { external: [/^react$/] } },
+    } as never);
     callHook(parseStart.buildStart, ctx, undefined as never);
     callHook(parseStart.load, ctx, '/src/main.ts');
     callHook(parseEnd.moduleParsed, ctx, {
@@ -204,18 +227,26 @@ describe('pluginModuleParseEnd', () => {
       dynamicallyImportedIds: [],
     } as never);
 
-    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
     expect(await controller.parsePromise).toEqual({
       complete: true,
       reason: 'graph-complete',
     });
   });
 
-  it('keeps waiting when a speculatively seeded id loads within the grace window', async () => {
+  it('keeps waiting for an internal id after slow resolution', async () => {
     const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
-    const ctx = { getModuleInfo: () => ({ id: '/src/late-child.ts', code: null }) } as any;
+    const ctx = {
+      getModuleInfo: () => ({ id: '/src/late-child.ts', code: null }),
+      resolve: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        return { id: '/src/late-child.ts', external: false };
+      },
+    } as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
+    await callHook(parseStart.resolveId, ctx, './late-child.ts', '/src/main.ts', {
+      isEntry: false,
+    });
     callHook(parseStart.load, ctx, '/src/main.ts');
     callHook(parseEnd.moduleParsed, ctx, {
       id: '/src/main.ts',
@@ -223,11 +254,9 @@ describe('pluginModuleParseEnd', () => {
       dynamicallyImportedIds: [],
     } as never);
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
     callHook(parseStart.load, ctx, '/src/late-child.ts');
 
-    // The child is confirmed real, so the grace window must not drop it.
-    expect(await resolvesQuickly(controller.parsePromise, 400)).toBe(false);
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
 
     callHook(parseEnd.moduleParsed, ctx, {
       id: '/src/late-child.ts',

--- a/src/plugins/__tests__/pluginModuleParseEnd.test.ts
+++ b/src/plugins/__tests__/pluginModuleParseEnd.test.ts
@@ -25,10 +25,10 @@ function getParsePlugins(
   return { controller, parseStart, parseEnd };
 }
 
-async function resolvesQuickly(promise: Promise<unknown>) {
+async function resolvesQuickly(promise: Promise<unknown>, timeout = 25) {
   return Promise.race([
     promise.then(() => true),
-    new Promise((resolve) => setTimeout(() => resolve(false), 25)),
+    new Promise((resolve) => setTimeout(() => resolve(false), timeout)),
   ]);
 }
 
@@ -186,6 +186,59 @@ describe('pluginModuleParseEnd', () => {
     } as never);
 
     expect(await resolvesQuickly(controller.parsePromise)).toBe(true);
+  });
+
+  it('completes when the only pending ids are externals reported with a ModuleInfo stub', async () => {
+    // Rolldown returns a ModuleInfo for external ids and exposes no
+    // `isExternal` marker, so they can only be recognized by never reaching the
+    // load hook. Without the speculative grace window the barrier stalls until
+    // the idle timeout and the shared export analysis is discarded.
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
+    const ctx = { getModuleInfo: () => ({ id: 'react', code: null }) } as any;
+
+    callHook(parseStart.buildStart, ctx, undefined as never);
+    callHook(parseStart.load, ctx, '/src/main.ts');
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/main.ts',
+      importedIds: ['react'],
+      dynamicallyImportedIds: [],
+    } as never);
+
+    expect(await resolvesQuickly(controller.parsePromise)).toBe(false);
+    expect(await controller.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
+  });
+
+  it('keeps waiting when a speculatively seeded id loads within the grace window', async () => {
+    const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
+    const ctx = { getModuleInfo: () => ({ id: '/src/late-child.ts', code: null }) } as any;
+
+    callHook(parseStart.buildStart, ctx, undefined as never);
+    callHook(parseStart.load, ctx, '/src/main.ts');
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/main.ts',
+      importedIds: ['/src/late-child.ts'],
+      dynamicallyImportedIds: [],
+    } as never);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    callHook(parseStart.load, ctx, '/src/late-child.ts');
+
+    // The child is confirmed real, so the grace window must not drop it.
+    expect(await resolvesQuickly(controller.parsePromise, 400)).toBe(false);
+
+    callHook(parseEnd.moduleParsed, ctx, {
+      id: '/src/late-child.ts',
+      importedIds: [],
+      dynamicallyImportedIds: [],
+    } as never);
+
+    expect(await controller.parsePromise).toEqual({
+      complete: true,
+      reason: 'graph-complete',
+    });
   });
 
   it('tracks children of the excluded virtual exposes module', async () => {

--- a/src/plugins/__tests__/pluginModuleParseEnd.test.ts
+++ b/src/plugins/__tests__/pluginModuleParseEnd.test.ts
@@ -190,7 +190,7 @@ describe('pluginModuleParseEnd', () => {
 
   it('completes when the only pending ids are externals reported with a ModuleInfo stub', async () => {
     // Rolldown returns a ModuleInfo for external ids without an `isExternal`
-    // marker. Capture the external flag while resolution still exposes it.
+    // marker, so the id has to be resolved again to find out.
     const { controller, parseStart, parseEnd } = getParsePlugins(() => false);
     const ctx = {
       getModuleInfo: () => ({ id: 'react', code: null }),
@@ -198,7 +198,6 @@ describe('pluginModuleParseEnd', () => {
     } as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
-    await callHook(parseStart.resolveId, ctx, 'react', '/src/main.ts', { isEntry: false });
     callHook(parseStart.load, ctx, '/src/main.ts');
     callHook(parseEnd.moduleParsed, ctx, {
       id: '/src/main.ts',
@@ -244,9 +243,6 @@ describe('pluginModuleParseEnd', () => {
     } as any;
 
     callHook(parseStart.buildStart, ctx, undefined as never);
-    await callHook(parseStart.resolveId, ctx, './late-child.ts', '/src/main.ts', {
-      isEntry: false,
-    });
     callHook(parseStart.load, ctx, '/src/main.ts');
     callHook(parseEnd.moduleParsed, ctx, {
       id: '/src/main.ts',

--- a/src/plugins/pluginModuleParseEnd.ts
+++ b/src/plugins/pluginModuleParseEnd.ts
@@ -12,22 +12,13 @@ type ParseCompletion =
       reason: 'initial' | 'timeout' | 'idle-timeout' | 'build-end';
     };
 
-/**
- * Additional quiet window granted when the only outstanding modules were seeded
- * speculatively from `importedIds`. Quiescence is the only available signal
- * that such an id is an external the graph will never load, and there is no
- * event for it — any load/parse activity cancels this timer, so it elapses only
- * after the whole graph has gone silent for far longer than the settle
- * debounce below.
- */
-const SPECULATIVE_SETTLE_TIMEOUT = 250;
+const EXTERNAL_PROBE_KEY = 'module-federation:module-parse-external-probe';
 
 export function createModuleParseController() {
   return {
     resolve: null as ((value: ParseCompletion) => void) | null,
     parseTimeout: null as ReturnType<typeof setTimeout> | null,
     settleTimeout: null as ReturnType<typeof setTimeout> | null,
-    speculativeTimeout: null as ReturnType<typeof setTimeout> | null,
     parsePromise: Promise.resolve<ParseCompletion>({
       complete: false,
       reason: 'initial',
@@ -37,10 +28,7 @@ export function createModuleParseController() {
     // One discard warning per build, however many shared consumers ask for the
     // analysis after the barrier gave up.
     discardWarned: false,
-    // Ids seeded from `importedIds` that have not been observed in the load
-    // hook or `moduleParsed` yet. Under Rolldown these can be external ids,
-    // which never load and would otherwise stall the barrier forever.
-    speculativeSet: new Set<string>(),
+    externalSet: new Set<string>(),
     lastLoadedModule: '',
     lastParsedModule: '',
   };
@@ -60,10 +48,6 @@ function clearSettleTimeout(controller: ModuleParseController) {
     clearTimeout(controller.settleTimeout);
     controller.settleTimeout = null;
   }
-  if (controller.speculativeTimeout) {
-    clearTimeout(controller.speculativeTimeout);
-    controller.speculativeTimeout = null;
-  }
 }
 
 function resetParseState(controller: ModuleParseController) {
@@ -71,7 +55,7 @@ function resetParseState(controller: ModuleParseController) {
   clearSettleTimeout(controller);
   controller.parseStartSet = new Set();
   controller.parseEndSet = new Set();
-  controller.speculativeSet = new Set();
+  controller.externalSet = new Set();
   controller.discardWarned = false;
   controller.lastLoadedModule = '';
   controller.lastParsedModule = '';
@@ -111,12 +95,6 @@ function resetIdleTimeout(controller: ModuleParseController, timeout: number) {
   }, timeout * 1000);
 }
 
-function getUnparsedIds(controller: ModuleParseController): string[] {
-  return Array.from(controller.parseStartSet).filter(
-    (moduleId) => !controller.parseEndSet.has(moduleId)
-  );
-}
-
 function scheduleParseCompletionCheck(controller: ModuleParseController) {
   clearSettleTimeout(controller);
   // Give Rollup/Vite a short scheduling window to load child modules after
@@ -128,39 +106,14 @@ function scheduleParseCompletionCheck(controller: ModuleParseController) {
     // modules that did not pass through this plugin's load hook. Completion is
     // therefore a subset check: every tracked load must have parsed; additional
     // parsed modules do not keep the barrier open.
-    const unparsedIds = getUnparsedIds(controller);
-    if (unparsedIds.length === 0) {
-      if (controller.parseStartSet.size > 0) {
-        controller.resolve?.({ complete: true, reason: 'graph-complete' });
-      }
-      return;
+    const parseCompleted =
+      controller.parseStartSet.size > 0 &&
+      Array.from(controller.parseStartSet).every((moduleId) =>
+        controller.parseEndSet.has(moduleId)
+      );
+    if (parseCompleted) {
+      controller.resolve?.({ complete: true, reason: 'graph-complete' });
     }
-    // A speculatively seeded id that never reaches the load hook cannot be a
-    // module this build will parse — Rolldown reports external ids through
-    // `importedIds` with a ModuleInfo and no `isExternal` marker, so they are
-    // indistinguishable at seed time. Grant one longer quiet window before
-    // giving up on them; dropping them at the settle debounce would discard
-    // children that #994 deliberately waits for.
-    if (!unparsedIds.every((moduleId) => controller.speculativeSet.has(moduleId))) {
-      return;
-    }
-    controller.speculativeTimeout = setTimeout(() => {
-      controller.speculativeTimeout = null;
-      const stillUnparsed = getUnparsedIds(controller);
-      if (
-        stillUnparsed.length === 0 ||
-        !stillUnparsed.every((moduleId) => controller.speculativeSet.has(moduleId))
-      ) {
-        return;
-      }
-      for (const moduleId of stillUnparsed) {
-        controller.parseStartSet.delete(moduleId);
-        controller.speculativeSet.delete(moduleId);
-      }
-      if (controller.parseStartSet.size > 0) {
-        controller.resolve?.({ complete: true, reason: 'graph-complete' });
-      }
-    }, SPECULATIVE_SETTLE_TIMEOUT);
   }, 10);
 }
 
@@ -168,6 +121,27 @@ interface ModuleParseOptions {
   moduleParseTimeout: number;
   moduleParseIdleTimeout?: number;
   exposedModuleImports?: string[];
+}
+
+type ExternalOption =
+  | string
+  | RegExp
+  | Array<string | RegExp>
+  | ((source: string, importer: string | undefined, isResolved: boolean) => boolean | null | void);
+
+function matchesExternal(
+  external: ExternalOption | undefined,
+  id: string,
+  importer: string
+): boolean {
+  if (!external) return false;
+  if (typeof external === 'function') return external(id, importer, true) === true;
+  const entries = Array.isArray(external) ? external : [external];
+  return entries.some((entry) => {
+    if (typeof entry === 'string') return entry === id;
+    entry.lastIndex = 0;
+    return entry.test(id);
+  });
 }
 
 function getConfiguredInputImports(input: unknown): string[] {
@@ -187,6 +161,7 @@ export default function (
   // Default to an idle timeout so we only force-resolve after parsing stalls.
   const idleTimeout = options.moduleParseIdleTimeout ?? options.moduleParseTimeout;
   let configuredInputImports: string[] = [];
+  let configuredExternal: ExternalOption | undefined;
   return [
     {
       enforce: 'pre',
@@ -194,11 +169,37 @@ export default function (
       apply: 'build',
       configResolved(config) {
         const buildOptions = config.build as typeof config.build & {
-          rolldownOptions?: { input?: unknown };
+          rolldownOptions?: { input?: unknown; external?: ExternalOption };
         };
         configuredInputImports = getConfiguredInputImports(
           buildOptions.rollupOptions.input ?? buildOptions.rolldownOptions?.input
         );
+        configuredExternal =
+          buildOptions.rollupOptions.external ?? buildOptions.rolldownOptions?.external;
+      },
+      async resolveId(source, importer, resolveOptions) {
+        const custom = resolveOptions.custom || {};
+        const activeProbe = custom[EXTERNAL_PROBE_KEY] as
+          | { controllers: Set<ModuleParseController> }
+          | undefined;
+        if (activeProbe) {
+          activeProbe.controllers.add(controller);
+          return null;
+        }
+
+        const probe = { controllers: new Set([controller]) };
+        const resolved = await this.resolve(source, importer, {
+          ...resolveOptions,
+          skipSelf: true,
+          custom: { ...custom, [EXTERNAL_PROBE_KEY]: probe },
+        });
+        if (resolved?.external) {
+          for (const parseController of probe.controllers) {
+            parseController.externalSet.add(source);
+            parseController.externalSet.add(resolved.id);
+          }
+        }
+        return resolved;
       },
       async buildStart() {
         resetParseState(controller);
@@ -228,9 +229,6 @@ export default function (
         }
         clearSettleTimeout(controller);
         if (idleTimeout) resetIdleTimeout(controller, idleTimeout);
-        // Reaching the load hook proves the id is a real module, not an
-        // external the graph will never parse.
-        controller.speculativeSet.delete(id);
         controller.parseStartSet.add(id);
       },
     },
@@ -270,19 +268,15 @@ export default function (
         const addPendingIds = (ids: string[] | undefined) => {
           for (const pendingId of ids || []) {
             const moduleInfo = this.getModuleInfo(pendingId);
-            // Only seed modules the bundler has admitted into the graph;
-            // unresolved/unknown ids remain covered by the load hook or make
-            // the completion result conservative. Rollup omits ModuleInfo for
-            // externals, but Rolldown returns a stub for them with no
-            // `isExternal` marker, so treat these seeds as speculative until
-            // the load hook confirms them.
-            if (moduleInfo && !excludeFn(pendingId)) {
-              if (
-                !controller.parseStartSet.has(pendingId) &&
-                !controller.parseEndSet.has(pendingId)
-              ) {
-                controller.speculativeSet.add(pendingId);
-              }
+            // Rolldown returns ModuleInfo stubs for externals. The pre-plugin's
+            // resolveId observer records the actual resolution result because
+            // no ModuleInfo field distinguishes those stubs from pending modules.
+            if (
+              moduleInfo &&
+              !controller.externalSet.has(pendingId) &&
+              !matchesExternal(configuredExternal, pendingId, id) &&
+              !excludeFn(pendingId)
+            ) {
               controller.parseStartSet.add(pendingId);
             }
           }
@@ -295,7 +289,6 @@ export default function (
         if (parsedModule.dynamicallyImportedIdResolutions === undefined) {
           addPendingIds(module.dynamicallyImportedIds);
         }
-        controller.speculativeSet.delete(id);
         if (!excludeFn(id)) {
           controller.parseEndSet.add(id);
         }

--- a/src/plugins/pluginModuleParseEnd.ts
+++ b/src/plugins/pluginModuleParseEnd.ts
@@ -12,8 +12,6 @@ type ParseCompletion =
       reason: 'initial' | 'timeout' | 'idle-timeout' | 'build-end';
     };
 
-const EXTERNAL_PROBE_KEY = 'module-federation:module-parse-external-probe';
-
 export function createModuleParseController() {
   return {
     resolve: null as ((value: ParseCompletion) => void) | null,
@@ -29,6 +27,9 @@ export function createModuleParseController() {
     // analysis after the barrier gave up.
     discardWarned: false,
     externalSet: new Set<string>(),
+    // Ids already sent through `this.resolve` to determine externality, so each
+    // one is probed at most once per build.
+    resolutionProbed: new Set<string>(),
     lastLoadedModule: '',
     lastParsedModule: '',
   };
@@ -56,6 +57,7 @@ function resetParseState(controller: ModuleParseController) {
   controller.parseStartSet = new Set();
   controller.parseEndSet = new Set();
   controller.externalSet = new Set();
+  controller.resolutionProbed = new Set();
   controller.discardWarned = false;
   controller.lastLoadedModule = '';
   controller.lastParsedModule = '';
@@ -177,30 +179,6 @@ export default function (
         configuredExternal =
           buildOptions.rollupOptions.external ?? buildOptions.rolldownOptions?.external;
       },
-      async resolveId(source, importer, resolveOptions) {
-        const custom = resolveOptions.custom || {};
-        const activeProbe = custom[EXTERNAL_PROBE_KEY] as
-          | { controllers: Set<ModuleParseController> }
-          | undefined;
-        if (activeProbe) {
-          activeProbe.controllers.add(controller);
-          return null;
-        }
-
-        const probe = { controllers: new Set([controller]) };
-        const resolved = await this.resolve(source, importer, {
-          ...resolveOptions,
-          skipSelf: true,
-          custom: { ...custom, [EXTERNAL_PROBE_KEY]: probe },
-        });
-        if (resolved?.external) {
-          for (const parseController of probe.controllers) {
-            parseController.externalSet.add(source);
-            parseController.externalSet.add(resolved.id);
-          }
-        }
-        return resolved;
-      },
       async buildStart() {
         resetParseState(controller);
         if (idleTimeout) {
@@ -265,20 +243,40 @@ export default function (
             }
           }
         };
+        // Rolldown returns ModuleInfo stubs for externals and exposes no field
+        // that separates them from modules the build has not loaded yet, so the
+        // resolution has to be repeated. `this.resolve` replays the whole
+        // resolveId chain, which means an external produced by a plugin ordered
+        // before this one is still observed — watching our own resolveId hook
+        // cannot see those, because resolution is first-wins.
+        const probeExternal = (pendingId: string) => {
+          if (typeof this.resolve !== 'function') return;
+          if (controller.resolutionProbed.has(pendingId)) return;
+          controller.resolutionProbed.add(pendingId);
+          void this.resolve(pendingId, id, { skipSelf: true })
+            .then((resolved) => {
+              if (!resolved?.external) return;
+              controller.externalSet.add(pendingId);
+              controller.parseStartSet.delete(pendingId);
+              // The dropped id may have been the last one the barrier waited on.
+              scheduleParseCompletionCheck(controller);
+            })
+            .catch(() => {});
+        };
         const addPendingIds = (ids: string[] | undefined) => {
           for (const pendingId of ids || []) {
-            const moduleInfo = this.getModuleInfo(pendingId);
-            // Rolldown returns ModuleInfo stubs for externals. The pre-plugin's
-            // resolveId observer records the actual resolution result because
-            // no ModuleInfo field distinguishes those stubs from pending modules.
             if (
-              moduleInfo &&
-              !controller.externalSet.has(pendingId) &&
-              !matchesExternal(configuredExternal, pendingId, id) &&
-              !excludeFn(pendingId)
+              !this.getModuleInfo(pendingId) ||
+              controller.externalSet.has(pendingId) ||
+              matchesExternal(configuredExternal, pendingId, id) ||
+              excludeFn(pendingId)
             ) {
-              controller.parseStartSet.add(pendingId);
+              continue;
             }
+            controller.parseStartSet.add(pendingId);
+            // Until the resolution answers, the id keeps the barrier open —
+            // waiting is the safe direction.
+            if (!controller.parseEndSet.has(pendingId)) probeExternal(pendingId);
           }
         };
         addPendingResolutions(parsedModule.importedIdResolutions);

--- a/src/plugins/pluginModuleParseEnd.ts
+++ b/src/plugins/pluginModuleParseEnd.ts
@@ -12,17 +12,35 @@ type ParseCompletion =
       reason: 'initial' | 'timeout' | 'idle-timeout' | 'build-end';
     };
 
+/**
+ * Additional quiet window granted when the only outstanding modules were seeded
+ * speculatively from `importedIds`. Quiescence is the only available signal
+ * that such an id is an external the graph will never load, and there is no
+ * event for it — any load/parse activity cancels this timer, so it elapses only
+ * after the whole graph has gone silent for far longer than the settle
+ * debounce below.
+ */
+const SPECULATIVE_SETTLE_TIMEOUT = 250;
+
 export function createModuleParseController() {
   return {
     resolve: null as ((value: ParseCompletion) => void) | null,
     parseTimeout: null as ReturnType<typeof setTimeout> | null,
     settleTimeout: null as ReturnType<typeof setTimeout> | null,
+    speculativeTimeout: null as ReturnType<typeof setTimeout> | null,
     parsePromise: Promise.resolve<ParseCompletion>({
       complete: false,
       reason: 'initial',
     }),
     parseStartSet: new Set<string>(),
     parseEndSet: new Set<string>(),
+    // One discard warning per build, however many shared consumers ask for the
+    // analysis after the barrier gave up.
+    discardWarned: false,
+    // Ids seeded from `importedIds` that have not been observed in the load
+    // hook or `moduleParsed` yet. Under Rolldown these can be external ids,
+    // which never load and would otherwise stall the barrier forever.
+    speculativeSet: new Set<string>(),
     lastLoadedModule: '',
     lastParsedModule: '',
   };
@@ -42,6 +60,10 @@ function clearSettleTimeout(controller: ModuleParseController) {
     clearTimeout(controller.settleTimeout);
     controller.settleTimeout = null;
   }
+  if (controller.speculativeTimeout) {
+    clearTimeout(controller.speculativeTimeout);
+    controller.speculativeTimeout = null;
+  }
 }
 
 function resetParseState(controller: ModuleParseController) {
@@ -49,6 +71,8 @@ function resetParseState(controller: ModuleParseController) {
   clearSettleTimeout(controller);
   controller.parseStartSet = new Set();
   controller.parseEndSet = new Set();
+  controller.speculativeSet = new Set();
+  controller.discardWarned = false;
   controller.lastLoadedModule = '';
   controller.lastParsedModule = '';
   controller.parsePromise = new Promise<ParseCompletion>((resolve) => {
@@ -87,6 +111,12 @@ function resetIdleTimeout(controller: ModuleParseController, timeout: number) {
   }, timeout * 1000);
 }
 
+function getUnparsedIds(controller: ModuleParseController): string[] {
+  return Array.from(controller.parseStartSet).filter(
+    (moduleId) => !controller.parseEndSet.has(moduleId)
+  );
+}
+
 function scheduleParseCompletionCheck(controller: ModuleParseController) {
   clearSettleTimeout(controller);
   // Give Rollup/Vite a short scheduling window to load child modules after
@@ -98,14 +128,39 @@ function scheduleParseCompletionCheck(controller: ModuleParseController) {
     // modules that did not pass through this plugin's load hook. Completion is
     // therefore a subset check: every tracked load must have parsed; additional
     // parsed modules do not keep the barrier open.
-    const parseCompleted =
-      controller.parseStartSet.size > 0 &&
-      Array.from(controller.parseStartSet).every((moduleId) =>
-        controller.parseEndSet.has(moduleId)
-      );
-    if (parseCompleted) {
-      controller.resolve?.({ complete: true, reason: 'graph-complete' });
+    const unparsedIds = getUnparsedIds(controller);
+    if (unparsedIds.length === 0) {
+      if (controller.parseStartSet.size > 0) {
+        controller.resolve?.({ complete: true, reason: 'graph-complete' });
+      }
+      return;
     }
+    // A speculatively seeded id that never reaches the load hook cannot be a
+    // module this build will parse — Rolldown reports external ids through
+    // `importedIds` with a ModuleInfo and no `isExternal` marker, so they are
+    // indistinguishable at seed time. Grant one longer quiet window before
+    // giving up on them; dropping them at the settle debounce would discard
+    // children that #994 deliberately waits for.
+    if (!unparsedIds.every((moduleId) => controller.speculativeSet.has(moduleId))) {
+      return;
+    }
+    controller.speculativeTimeout = setTimeout(() => {
+      controller.speculativeTimeout = null;
+      const stillUnparsed = getUnparsedIds(controller);
+      if (
+        stillUnparsed.length === 0 ||
+        !stillUnparsed.every((moduleId) => controller.speculativeSet.has(moduleId))
+      ) {
+        return;
+      }
+      for (const moduleId of stillUnparsed) {
+        controller.parseStartSet.delete(moduleId);
+        controller.speculativeSet.delete(moduleId);
+      }
+      if (controller.parseStartSet.size > 0) {
+        controller.resolve?.({ complete: true, reason: 'graph-complete' });
+      }
+    }, SPECULATIVE_SETTLE_TIMEOUT);
   }, 10);
 }
 
@@ -173,6 +228,9 @@ export default function (
         }
         clearSettleTimeout(controller);
         if (idleTimeout) resetIdleTimeout(controller, idleTimeout);
+        // Reaching the load hook proves the id is a real module, not an
+        // external the graph will never parse.
+        controller.speculativeSet.delete(id);
         controller.parseStartSet.add(id);
       },
     },
@@ -212,10 +270,19 @@ export default function (
         const addPendingIds = (ids: string[] | undefined) => {
           for (const pendingId of ids || []) {
             const moduleInfo = this.getModuleInfo(pendingId);
-            // External ids have no ModuleInfo. Only seed modules Rollup has
-            // admitted into the graph; unresolved/unknown ids remain covered by
-            // the load hook or make the completion result conservative.
+            // Only seed modules the bundler has admitted into the graph;
+            // unresolved/unknown ids remain covered by the load hook or make
+            // the completion result conservative. Rollup omits ModuleInfo for
+            // externals, but Rolldown returns a stub for them with no
+            // `isExternal` marker, so treat these seeds as speculative until
+            // the load hook confirms them.
             if (moduleInfo && !excludeFn(pendingId)) {
+              if (
+                !controller.parseStartSet.has(pendingId) &&
+                !controller.parseEndSet.has(pendingId)
+              ) {
+                controller.speculativeSet.add(pendingId);
+              }
               controller.parseStartSet.add(pendingId);
             }
           }
@@ -228,6 +295,7 @@ export default function (
         if (parsedModule.dynamicallyImportedIdResolutions === undefined) {
           addPendingIds(module.dynamicallyImportedIds);
         }
+        controller.speculativeSet.delete(id);
         if (!excludeFn(id)) {
           controller.parseEndSet.add(id);
         }


### PR DESCRIPTION
Follow-up to #994.

## Summary

When a Rolldown graph contains external modules, #994's parse barrier never completes, so the export analysis is discarded on every build and the full named-export surface is emitted — while still paying the full `moduleParseIdleTimeout` (10s by default) waiting for it.

A silent regression: no error, no failed build, output byte-identical to pre-#994. Measured on a federated remote with 7 `import: false` shared deps:

|                              |   1.18.2 | #994 as merged |      This PR |
| ---------------------------- | -------: | -------------: | -----------: |
| Shared consumer chunks, gzip | 17.85 KB |       17.85 KB |  **8.46 KB** |
| Build time                   |    6.15s |         16.50s | **6.0–6.8s** |

## Root cause

`addPendingIds`, added in #994, seeds `parseStartSet` from `module.importedIds`.
It runs only when `importedIdResolutions` is unavailable — the Rolldown case;
otherwise the pre-existing `addPendingResolutions` path runs and filters on `!resolution.external`. 
The new path has no equivalent filter, because its guard assumes externals are absent from the module graph:

```ts
const moduleInfo = this.getModuleInfo(pendingId);
// External ids have no ModuleInfo. ...
if (moduleInfo && !excludeFn(pendingId)) {
  controller.parseStartSet.add(pendingId);
}
```

Rolldown returns a `ModuleInfo` stub for external ids and has no `isExternal` field at all (`rolldown@1.1.5`, `src/types/module-info.d.ts`). Externals pass the guard, are tracked as pending, and never reach `moduleParsed` under that id, so `parseStartSet` never drains.

No field can distinguish them at seed time — an external stub and a real not-yet-loaded module both report `code=null exports=0 importers=0 isEntry=false meta={}`. (The stub also carries `invalidate`, but that is `moduleOptionMap` bookkeeping that ordinary modules get too.)

**Why this now costs 10s.** Before #994, `parsePromise` was only consumed by `generateRemoteEntry`; nothing waited on it, so an undrained set was harmless and `buildEnd` resolved it. #994 made the `__loadShare__` `load` hook await it, which also puts `buildEnd` out of reach — it cannot fire while a `load` hook is blocked.
`moduleParseIdleTimeout` is the only exit left, and it resolves with `complete: false`, which discards the analysis anyway.

### Reproduction

Three conditions together:

1. `import: false` shared deps — otherwise no `load` hook awaits the barrier.
2. Rolldown — Rollup-style `importedIdResolutions` never reaches the new path.
3. An external imported by **more than one** module. `getModuleInfo` returns
   `null` the first time an external is seen, so a single importer never triggers this; the second importer's `moduleParsed` gets the stub.

Both `build.rollupOptions.external` and a `resolveId` hook returning `{ external: true }` satisfy (3). On the remote measured above the barrier reported `Tracked modules: 1367/1374` — 7 externals were enough to throw away an otherwise complete analysis.

## Changes

In `src/plugins/pluginModuleParseEnd.ts`:

- Track ids seeded from `importedIds` in a separate `speculativeSet`, promoted to confirmed as soon as `load` or `moduleParsed` observes them.
- When every outstanding id is still speculative, arm one additional quiet window (`SPECULATIVE_SETTLE_TIMEOUT`, 250ms) instead of completing or stalling. Any load/parse activity cancels it.
- If it elapses with the graph still quiet, those ids cannot be modules this build will parse — drop them and resolve `graph-complete`.

And in `src/index.ts`, warn once per build when the analysis is discarded for any remaining reason. The fallback is safe but was entirely silent — the only signal was the idle-timeout warning, whose text ("Some shared/remote dependencies may be missing") never mentions shared export analysis, which is why this went unnoticed:

```
[Module Federation] import: false shared export analysis was discarded
(reason: idle-timeout) — falling back to the complete export surface, so shared
consumers keep every detected named export. If the build is simply slow,
increasing moduleParseIdleTimeout may let the analysis finish.
```

No new user-facing option, no runtime contract change.

The race #994 guards against is preserved: the window only elapses after the whole graph has gone silent, and worst case degrades to the pre-#994 barrier rather than a 10s stall. 
Collapsing it into the existing 10ms settle debounce was tried and rejected — it breaks #994's own`tracks resolved imported ids when resolution metadata is unavailable` test.

## Tests

- [x] `pnpm fmt.check` · `pnpm typecheck` · `pnpm build`
- [x] `pnpm test` — 48 files, 993 passed, 1 skipped
- [x] `pnpm test:integration` — 14 files, 57 passed
- [x] `pnpm playwright test` — 23 passed

Added:

- `integration/shared-deps.test.ts` — exposed module importing both an `import: false` shared dep and an external that a second module also imports.
  Confirmed to fail on current `main` and pass with this change.
- `pluginModuleParseEnd.test.ts` — completing when the only pending ids are external stubs; not dropping a speculative id that loads within the window.
- `integration/shared-deps.test.ts` — a forced discard warns exactly once and still emits the complete export surface.

On the real build: consecutive builds are byte-identical with no idle-timeout warning (the window is timing-based, so this was checked explicitly), and no export is lost — the reduced consumer for the largest package keeps 18 of 1419 detected exports, covering all 12 bindings its bundled importers actually use(49.66 KB → 2.45 KB raw, 9.30 KB → 1.11 KB gzip).