### PR TITLE
fix: shared export scan should correctly resolve nested template literals

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -210,6 +210,9 @@ vi.mock('../../utils/packageUtils', () => ({
     if (pkg === 'mock-package-cjs-star-entry') {
       return '/repo/apps/remote/node_modules/mock-package-cjs-star-entry/index.mjs';
     }
+    if (pkg === 'mock-package-nested-template-literal') {
+      return '/repo/apps/remote/node_modules/mock-package-nested-template-literal/index.js';
+    }
     if (pkg === 'mock-package-esm-only/stores' || pkg === 'mock-package-esm-only') {
       return '/repo/apps/remote/node_modules/mock-package-esm-only/dist/stores.js';
     }
@@ -479,6 +482,8 @@ vi.mock('fs', () => ({
       filePath.endsWith('/mock-package-cjs-star-entry/index.mjs') ||
       filePath.endsWith('node_modules/mock-package-cjs-star-entry/index.cjs') ||
       filePath.endsWith('/mock-package-cjs-star-entry/index.cjs') ||
+      filePath.endsWith('node_modules/mock-package-nested-template-literal/index.js') ||
+      filePath.endsWith('/mock-package-nested-template-literal/index.js') ||
       filePath.endsWith('node_modules/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('/mock-package-dual-shape/dist/browser.js') ||
       filePath.endsWith('node_modules/mock-package-cjs-comment/index.js') ||
@@ -670,6 +675,17 @@ export const buttonBase = 1;`;
     }
     if (filePath.endsWith('node_modules/mock-package-cjs-star-entry/index.cjs')) {
       return 'module.exports = { fromCommonJs: true };';
+    }
+    if (filePath.endsWith('node_modules/mock-package-nested-template-literal/index.js')) {
+      // Markup assembled from template literals nested inside the `${...}`
+      // interpolations of an outer template literal. The `/` of the closing tag
+      // is what makes a desynced scan observable: once a nested backtick is
+      // mistaken for the outer closing backtick, the remaining template text is
+      // scanned as code and that slash opens a regex which never closes.
+      return [
+        "const body = 'text';",
+        'export const injectedHtml = `${`<div>`}${body}${`</div>`}`;',
+      ].join('\n');
     }
     if (
       filePath.endsWith('node_modules/lit/package.json') ||
@@ -2665,6 +2681,10 @@ describe('writeLoadShareModule', () => {
     expect(
       getSharedNamedExports('mock-package-cjs-star-entry', undefined, ['node', 'import', 'default'])
     ).toEqual(['fromCommonJs']);
+  });
+
+  it('detects named exports past a nested template literal interpolation', () => {
+    expect(getSharedNamedExports('mock-package-nested-template-literal')).toEqual(['injectedHtml']);
   });
 
   it('uses worker conditional exports for webworker SSR', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -353,6 +353,9 @@ function resolveReExportModule(
   }
 }
 
+/** Marks a template-literal frame whose text (not its interpolation) is being scanned. */
+const TEMPLATE_TEXT = Symbol('templateText');
+
 function hasTopLevelDeclaratorComma(
   source: string,
   start: number,
@@ -362,9 +365,33 @@ function hasTopLevelDeclaratorComma(
   let quote: string | undefined;
   let escaped = false;
   let canStartRegex = true;
+  // Template literals cannot be treated as plain quoted strings: a nested
+  // template inside a `${...}` interpolation would close the outer one early,
+  // after which real template text is scanned as code. That desync miscounts
+  // brace depth and lets constructs like `</Tag>` be read as a regex, so the
+  // scan reports a phantom top-level comma. Track template text and
+  // interpolations explicitly instead. Entries are either TEMPLATE_TEXT or the
+  // brace depth at which an interpolation opened.
+  const templateFrames: (typeof TEMPLATE_TEXT | number)[] = [];
+  const inTemplateText = () => templateFrames[templateFrames.length - 1] === TEMPLATE_TEXT;
 
   for (let index = start; index < source.length; index++) {
     const char = source[index];
+    if (inTemplateText()) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '$' && source[index + 1] === '{') {
+        templateFrames.push(depth);
+        index++;
+        canStartRegex = true;
+      } else if (char === '`') {
+        templateFrames.pop();
+        canStartRegex = false;
+      }
+      continue;
+    }
     if (quote) {
       if (escaped) {
         escaped = false;
@@ -375,7 +402,12 @@ function hasTopLevelDeclaratorComma(
       }
       continue;
     }
-    if (char === '"' || char === "'" || char === '`') {
+    if (char === '`') {
+      templateFrames.push(TEMPLATE_TEXT);
+      canStartRegex = false;
+      continue;
+    }
+    if (char === '"' || char === "'") {
       quote = char;
       canStartRegex = false;
       continue;
@@ -462,12 +494,25 @@ function hasTopLevelDeclaratorComma(
       continue;
     }
     if (char === ')' || char === ']' || char === '}') {
+      // A `}` closing a `${...}` interpolation returns to the template text it
+      // was opened from rather than unwinding the surrounding brace depth.
+      if (
+        char === '}' &&
+        templateFrames.length > 0 &&
+        templateFrames[templateFrames.length - 1] === depth
+      ) {
+        templateFrames.pop();
+        canStartRegex = false;
+        continue;
+      }
       depth = Math.max(0, depth - 1);
       canStartRegex = false;
       continue;
     }
-    if (depth === 0 && char === ',') return true;
-    if (depth === 0 && char === ';') return false;
+    // Commas and semicolons inside an interpolation belong to that expression,
+    // not to the declarator list, even when the brace depth happens to be 0.
+    if (templateFrames.length === 0 && depth === 0 && char === ',') return true;
+    if (templateFrames.length === 0 && depth === 0 && char === ';') return false;
     if (!/\s/.test(char)) {
       canStartRegex = char !== '.';
     }


### PR DESCRIPTION
`hasTopLevelDeclaratorComma` treated a backtick as a plain quote, so a template literal nested inside a `${...}` interpolation closed the outer template early. Everything after that point was scanned as code: brace depth drifted, and a `/` sitting in template text was read as the start of a regex, which then never closes and reports a phantom top-level comma.

A phantom comma marks the whole export scan incomplete, so `getSharedNamedExports` returns undefined. Since #918 gated `usesDeferredSingletonFallback` on `hasCompleteExportCoverage`, losing coverage silently downgrades a `singleton: true` share to a locally pre-built copy. The remote then never joins the host's share scope and the library is instantiated twice, which breaks any module-level state or context the singleton was meant to guarantee.

This affects any shared package whose entry transitively re-exports a module that builds markup from nested template literals, and it has been present in every version since 1.17.1.

Track template text and interpolations on an explicit stack so the scanner stays in sync, and ignore commas and semicolons that appear inside an interpolation.

Minimal reproduction:

    const body = 'text';
    export const injectedHtml = `${`<div>`}${body}${`</div>`}`;