### PR TITLE
fix: preserve public aliases for loadRemote

### DIFF
--- a/e2e/vite-webpack-rspack/tests/index.spec.ts
+++ b/e2e/vite-webpack-rspack/tests/index.spec.ts
@@ -43,6 +43,10 @@ test.describe('Vite Host Tests', () => {
     ]);
   });
 
+  test('loadRemote resolves a plugin-configured public alias', async ({ page }) => {
+    await expect(page.getByTestId('configured-load-remote')).toHaveText('loaded');
+  });
+
   test('test footer - vite host', async ({ page }) => {
     const productsHeading = page.getByRole('heading', {
       level: 3,

--- a/examples/vite-webpack-rspack/host/src/App.tsx
+++ b/examples/vite-webpack-rspack/host/src/App.tsx
@@ -79,6 +79,10 @@ const App = () => {
   const [randomBanner, setRandomBanner] = React.useState<'SignUpBanner' | 'SpecialPromo'>(
     'SpecialPromo'
   );
+  const RuntimeModuleRemoteProduct = useDynamicImport({
+    module: 'Product',
+    scope: 'moduleRemote',
+  });
 
   const Banner = useDynamicImport({
     module: randomBanner,
@@ -102,6 +106,9 @@ const App = () => {
           <Suspense fallback="Loading...">
             <ModuleRemoteProduct />
           </Suspense>
+          <span data-testid="configured-load-remote">
+            {RuntimeModuleRemoteProduct ? 'loaded' : 'loading'}
+          </span>
           <Suspense fallback="Loading...">
             <VarRemotePurchasesCount />
           </Suspense>

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -361,6 +361,27 @@ describe('generateRemotes', () => {
     expect(code).toContain('"alias":"alias"');
   });
 
+  it('keeps the public alias when runtime names are owner-scoped', () => {
+    mockOptions.shareStrategy = 'loaded-first';
+    const options = {
+      internalName: '__mfe_internal__host',
+      shareStrategy: 'loaded-first',
+      remotes: {
+        remote: {
+          entryGlobalName: 'remote',
+          name: 'remote',
+          type: 'module',
+          entry: 'http://localhost:4174/remoteEntry.js',
+        },
+      },
+    } as never;
+
+    const code = generateRemotes('remote/Button', 'serve', false, 'client', options);
+
+    expect(code).toMatch(/"name":"__mfe_internal__host__mf_owner__\d+__remote"/);
+    expect(code).toContain('"alias":"remote"');
+  });
+
   it('skips remote registration when a scoped id matches no configured remote', () => {
     mockOptions.shareStrategy = 'loaded-first';
     const code = generateRemotes('@scope/unknown/Button', 'serve');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -283,7 +283,7 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
           if (!remote) return null;
           return `
                 {
-                  alias: ${JSON.stringify(getRuntimeRemoteAlias(key, options))},
+                  alias: ${JSON.stringify(key)},
                   entryGlobalName: ${JSON.stringify(remote.entryGlobalName)},
                   name: ${JSON.stringify(
                     options ? getRuntimeRemoteAlias(key, options) : remote.name

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -364,7 +364,7 @@ export function generateRemotes(
       ? `runtime.registerRemotes([${JSON.stringify({
           entryGlobalName: remote.entryGlobalName,
           name: options ? runtimeRemoteAlias : remote.name,
-          alias: runtimeRemoteAlias,
+          alias: remoteAlias,
           type: remote.type,
           entry: remote.entry,
           shareScope: remote.shareScope ?? 'default',


### PR DESCRIPTION
Close #999 

Preserve public remote aliases so loadRemote() works in dev mode while internal names remain owner-scoped.