### PR TITLE
fix: derive runtime plugin version from dependency

### DIFF
--- a/src/utils/__tests__/injectExternalRuntimeCorePlugin.test.ts
+++ b/src/utils/__tests__/injectExternalRuntimeCorePlugin.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as runtimeCore from '@module-federation/runtime/core';
+import { createRequire } from 'node:module';
 import injectExternalRuntimeCorePlugin from '../injectExternalRuntimeCorePlugin';
 
 type FederationGlobal = typeof globalThis & {
@@ -8,6 +9,9 @@ type FederationGlobal = typeof globalThis & {
 };
 
 const globalRef = globalThis as FederationGlobal;
+const require = createRequire(import.meta.url);
+const runtimeVersion = (require('@module-federation/runtime/package.json') as { version: string })
+  .version;
 const previousCore = globalRef._FEDERATION_RUNTIME_CORE;
 const previousFrom = globalRef._FEDERATION_RUNTIME_CORE_FROM;
 
@@ -31,8 +35,25 @@ describe('injectExternalRuntimeCorePlugin', () => {
     plugin.beforeInit({ options: { name: 'hostApp' } });
     expect(globalRef._FEDERATION_RUNTIME_CORE).toBe(runtimeCore);
     expect(globalRef._FEDERATION_RUNTIME_CORE_FROM).toEqual({
-      version: '2.8.0',
+      version: runtimeVersion,
       name: 'hostApp',
     });
+    expect(plugin.version).toBe(runtimeVersion);
+  });
+
+  it('does not warn when an existing provider reports the installed runtime version', () => {
+    globalRef._FEDERATION_RUNTIME_CORE_FROM = {
+      version: runtimeVersion,
+      name: 'hostApp',
+    };
+    const plugin = injectExternalRuntimeCorePlugin();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      plugin.beforeInit({ options: { name: 'hostApp' } });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/utils/injectExternalRuntimeCorePlugin.ts
+++ b/src/utils/injectExternalRuntimeCorePlugin.ts
@@ -7,6 +7,7 @@
  * adding that package (or `runtime-tools`) as a dependency of this plugin.
  */
 
+import runtimePackage from '@module-federation/runtime/package.json' with { type: 'json' };
 import * as runtimeCore from '@module-federation/runtime/core';
 
 type BeforeInitArgs = {
@@ -18,8 +19,7 @@ type FederationGlobal = Record<string, unknown> & {
   _FEDERATION_RUNTIME_CORE_FROM?: { name: string; version: string };
 };
 
-/** Keep in sync with the `@module-federation/runtime` dependency version. */
-const PLUGIN_VERSION = '2.8.0';
+const PLUGIN_VERSION = runtimePackage.version;
 
 function getFederationGlobal(): FederationGlobal | undefined {
   const globalRef = runtimeCore.Global as FederationGlobal | undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2022"],
     "module": "preserve",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "noEmit": true,
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary

- Derive the external runtime plugin version from the installed `@module-federation/runtime` package metadata.
- Keep `plugin.version` and `_FEDERATION_RUNTIME_CORE_FROM.version` aligned automatically when the runtime dependency is upgraded.
- Add regression coverage for matching runtime provenance and avoid false multiple-runtime warnings.

## Problem

`injectExternalRuntimeCorePlugin` used a hard-coded `2.8.0` version while the project depended on `@module-federation/runtime@2.8.1`. This could make compatible runtimes appear to have different versions and trigger an unnecessary multiple-runtime warning.

## Changes

- Read `@module-federation/runtime/package.json` directly from the runtime plugin.
- Enable JSON module resolution in TypeScript.
- Replace the stale test expectation with the installed runtime version.
- Verify that a provider reporting the installed version does not emit a warning.

## Validation

- `pnpm test`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm build`
- `pnpm fmt.check`