### PR TITLE
fix: honor eager workspace singleton exports

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -3324,6 +3324,39 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('Promise.resolve().then');
   });
 
+  it('emits eager local exports for an explicitly eager leaf workspace singleton', () => {
+    normalizeModuleFederationOptions({
+      name: 'host',
+      shared: {
+        'workspace-producer': { singleton: true, eager: true },
+      },
+    });
+    const pkg = 'workspace-producer';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        eager: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'import * as __mfLocalShare from "/repo/packages/workspace-producer/src/index.ts";'
+    );
+    expect(generatedCode).toContain('const __mfApplyEagerShareExports = (mod) => {');
+    expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
+    expect(generatedCode).not.toContain('initPromise.then');
+  });
+
   it('does not treat parent package.json name mismatches as workspace package matches', () => {
     const pkg = 'workspace-name-mismatch';
     const mockShareItem: ShareItem = {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1939,7 +1939,9 @@ export function writeLoadShareModule(
     resolvedOptions.hostInitInjectLocation === 'entry' &&
     isConsumedByPeerSingleton;
   const usesEagerWorkspaceFallback =
-    hasCompleteExportCoverage && isWorkspaceSingleton && isConsumedByPeerSingleton;
+    hasCompleteExportCoverage &&
+    isWorkspaceSingleton &&
+    (isConsumedByPeerSingleton || shareItem.shareConfig.eager === true);
   const usesDeferredTreeShakingFallback = hasCompleteExportCoverage && Boolean(treeShakingConsumer);
   const reactMixedModeGuard = pkg === 'react' ? createReactMixedModeRuntimeGuard() : '';
   let exportLine: string;


### PR DESCRIPTION
Close #1027

Makes eager: true generate synchronous exports for workspace singletons, preventing undefined bindings during module evaluation.