### PR TITLE
fix: skip preloading dynamic-only remote exposes

### DIFF
--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -65,8 +65,9 @@ describe('host build', () => {
     expect(bootstrapAsset?.source).toContain('const { initHost } = __mfHostInit;');
     expect(bootstrapAsset?.source).toContain('const runtime = await initHost();');
     expect(bootstrapAsset?.source).toMatch(
-      /__mfPreloadRemote\("__mfe_internal__hostApp__mf_owner__\d+__remote1\/Module", "remote1\/Module"\)/
+      /__mfPreloadRemote\("__mfe_internal__hostApp__mf_owner__\d+__remote1", "remote1"\)/
     );
+    expect(bootstrapAsset?.source).not.toContain('remote1/Module');
     expect(bootstrapAsset?.source).toContain('runtime.loadRemote(runtimeRemote)');
     expect(bootstrapAsset?.source).toContain('})().then(() => __mfImport(');
     expect(bootstrapAsset?.source).toContain('globalThis.System.import(src)');
@@ -108,6 +109,13 @@ describe('host build', () => {
     // but it's loaded through the module graph rather than an HTML script tag
     expect(getChunkNames(output).some((name) => name.includes('hostInit'))).toBe(true);
     expect(getAllChunkCode(output)).toContain('initializeSharing');
+    const entryBootstrap = output.output.find(
+      (item) => item.type === 'chunk' && item.code.includes('__mfRemotePreloads')
+    );
+    expect(entryBootstrap?.code).toMatch(
+      /__mfPreloadRemote\("__mfe_internal__hostApp__mf_owner__\d+__remote1", "remote1"\)/
+    );
+    expect(entryBootstrap?.code).not.toMatch(/__mfPreloadRemote\([^)]*remote1\/Module/);
   });
 
   it('embeds configured federation name in remoteEntry chunk', async () => {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -25,6 +25,7 @@ import {
   addUsedRemote,
   getRuntimeRemoteId,
   getUsedRemotesMap,
+  isDynamicOnlyRemote,
 } from '../virtualModules/virtualRemotes';
 import {
   getRuntimeModuleCacheBootstrapCode,
@@ -315,6 +316,7 @@ const __mfCurrentScript = document.currentScript;
     const remotePreloads = shouldPreloadRemotes
       ? Object.entries(getUsedRemotesMap(federationOptions))
           .flatMap(([, remotes]) => Array.from(remotes))
+          .filter((remote) => !federationOptions || !isDynamicOnlyRemote(remote, federationOptions))
           .sort()
           .map(
             (remote) =>

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -22,7 +22,12 @@ import type { Plugin } from 'vite';
 import { createCodePositionMap } from '../utils/codePositionMap';
 import { CodeRewriter, type SourceMapLike } from '../utils/codeRewriter';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
-import { LOAD_REMOTE_TAG, LOAD_SHARE_TAG } from '../virtualModules';
+import {
+  LOAD_REMOTE_TAG,
+  LOAD_SHARE_TAG,
+  markDynamicRemote,
+  markStaticRemote,
+} from '../virtualModules';
 
 const JS_EXTENSIONS_RE = /\.(?:[mc]?[jt]sx?|vue|svelte)(?:\?|$)/;
 
@@ -55,6 +60,7 @@ interface ExportAllInfo {
 
 interface DynamicImportInfo {
   kind: 'dynamic';
+  source: string;
   start: number;
   end: number;
   originalText: string;
@@ -76,6 +82,22 @@ interface WalkVisitor {
 
 function isAstNode(value: unknown): value is { type: string; [key: string]: unknown } {
   return !!value && typeof value === 'object' && typeof (value as any).type === 'string';
+}
+
+function findStaticRemoteSources(code: string, isRemoteImport: (source: string) => boolean) {
+  const codePositions = createCodePositionMap(code);
+  const sources = new Set<string>();
+  const patterns = [
+    /\b(?:import|export)\s+[^;]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*["']([^"']+)["']/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of code.matchAll(pattern)) {
+      const source = match[1];
+      if (codePositions[match.index!] && isRemoteImport(source)) sources.add(source);
+    }
+  }
+  return sources;
 }
 
 function walkAST(root: unknown, visitor: WalkVisitor): void {
@@ -377,6 +399,7 @@ async function collectFromAST(
 
         result.push({
           kind: 'dynamic',
+          source: value,
           start: node.start,
           end: node.end,
           originalText: code.slice(node.start, node.end),
@@ -492,6 +515,7 @@ function collectFromRegex(
 
     result.push({
       kind: 'dynamic',
+      source,
       start: match.index!,
       end: match.index! + full.length,
       originalText: full,
@@ -530,6 +554,9 @@ export function pluginRemoteNamedExports(options: NormalizedModuleFederationOpti
       // Quick bail-out: does the source mention any remote name?
       if (!remoteNames.some((name) => code.includes(name))) return;
       const matchesRemoteImport = (source: string) => isRemoteImport(source, id);
+      for (const source of findStaticRemoteSources(code, matchesRemoteImport)) {
+        markStaticRemote(source, options);
+      }
 
       let imports: ImportInfo[] | undefined;
 
@@ -545,6 +572,9 @@ export function pluginRemoteNamedExports(options: NormalizedModuleFederationOpti
       }
 
       if (!imports) return;
+      for (const remoteImport of imports) {
+        if (remoteImport.kind === 'dynamic') markDynamicRemote(remoteImport.source, options);
+      }
       return applyRewrites(code, imports, id);
     },
   };

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -6,8 +6,20 @@ import {
   generateRemotes,
   getRemoteVirtualModule,
   getUsedRemotesMap,
+  isDynamicOnlyRemote,
+  markDynamicRemote,
+  markStaticRemote,
   resolveRemoteInitMode,
 } from '../virtualRemotes';
+
+it('classifies an expose as dynamic-only until a static import is seen', () => {
+  const options = {} as never;
+  markDynamicRemote('remote/Card', options);
+  expect(isDynamicOnlyRemote('remote/Card', options)).toBe(true);
+
+  markStaticRemote('remote/Card', options);
+  expect(isDynamicOnlyRemote('remote/Card', options)).toBe(false);
+});
 
 const mockOptions = vi.hoisted(() => ({
   shareStrategy: 'version-first' as 'version-first' | 'loaded-first',

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -27,6 +27,8 @@ export {
   addUsedRemote,
   getRemoteVirtualModule,
   getUsedRemotesMap,
+  markDynamicRemote,
+  markStaticRemote,
   LOAD_REMOTE_TAG,
 } from './virtualRemotes';
 

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -63,6 +63,8 @@ const usedRemotesByOptions = new WeakMap<
   NormalizedModuleFederationOptions,
   Record<string, Set<string>>
 >();
+const dynamicRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
+const staticRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
 
 function getScopedUsedRemotesMap(options: NormalizedModuleFederationOptions) {
   let scoped = usedRemotesByOptions.get(options);
@@ -93,6 +95,31 @@ export function addUsedRemote(
 export function getUsedRemotesMap(options?: NormalizedModuleFederationOptions) {
   if (options) return getScopedUsedRemotesMap(options);
   return usedRemotesMap;
+}
+
+export function markDynamicRemote(remote: string, options: NormalizedModuleFederationOptions) {
+  let remotes = dynamicRemotesByOptions.get(options);
+  if (!remotes) {
+    remotes = new Set();
+    dynamicRemotesByOptions.set(options, remotes);
+  }
+  remotes.add(remote);
+}
+
+export function markStaticRemote(remote: string, options: NormalizedModuleFederationOptions) {
+  let remotes = staticRemotesByOptions.get(options);
+  if (!remotes) {
+    remotes = new Set();
+    staticRemotesByOptions.set(options, remotes);
+  }
+  remotes.add(remote);
+}
+
+export function isDynamicOnlyRemote(remote: string, options: NormalizedModuleFederationOptions) {
+  return (
+    (dynamicRemotesByOptions.get(options)?.has(remote) ?? false) &&
+    !(staticRemotesByOptions.get(options)?.has(remote) ?? false)
+  );
 }
 
 function getRemoteAliasFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {


### PR DESCRIPTION
Close #998 

Prevents `version-first` hosts from preloading dynamic-only remote exposes while preserving remote initialization and static expose preloading.