### PR TITLE
chore: add automatic support for a DEV host consuming a PROD React remote

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -65,6 +65,10 @@ vi.mock('../utils/logger', async () => {
 });
 
 import { federation } from '../index';
+import {
+  REACT_MIXED_MODE_ESBUILD_PLUGIN,
+  REACT_MIXED_MODE_ROLLDOWN_PLUGIN,
+} from '../plugins/pluginReactMixedModeGuard';
 import VirtualModule from '../utils/VirtualModule';
 import {
   getPreBuildLibImportId,
@@ -1222,6 +1226,72 @@ describe('vite:module-federation-early-init', () => {
     expect(resolver.resolveId('react', '/repo/node_modules/react-dom/cjs/react-dom.js')).toBe(
       undefined
     );
+  });
+
+  it('guards React DEV runtimes for Rolldown dev hosts with remotes', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        remotes: { remote: 'remote@http://localhost:4174/remoteEntry.js' },
+        shared: { react: { singleton: true } },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = { root: process.cwd(), optimizeDeps: { include: [] } };
+    runConfig(plugin, { meta: { rolldownVersion: '1.0.0' } } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    const guard = config.optimizeDeps.rolldownOptions.plugins.find(
+      (entry: { name: string }) => entry.name === REACT_MIXED_MODE_ROLLDOWN_PLUGIN
+    );
+    expect(guard).toBeDefined();
+    expect(
+      guard.transform(
+        'return null === dispatcher ? null : dispatcher.getOwner();',
+        '/repo/node_modules/react/cjs/react-jsx-runtime.development.js'
+      )
+    ).toContain('typeof dispatcher?.getOwner === "function"');
+  });
+
+  it('guards React DEV runtimes for esbuild dev hosts with remotes', () => {
+    const plugin = (
+      federation({
+        name: 'host',
+        remotes: { remote: 'remote@http://localhost:4174/remoteEntry.js' },
+        shared: { react: { singleton: true } },
+      }) as Plugin[]
+    ).find((entry) => entry.name === 'vite:module-federation-early-init');
+    if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+    const config: any = { root: process.cwd(), optimizeDeps: { include: [] } };
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(
+      config.optimizeDeps.esbuildOptions.plugins.some(
+        (entry: { name: string }) => entry.name === REACT_MIXED_MODE_ESBUILD_PLUGIN
+      )
+    ).toBe(true);
+  });
+
+  it('does not install the React mixed-mode guard without remotes', () => {
+    const plugin = getEarlyInitPluginWithReactShared();
+    const config: any = { root: process.cwd(), optimizeDeps: { include: [] } };
+    runConfig(plugin, { meta: { rolldownVersion: '1.0.0' } } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(
+      config.optimizeDeps.rolldownOptions.plugins.some(
+        (entry: { name: string }) => entry.name === REACT_MIXED_MODE_ROLLDOWN_PLUGIN
+      )
+    ).toBe(false);
   });
 
   it('decouples Rolldown react-dom/client from the react-dom optimizer entry', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ import pluginManifest from './plugins/pluginMFManifest';
 import pluginModuleParseEnd, { createModuleParseController } from './plugins/pluginModuleParseEnd';
 import pluginProxyRemoteEntry from './plugins/pluginProxyRemoteEntry';
 import pluginProxyRemotes from './plugins/pluginProxyRemotes';
+import {
+  createEsbuildReactMixedModeGuard,
+  createRolldownReactMixedModeGuard,
+} from './plugins/pluginReactMixedModeGuard';
 import { findSharedKey, proxySharedModule } from './plugins/pluginProxySharedModule_preBuild';
 import { pluginRemoteNamedExports } from './plugins/pluginRemoteNamedExports';
 import { pluginSSRRemoteEntry } from './plugins/pluginSSRRemoteEntry';
@@ -421,6 +425,8 @@ function includeLinkedSharedEntries(
 function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOptions): Plugin {
   const { shared, remotes } = options;
   const isLitShare = (pkg: string) => pkg === 'lit' || pkg.startsWith('lit/');
+  const shouldGuardReactMixedMode =
+    Object.keys(remotes ?? {}).length > 0 && shared?.react?.shareConfig.singleton === true;
 
   return {
     name: 'vite:module-federation-early-init',
@@ -471,6 +477,9 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
           if (isRolldown) {
             optimizeDeps.rolldownOptions ??= {};
             optimizeDeps.rolldownOptions.plugins ??= [];
+            if (shouldGuardReactMixedMode) {
+              optimizeDeps.rolldownOptions.plugins.push(createRolldownReactMixedModeGuard());
+            }
             optimizeDeps.rolldownOptions.plugins.push({
               name: 'module-federation:optimize-shared-resolver',
               load(id: string) {
@@ -541,6 +550,9 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
           } else {
             optimizeDeps.esbuildOptions ??= {};
             optimizeDeps.esbuildOptions.plugins ??= [];
+            if (shouldGuardReactMixedMode) {
+              optimizeDeps.esbuildOptions.plugins.push(createEsbuildReactMixedModeGuard());
+            }
             optimizeDeps.esbuildOptions.plugins.push({
               name: 'module-federation:optimize-shared-proxy',
               setup(build: any) {

--- a/src/plugins/__tests__/pluginReactMixedModeGuard.test.ts
+++ b/src/plugins/__tests__/pluginReactMixedModeGuard.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  createEsbuildReactMixedModeGuard,
+  createRolldownReactMixedModeGuard,
+  patchReactDevelopmentRuntime,
+} from '../pluginReactMixedModeGuard';
+
+const unsafe = 'return null === dispatcher ? null : dispatcher.getOwner();';
+
+describe('React mixed-mode guard', () => {
+  it.each([
+    'react.development.js',
+    'react-jsx-runtime.development.js',
+    'react-jsx-dev-runtime.development.js',
+  ])('guards %s', (filename) => {
+    const id = `/repo/node_modules/react/cjs/${filename}`;
+    const result = patchReactDevelopmentRuntime(unsafe, id);
+
+    expect(result).toContain('typeof dispatcher?.getOwner === "function"');
+    expect(result).not.toContain(unsafe);
+  });
+
+  it('ignores production and non-React modules', () => {
+    expect(
+      patchReactDevelopmentRuntime(
+        unsafe,
+        '/repo/node_modules/react/cjs/react-jsx-runtime.production.js'
+      )
+    ).toBeUndefined();
+    expect(
+      patchReactDevelopmentRuntime(unsafe, '/repo/node_modules/other/cjs/react.development.js')
+    ).toBeUndefined();
+  });
+
+  it('exposes the guard as a Rolldown transform', () => {
+    const plugin = createRolldownReactMixedModeGuard();
+    const result = plugin.transform(
+      unsafe,
+      '/repo/node_modules/react/cjs/react-jsx-runtime.development.js'
+    );
+
+    expect(result).toContain('typeof dispatcher?.getOwner === "function"');
+  });
+
+  it('exposes the guard as an esbuild onLoad hook', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-react-guard-'));
+    const reactCjs = path.join(root, 'node_modules/react/cjs');
+    const runtime = path.join(reactCjs, 'react-jsx-runtime.development.js');
+    mkdirSync(reactCjs, { recursive: true });
+    writeFileSync(runtime, unsafe);
+
+    try {
+      let onLoad: ((args: { path: string }) => any) | undefined;
+      createEsbuildReactMixedModeGuard().setup({
+        onLoad(_options: unknown, handler: typeof onLoad) {
+          onLoad = handler;
+        },
+      });
+
+      expect(onLoad).toBeDefined();
+      const result = onLoad?.({ path: runtime });
+      expect(result?.contents).toContain('typeof dispatcher?.getOwner === "function"');
+      expect(result?.loader).toBe('js');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/pluginReactMixedModeGuard.ts
+++ b/src/plugins/pluginReactMixedModeGuard.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+
+const REACT_DEVELOPMENT_RUNTIME =
+  /[\\/]react[\\/]cjs[\\/]react(?:-jsx-(?:dev-)?runtime)?\.development\.js$/;
+const UNSAFE_GET_OWNER = 'return null === dispatcher ? null : dispatcher.getOwner();';
+const SAFE_GET_OWNER =
+  'return typeof dispatcher?.getOwner === "function" ? dispatcher.getOwner() : null;';
+
+export const REACT_MIXED_MODE_ROLLDOWN_PLUGIN = 'module-federation:react-mixed-mode-rolldown';
+export const REACT_MIXED_MODE_ESBUILD_PLUGIN = 'module-federation:react-mixed-mode-esbuild';
+
+export function patchReactDevelopmentRuntime(code: string, id: string): string | undefined {
+  if (!REACT_DEVELOPMENT_RUNTIME.test(id)) return;
+  const patched = code.replaceAll(UNSAFE_GET_OWNER, SAFE_GET_OWNER);
+  return patched === code ? undefined : patched;
+}
+
+export function createRolldownReactMixedModeGuard() {
+  return {
+    name: REACT_MIXED_MODE_ROLLDOWN_PLUGIN,
+    transform(code: string, id: string) {
+      return patchReactDevelopmentRuntime(code, id);
+    },
+  };
+}
+
+export function createEsbuildReactMixedModeGuard() {
+  return {
+    name: REACT_MIXED_MODE_ESBUILD_PLUGIN,
+    setup(build: any) {
+      build.onLoad({ filter: REACT_DEVELOPMENT_RUNTIME }, (args: { path: string }) => {
+        const code = readFileSync(args.path, 'utf8');
+        const patched = patchReactDevelopmentRuntime(code, args.path);
+        if (patched === undefined) return;
+        return { contents: patched, loader: 'js' };
+      });
+    },
+  };
+}


### PR DESCRIPTION
Adds automatic support for a DEV host consuming a PROD React remote. The Vite dependency optimizer safely guards React’s DEV-only dispatcher.getOwner() call when the production renderer does not provide it. Supports Rolldown and esbuild without modifying React inside node_modules.