### PR TITLE
fix: normalize publicPath for dev remote entry URL

### DIFF
--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -150,7 +150,7 @@ describe('pluginProxyRemoteEntry', () => {
   it('uses a dev-safe filename for hash-pattern host init remote entry imports', async () => {
     normalizeModuleFederationOptions({ name: 'test' });
     const plugin = pluginProxyRemoteEntry({
-      options: getDefaultMockOptions({ filename: 'remoteEntry-[hash]' }),
+      options: getDefaultMockOptions({ filename: 'remoteEntry-[hash]', publicPath: '/cdn' }),
       remoteEntryId: 'virtual:mf-remote-entry',
       virtualExposesId: 'virtual:mf-exposes',
     });
@@ -180,8 +180,50 @@ describe('pluginProxyRemoteEntry', () => {
       code: string;
     };
 
-    expect(result.code).toContain('origin + "/remoteEntry.js"');
+    expect(result.code).toContain('origin + "/cdn/remoteEntry.js"');
     expect(result.code).not.toContain('remoteEntry-[hash]');
+  });
+
+  it.each([
+    ['/cdn', 'origin + "/cdn/remoteEntry.js"'],
+    ['/cdn/', 'origin + "/cdn/remoteEntry.js"'],
+    ['/', 'origin + "/remoteEntry.js"'],
+    ['https://cdn.example.com/assets', '"https://cdn.example.com/assets/remoteEntry.js"'],
+    ['https://cdn.example.com/assets/', '"https://cdn.example.com/assets/remoteEntry.js"'],
+  ])('resolves publicPath %s for dev host init', async (publicPath, expected) => {
+    normalizeModuleFederationOptions({ name: 'test' });
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions({ publicPath }),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    callHook(
+      plugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      {
+        root: '/repo',
+        base: '/',
+        server: { host: '0.0.0.0', port: 4173 },
+      } as unknown as ResolvedConfig
+    );
+
+    const result = (await callHook(
+      plugin.transform,
+      {} as Rollup.TransformPluginContext,
+      '',
+      getHostAutoInitPath()
+    )) as { code: string };
+
+    expect(result.code).toContain(
+      `const remoteEntryImport = typeof window !== 'undefined' ? ${expected}`
+    );
   });
 
   it('uses an explicitly configured Vite base for dev host init', async () => {

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -13,7 +13,7 @@ import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap'
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
 import { getReactIslandExposes } from '../utils/reactIsland';
-import { filterId, resolvePublicPath } from '../utils/pathNormalization';
+import { ensureTrailingSlash, filterId, resolvePublicPath } from '../utils/pathNormalization';
 import {
   generateExposes,
   generateHostAutoInitCode,
@@ -36,6 +36,12 @@ function resolveDevHashEntryFileName(fileName: string) {
   const baseName = path.basename(normalized);
 
   return path.extname(baseName) ? normalized : `${normalized}.js`;
+}
+
+function resolveAbsoluteDevRemoteEntryUrl(publicPath: string, fileName: string): string {
+  const base = new URL(publicPath);
+  base.pathname = ensureTrailingSlash(base.pathname);
+  return new URL(fileName, base).href;
 }
 
 export default function ({
@@ -241,9 +247,13 @@ export default function ({
               viteConfig.base,
               originalConfigBase
             );
-            const publicPath = JSON.stringify(
-              (resolvedPublicPath === 'auto' ? '/' : resolvedPublicPath) +
-                resolveDevHashEntryFileName(options.filename)
+            const devPublicPath = resolvedPublicPath === 'auto' ? '/' : resolvedPublicPath;
+            const remoteEntryFileName = resolveDevHashEntryFileName(options.filename);
+            const isAbsolutePublicPath = /^https?:\/\//i.test(devPublicPath);
+            const remoteEntryUrl = JSON.stringify(
+              isAbsolutePublicPath
+                ? resolveAbsoluteDevRemoteEntryUrl(devPublicPath, remoteEntryFileName)
+                : `${ensureTrailingSlash(devPublicPath)}${remoteEntryFileName}`
             );
             const fallbackOrigin = `//${host}:${viteConfig.server?.port}`;
             const ssrRemoteEntry =
@@ -253,7 +263,7 @@ export default function ({
               );
             return `
           const origin = typeof window !== 'undefined' && (${!options.ignoreOrigin}) ? window.origin : ${JSON.stringify(fallbackOrigin)};
-          const remoteEntryImport = typeof window !== 'undefined' ? origin + ${publicPath} : ${JSON.stringify(ssrRemoteEntry)};
+          const remoteEntryImport = typeof window !== 'undefined' ? ${isAbsolutePublicPath ? remoteEntryUrl : `origin + ${remoteEntryUrl}`} : ${JSON.stringify(ssrRemoteEntry)};
           ${generateHostAutoInitCode('remoteEntryImport', 'serve', options)}
         `;
           }


### PR DESCRIPTION
## Summary

- Normalize path-based `publicPath` values before composing the dev remote entry URL.
- Resolve absolute `http://` and `https://` public paths without prepending the host origin.
- Add regression coverage for slash variants, absolute CDN URLs, and hash-based filenames.

## Problem

When `publicPath` does not end with `/`, the dev host auto-init code concatenates it directly with the remote entry filename. For example, `publicPath: '/cdn'` produces `/cdnremoteEntry.js` instead of `/cdn/remoteEntry.js`.

Absolute public paths have a related problem: `origin` is prepended to values such as `https://cdn.example.com/assets`, producing an invalid import URL.

## Changes

- Keep the original `publicPath` value unchanged for manifest metadata.
- Normalize path-based dev URLs with `ensureTrailingSlash()` before appending the remote entry filename.
- Resolve absolute public paths with the URL API and preserve their origin.
- Cover `/cdn`, `/cdn/`, `/`, absolute CDN URLs, and `remoteEntry-[hash]` in `pluginProxyRemoteEntry` tests.

## Validation

- `pnpm exec vitest run src/plugins/__tests__/pluginProxyRemoteEntry.test.ts src/utils/__tests__/pathNormalization.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm exec oxfmt --check src/plugins/pluginProxyRemoteEntry.ts src/plugins/__tests__/pluginProxyRemoteEntry.test.ts`
- `pnpm build`