### PR TITLE
fix: keep `_` imports whose binding is referenced as a value

### DIFF
--- a/src/utils/__tests__/controlChunkSanitizer.test.ts
+++ b/src/utils/__tests__/controlChunkSanitizer.test.ts
@@ -59,6 +59,24 @@ describe('controlChunkSanitizer', () => {
     expect(result).toContain('o(()=>import("./ui.js"),__vite__mapDeps([0]),import.meta.url)');
   });
 
+  it('keeps `_` imports whose binding is referenced as a value instead of called', () => {
+    // Rollup renders `import * as ns from "virtual:..."` as `import { _ as ns } from "<chunk>"`
+    // when the module ends up in another chunk. Such a binding is returned, not called, so a
+    // call-only check would strip the import and leave `ns` as an undeclared free identifier.
+    const code =
+      'import{_ as __vitePreload}from"./assets/preload-helper-CWZBUsdZ.js";' +
+      'import{_ as __mfLocalSharedImportMap}from"./assets/_virtual_mf-localSharedImportMap-CiudmNFF.js";' +
+      'async function getLocalSharedImportMap(){return __mfLocalSharedImportMap}';
+
+    const result = stripEmptyPreloadCalls(code);
+
+    expect(result).toContain(
+      'import{_ as __mfLocalSharedImportMap}from"./assets/_virtual_mf-localSharedImportMap-CiudmNFF.js";'
+    );
+    // the genuinely unused preload helper is still removed
+    expect(result).not.toContain('preload-helper-CWZBUsdZ.js');
+  });
+
   it('detects federation control chunks', () => {
     expect(isFederationControlChunk('remoteEntry.js', 'remoteEntry.js')).toBe(true);
     expect(isFederationControlChunk('assets/hostInit-abc.js', 'remoteEntry.js')).toBe(true);

--- a/src/utils/controlChunkSanitizer.ts
+++ b/src/utils/controlChunkSanitizer.ts
@@ -54,8 +54,14 @@ export function stripEmptyPreloadCalls(code: string): string {
   nextCode = nextCode.replace(/import\s*["'][^"']*__loadShare__[^"']*["']\s*;?/g, '');
 
   nextCode = nextCode.replace(helperImportRegex, (statement, local) => {
-    const helperCallRegex = new RegExp(`\\b${local}\\s*\\(`);
-    return helperCallRegex.test(nextCode.replace(statement, '')) ? statement : '';
+    // Only drop the import when the binding is not referenced anywhere else.
+    // Testing for a call (`local(`) is not enough: `import { _ as x } from '...'` is
+    // also how Rollup renders a namespace import that crosses a chunk boundary, and
+    // such a binding is usually referenced as a plain value (e.g. `return x;`) rather
+    // than called. Dropping that import leaves an undeclared free identifier behind,
+    // which throws at runtime while the build still exits successfully.
+    const helperReferenceRegex = new RegExp(`\\b${local}\\b`);
+    return helperReferenceRegex.test(nextCode.replace(statement, '')) ? statement : '';
   });
 
   return nextCode;


### PR DESCRIPTION
## Problem

`stripEmptyPreloadCalls()` drops an import statement whenever the imported binding is not **called**:

```ts
const helperImportRegex = /import\s*\{\s*_\s*as\s*(\w+)\s*\}\s*from\s*["'][^"']+["']\s*;?/g;
...
nextCode = nextCode.replace(helperImportRegex, (statement, local) => {
  const helperCallRegex = new RegExp(`\\b${local}\\s*\\(`);
  return helperCallRegex.test(nextCode.replace(statement, '')) ? statement : '';
});
```

The intent is to remove a Vite preload helper that became unused after the empty-deps rewrite above it. But `import { _ as x } from '...'` is not exclusive to the preload helper — it is also how Rollup renders `import * as ns from '...'` once the namespace crosses a chunk boundary, and a namespace binding is normally *referenced as a value*, not called.

When that happens inside a federation control chunk (`remoteEntry`, `hostInit`, `virtualExposes`, `localSharedImportMap`), the import is deleted while the identifier stays behind. The chunk is now silently corrupted: `vite build` exits `0` with no warning, and the browser throws at startup.

I hit this via the eager shared map (#1011). Instrumenting the callback during a build shows the deletion directly — note the unresolved Rollup hash placeholder, i.e. this happens in `renderChunk`, after Rollup has correctly emitted the import:

```
[MF-SANITIZER-DELETED] "import { _ as __mfLocalSharedImportMap } from './assets/_virtual_mf-localSharedImportMap___mfe_internal__hostApp__mf_owner__1-!~{005}~.js';"
```

producing

```js
import { _ as __vitePreload } from './assets/preload-helper-CWZBUsdZ.js';
import { h as helpers, i as init$1 } from './assets/index-GcC7LmTc.js';
...
async function getLocalSharedImportMap() {
    return __mfLocalSharedImportMap;   // free, undeclared identifier
}
```

```
ReferenceError: __mfLocalSharedImportMap is not defined
    at getLocalSharedImportMap (remoteEntry.js:215:5)
    at Module.init (remoteEntry.js:361:45)
```

#1013 fixed that particular crash by removing the eager branch that produced this shape, and it is a good fix on its own. This PR addresses the sanitizer itself, which still deletes any value-referenced `{ _ as x }` import in a control chunk and can silently corrupt output again from a different source.

## Fix

Check whether the binding is **referenced** at all, rather than whether it is called.

```ts
const helperReferenceRegex = new RegExp(`\\b${local}\\b`);
return helperReferenceRegex.test(nextCode.replace(statement, '')) ? statement : '';
```

The failure modes are asymmetric: keeping an unused import costs a few bytes, deleting a used one breaks the app at runtime with a green build. So the check errs toward keeping.

## Why not gate on the module path

Restricting the strip to specifiers containing `preload-helper` also fixes the crash, but it regresses the existing test `strips minified preload helpers and loadShare side-effect imports`, where the helper legitimately arrives from `./assets/TreeLoader-KqsPzsXB.js`. Vite can inline the helper into an arbitrary chunk, so the path is not a reliable signal. The reference check does not depend on chunk naming at all.

## Compatibility

The preceding empty-deps rewrite turns `x(()=>import(m),[],import.meta.url)` into `import(m)`, so a helper that was only used for empty-deps calls has no remaining references and is still stripped — the existing tests cover this and continue to pass unchanged.

## Tests

Added `keeps \`_\` imports whose binding is referenced as a value instead of called`, which asserts both directions: the value-referenced import survives, the genuinely unused preload helper is still removed.

Verified the test is not vacuous — it fails on `main` and passes with the fix:

```
FAIL  src/utils/__tests__/controlChunkSanitizer.test.ts > controlChunkSanitizer > keeps `_` imports whose binding is referenced as a value instead of called
AssertionError: expected 'async function getLocalSharedImportMa…' to contain 'import{_ as __mfLocalSharedImportMap}…'
      Tests  1 failed | 5 passed (6)
```

Full suite after the fix:

```
pnpm test        ->  Test Files  49 passed (49) / Tests  1017 passed | 1 skipped (1018)
pnpm fmt.check   ->  All matched files use the correct format.
pnpm typecheck   ->  clean
```

Refs #1011, #1013.
