### PR TITLE
fix: preserve ssrExternals during normalization

### DIFF
--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -304,9 +304,29 @@ describe('pluginSSRRemoteEntry', () => {
     });
 
     it('externalises user-provided ssrExternals', () => {
-      const base = makeOptions();
-      const options = { ...base, ssrExternals: ['my-server-only-pkg'] };
-      const plugins = pluginSSRRemoteEntry(options);
+      const plugins = pluginSSRRemoteEntry(makeOptions({ ssrExternals: ['my-server-only-pkg'] }));
+      const prePlugin = plugins[0];
+      const ssrId = 'virtual:mf-REMOTE_ENTRY_SSR_ID:__mfe_internal__remote__remoteEntry_js';
+
+      expect(
+        callHook(prePlugin.resolveId, {} as Rollup.PluginContext, 'my-server-only-pkg', ssrId, {
+          isEntry: false,
+        })
+      ).toEqual({ id: 'my-server-only-pkg', external: true });
+
+      expect(
+        callHook(
+          prePlugin.resolveId,
+          {} as Rollup.PluginContext,
+          'my-server-only-pkg/subpath',
+          ssrId,
+          { isEntry: false }
+        )
+      ).toEqual({ id: 'my-server-only-pkg/subpath', external: true });
+    });
+
+    it('does not externalise unconfigured packages by default', () => {
+      const plugins = pluginSSRRemoteEntry(makeOptions());
       const prePlugin = plugins[0];
       const ssrId = 'virtual:mf-REMOTE_ENTRY_SSR_ID:__mfe_internal__remote__remoteEntry_js';
 
@@ -318,7 +338,7 @@ describe('pluginSSRRemoteEntry', () => {
         { isEntry: false }
       );
 
-      expect(result).toEqual({ id: 'my-server-only-pkg', external: true });
+      expect(result).toBeUndefined();
     });
 
     it('does not track bare specifiers into the SSR graph', () => {

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -55,6 +55,7 @@ describe('normalizeModuleFederationOption', () => {
       moduleParseTimeout: 10,
       moduleParseIdleTimeout: undefined,
       target: undefined,
+      ssrExternals: undefined,
       disableRemote: undefined,
       disableShared: undefined,
       disableSnapshot: undefined,
@@ -65,6 +66,15 @@ describe('normalizeModuleFederationOption', () => {
         ssrMode: undefined,
       },
     });
+  });
+
+  it('preserves ssrExternals for the SSR remote entry', () => {
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        ssrExternals: ['sharp'],
+      }).ssrExternals
+    ).toEqual(['sharp']);
   });
 
   it('normalizes experiments.ssrMode as an explicit island opt-in', () => {

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -805,6 +805,7 @@ export function normalizeModuleFederationOptions(
     moduleParseIdleTimeout: options.moduleParseIdleTimeout,
     varFilename: options.varFilename,
     target: options.target,
+    ssrExternals: options.ssrExternals,
     disableRemote: options.disableRemote,
     disableShared: options.disableShared,
     disableSnapshot: options.disableSnapshot,


### PR DESCRIPTION
## Summary

- Preserve the public `ssrExternals` option when normalizing Module Federation options.
- Ensure user-configured SSR-only packages reach `pluginSSRRemoteEntry`.
- Add regression coverage for the full raw-options → normalization → SSR plugin path.

## Problem

`ssrExternals` was declared as a public option but omitted from the normalized options object. Since the SSR plugin receives only normalized options, packages configured by users were not added to the SSR external list.

For example, configuring `ssrExternals: ['sharp']` could still allow `sharp` or a server-only SDK to be bundled into the SSR remote entry, depending on the Vite/Rollup configuration.

## Changes

- Copy `options.ssrExternals` into the normalized options object.
- Add a normalization test for user-provided `ssrExternals`.
- Update the SSR plugin test to exercise the public configuration path.
- Verify configured package subpaths are externalized and unconfigured packages retain the default behavior.

The existing SSR external pattern already matches both `sharp` and `sharp/subpath`, so no regex change was needed.

## Validation

- `pnpm exec vitest run src/utils/__tests__/normalizeModuleFederationOption.test.ts src/plugins/__tests__/pluginSSRRemoteEntry.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm fmt.check`
