### PR TITLE
fix: dynamically load eager shared map

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1120,7 +1120,7 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
   });
 
-  it('statically includes the local shared map when a local eager share is configured', async () => {
+  it('loads the local shared map dynamically when a local eager share is configured', async () => {
     const mod = await import('../virtualRemoteEntry');
     const eagerShare = {
       name: 'eager-shared',
@@ -1146,10 +1146,9 @@ describe('virtualRemoteEntry', () => {
     );
 
     expect(code).toMatch(
-      /import \* as __mfLocalSharedImportMap from "virtual:mf-localSharedImportMap:__mfe_internal__host__mf_owner__\d+";/
+      /retrySharedInit\(\(\) => import\("virtual:mf-localSharedImportMap:__mfe_internal__host__mf_owner__\d+"\)\)/
     );
-    expect(code).toContain('return __mfLocalSharedImportMap;');
-    expect(code).not.toContain('retrySharedInit(() => import("virtual:mf-localSharedImportMap');
+    expect(code).not.toContain('__mfLocalSharedImportMap');
   });
 
   it('patches server-calc providers from Snapshot and coverage-caches runtime selections', async () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -934,9 +934,6 @@ export function generateRemoteEntry(
   const hasTreeShakingShared = Object.values(options.shared ?? {}).some(
     (share) => !!share?.shareConfig.treeShaking
   );
-  const hasEagerShared = Object.values(options.shared ?? {}).some(
-    (share) => share?.shareConfig.eager === true && share.shareConfig.import !== false
-  );
   const hasMultipleShareScopes = Array.isArray(options.shareScope);
   const runtimeImports = [
     'init as runtimeInit',
@@ -995,11 +992,6 @@ export function generateRemoteEntry(
   }
   import {${runtimeImports}} from "@module-federation/runtime";
   ${
-    hasEagerShared
-      ? `import * as __mfLocalSharedImportMap from "${getLocalSharedImportMapPath(options)}";`
-      : ''
-  }
-  ${
     runtimeHelperImports.length
       ? `import {${runtimeHelperImports.join(', ')}} from "@module-federation/runtime/helpers";`
       : ''
@@ -1052,16 +1044,11 @@ export function generateRemoteEntry(
   ${needsSharedProviderSelectionHelper ? externalSharedProviderSelectionHelperCode : ''}
 
   async function getLocalSharedImportMap() {
-    ${hasEagerShared ? 'return __mfLocalSharedImportMap;' : ''}
-    ${
-      hasEagerShared
-        ? ''
-        : `if (!localSharedImportMapPromise) {
+    if (!localSharedImportMapPromise) {
       localSharedImportMapPromise = retrySharedInit(() => import("${getLocalSharedImportMapPath(options)}"))
         .catch((e) => { localSharedImportMapPromise = undefined; throw e; });
     }
-    return localSharedImportMapPromise`
-    }
+    return localSharedImportMapPromise
   }
 
   async function getExposesMap() {


### PR DESCRIPTION
Close #1011 

Prevent missing eager-share bindings in multi-entry production builds.