### PR TITLE
fix: reuse compatible non-singleton shared fallbacks

### DIFF
--- a/e2e/vite-vite/tests/host-preview.spec.ts
+++ b/e2e/vite-vite/tests/host-preview.spec.ts
@@ -14,6 +14,26 @@ test.describe('vite-vite host preview', () => {
     await expect(heading).toBeVisible();
   });
 
+  test('downloads a compatible non-singleton fallback once', async ({ page }) => {
+    const scriptResponses: Promise<{ url: string; body: string }>[] = [];
+    page.on('response', (response) => {
+      if (response.request().resourceType() === 'script') {
+        scriptResponses.push(
+          response.text().then((body) => ({ url: response.url(), body }))
+        );
+      }
+    });
+
+    await page.goto('/');
+    await expect(page.getByTestId('shared-counter-[shared-lib] Host')).toBeVisible();
+    await expect(page.getByTestId('shared-counter-[shared-lib] Remote')).toBeVisible();
+
+    const sharedLibResponses = (await Promise.all(scriptResponses)).filter(({ body }) =>
+      body.includes('[Shared Lib] Initialized')
+    );
+    expect(sharedLibResponses.map(({ url }) => url)).toHaveLength(1);
+  });
+
   test('renders Emotion styled component from remote', async ({ page }) => {
     await page.goto('/');
     // EmotionDemo uses `import styled from '@emotion/styled'` (default import).

--- a/examples/vite-vite/vite-host/vite.config.js
+++ b/examples/vite-vite/vite-host/vite.config.js
@@ -33,7 +33,11 @@ const shared = {
     requiredVersion: '^19.2.4',
   },
   '@vite-vite/shared-consumer': { singleton: true },
-  '@vite-vite/shared-lib': { singleton: true },
+  '@vite-vite/shared-lib': {
+    singleton: false,
+    version: '0.0.1',
+    requiredVersion: '^0.0.1',
+  },
   '@vite-vite/shared-lib/helpers': { singleton: true },
   antd: {
     ...antdShared,

--- a/examples/vite-vite/vite-remote/vite.config.js
+++ b/examples/vite-vite/vite-remote/vite.config.js
@@ -34,7 +34,11 @@ const shared = {
     singleton: true,
     requiredVersion: '^19.2.4',
   },
-  '@vite-vite/shared-lib': { singleton: true },
+  '@vite-vite/shared-lib': {
+    singleton: false,
+    version: '0.0.1',
+    requiredVersion: '^0.0.1',
+  },
   antd: {
     ...antdShared,
   },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -902,6 +902,7 @@ describe('module-federation-esm-shims', () => {
     expect(functionOutput.manualChunks(`/virtual/react${LOAD_SHARE_TAG}chunk.js`)).toBe(
       `react${LOAD_SHARE_TAG}chunk.js`
     );
+    expect(functionOutput.manualChunks('\0vite/preload-helper.js')).toBe('vite-preload-helper');
     // Non-federation modules are left to automatic chunking (and it is not the
     // user's original function, which would have returned 'existing-fn-chunk').
     expect(functionOutput.manualChunks('/src/custom.ts')).toBeUndefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1302,9 +1302,10 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
 
           if (!useCodeSplitting) {
             // Rollup (Vite 5–7): `codeSplitting` is rejected as an unknown output
-            // option, and the hoisted-preload-helper deadlock is Rolldown-specific,
-            // so keep the original `manualChunks` isolation of runtimeInit/loadShare.
+            // option, so isolate runtimeInit, loadShare, and the preload helper with
+            // `manualChunks`.
             const mfManualChunks = function (id: string) {
+              if (PRELOAD_HELPER_TEST.test(id)) return PRELOAD_HELPER_CHUNK;
               return mfChunkName(id) ?? undefined;
             };
             patchedManualChunks.add(mfManualChunks);

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2502,10 +2502,10 @@ describe('virtualRemoteEntry', () => {
     expect(liveProviderRead).toBeLessThan(providerLoad);
     expect(providerLoad).toBeLessThan(latestOwnerRead);
     expect(latestOwnerRead).toBeLessThan(bridgedCacheWrite);
-    expect(bridgeHelperCode).toContain('if (!usedShare.shareConfig?.singleton) return;');
-    expect(bridgeHelperCode.indexOf('if (!usedShare.shareConfig?.singleton) return;')).toBeLessThan(
-      providerLoad
+    expect(bridgeHelperCode).toContain(
+      'if (!usedShare.shareConfig?.singleton && version !== usedShare.version) return;'
     );
+    expect(bridgeHelperCode).not.toContain('if (!usedShare.shareConfig?.singleton) return;');
     expect(bridgeHelperCode).toContain('if (usedShare.canLiveRebind === false) return;');
     expect(bridgeHelperCode.indexOf('if (usedShare.canLiveRebind === false) return;')).toBeLessThan(
       providerLoad

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -3115,6 +3115,31 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('export { __mf_default as default };');
   });
 
+  it('defers non-singleton workspace fallback without top-level await', () => {
+    const pkg = 'workspace-shared-lib';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: false,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    expect(generatedCode).not.toContain('import * as __mfLocalShare');
+    expect(generatedCode).toContain('initPromise.then');
+    expect(generatedCode).toContain(
+      'import("/repo/packages/workspace-shared-lib/src/index.tsx").then((mod) => {'
+    );
+    expect(generatedCode).not.toContain('await ');
+  });
+
   it('prepends workspace singleton static import for SSR build loads only', async () => {
     const { prependWorkspaceSingletonSsrImport } = await import('../virtualShared_preBuild');
     const pkg = 'workspace-shared-lib';

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -680,7 +680,6 @@ function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
         : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor);
       if (cachedShare !== undefined) return false;
       if (share.treeShaking || share.shareConfig?.import === false) return true;
-      if (!share.shareConfig?.singleton) return false;
       if (typeof __mfSelectExternalSharedProvider !== 'function') return false;
       return Boolean(__mfSelectExternalSharedProvider(
         initialShared[pkg],
@@ -1521,6 +1520,7 @@ export function generateRemoteEntry(
         if (!providerEntry) return;
         const selectedLocalProvider = __mfMatchesSharedProvider(selectedRuntimeProvider, usedShare);
         const { version } = providerEntry;
+        if (!usedShare.shareConfig?.singleton && version !== usedShare.version) return;
         const passedProvider = passedVersionMap?.[version];
         const resolvedExternalProvider = __mfResolveExternalSharedProvider(
           federationInstances,
@@ -1540,10 +1540,6 @@ export function generateRemoteEntry(
           provider: selectedRuntimeProvider,
           scopeRootProvider: undefined
         };
-        // Non-singleton proxies may have already snapshotted their local exports while
-        // seeding shared dependencies. Late cache replacement is safe only for the
-        // live-bound singleton proxies.
-        if (!usedShare.shareConfig?.singleton) return;
         if (usedShare.canLiveRebind === false) return;
         // Preserve a singleton already selected by another container. The bridge may
         // only replace the provisional local fallback seeded by this container.

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1917,7 +1917,7 @@ export function writeLoadShareModule(
     (Array.isArray(shareItem.scope) && shareItem.scope[0] === 'default');
   const usesDeferredSingletonFallback =
     hasCompleteExportCoverage &&
-    (isWorkspaceSingleton ||
+    (isWorkspacePackage ||
       (command !== 'build' &&
         isRemoteOnlyContainer(resolvedOptions) &&
         shareItem.shareConfig.singleton === true) ||


### PR DESCRIPTION
Close #1018

Defers workspace fallbacks until federation initialisation, reusing an existing exact-version provider instead of downloading duplicate implementations. Preserves singleton behaviour.