### PR TITLE
fix: preserve SSR entry during cleanup

### DIFF
--- a/integration/build.test.ts
+++ b/integration/build.test.ts
@@ -11,6 +11,23 @@ const BASIC_REMOTE_MF_OPTIONS = {
 
 describe('build', () => {
   describe('remote', () => {
+    it('emits the SSR remote entry with ssrEmitAssets disabled', async () => {
+      const output = await buildFixture({
+        mfOptions: BASIC_REMOTE_MF_OPTIONS,
+        viteConfig: {
+          build: {
+            ssr: true,
+            ssrEmitAssets: false,
+            rollupOptions: {
+              input: resolve(FIXTURES, 'basic-remote', 'entry.js'),
+            },
+          },
+        },
+      });
+
+      expect(output.output.some((item) => item.fileName === 'remoteEntry.ssr.js')).toBe(true);
+    });
+
     it('remoteEntry contains federation runtime init with correct name', async () => {
       const output = await buildFixture({ mfOptions: BASIC_REMOTE_MF_OPTIONS });
       const remoteEntry = findChunk(output, 'remoteEntry');

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -800,7 +800,7 @@ describe('pluginSSRRemoteEntry', () => {
       );
     }
 
-    it('emits SSR entry as a pre-generated ESM asset for Rollup (avoids code-splitting side effects)', () => {
+    it('emits SSR entry as a post-generated ESM asset for Rollup', () => {
       getIsRolldownMock.mockReturnValue(false);
       const emitFile = makeEmitFile();
       const plugins = pluginSSRRemoteEntry(makeOptions());
@@ -814,6 +814,15 @@ describe('pluginSSRRemoteEntry', () => {
           emitFile,
         } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
+      );
+      expect(emitFile).not.toHaveBeenCalled();
+
+      callHook(
+        mainPlugin.generateBundle,
+        { emitFile } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {} as Rollup.OutputBundle,
+        false
       );
 
       expect(emitFile).toHaveBeenCalledWith(
@@ -838,6 +847,13 @@ describe('pluginSSRRemoteEntry', () => {
           emitFile,
         } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
+      );
+      callHook(
+        mainPlugin.generateBundle,
+        { emitFile } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {} as Rollup.OutputBundle,
+        false
       );
 
       expect(emitFile).toHaveBeenCalledWith(
@@ -1017,6 +1033,13 @@ describe('pluginSSRRemoteEntry', () => {
         { meta: makePluginMeta(false), emitFile } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
       );
+      callHook(
+        mainPlugin.generateBundle,
+        { emitFile } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {} as Rollup.OutputBundle,
+        false
+      );
 
       const call = emitFile.mock.calls[0]?.[0] as { source?: string } | undefined;
       return call?.source ?? '';
@@ -1085,47 +1108,49 @@ describe('pluginSSRRemoteEntry', () => {
 
     it('rewrites Nuxt Rollup SSR asset to import the emitted _nuxt exposes chunk', () => {
       getIsRolldownMock.mockReturnValue(false);
+      vi.mocked(generateRemoteEntrySSR).mockReturnValueOnce(
+        'const map = import("virtual:mf-exposes-ssr:remote");'
+      );
       const plugins = pluginSSRRemoteEntry(makeOptions());
       const mainPlugin = plugins[1];
 
       callHook(
         mainPlugin.configResolved,
         {} as Rollup.PluginContext,
-        { command: 'build', base: '/_nuxt/' } as ResolvedConfig
+        { command: 'build', base: '/_nuxt/', build: { ssr: true } } as ResolvedConfig
       );
+      const emitFile = makeEmitFile();
       callHook(
         mainPlugin.buildStart,
         {
           meta: makePluginMeta(false),
-          emitFile: makeEmitFile(),
+          emitFile,
         } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
       );
 
-      const asset = {
-        type: 'asset' as const,
-        fileName: 'remoteEntry.ssr.js',
-        source: 'const map = import("virtual:mf-exposes-ssr:remote");',
-      };
       const exposesChunk = {
         type: 'chunk' as const,
         fileName: '_nuxt/virtualExposes-abc.js',
         code: 'export default {"./Widget": () => import("./Widget.js")}',
       };
       const bundle = {
-        'remoteEntry.ssr.js': asset,
         '_nuxt/virtualExposes-abc.js': exposesChunk,
       };
 
       callHook(
         mainPlugin.generateBundle,
-        {} as Rollup.PluginContext,
+        { emitFile } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedOutputOptions,
         bundle as unknown as Rollup.OutputBundle,
         false
       );
 
-      expect(asset.source).toBe('const map = import("./_nuxt/virtualExposes-abc.js");');
+      expect(emitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'const map = import("./_nuxt/virtualExposes-abc.js");',
+        })
+      );
     });
   });
 

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -215,6 +215,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   const remoteEntrySSRId = getRemoteEntrySSRId(options);
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
   let isRolldown = false;
+  let shouldEmitSsrEntry = false;
   let ssrOutputFilename = '';
   let ssrOutputFiles = new Set<string>();
   let ssrOutputDir = '';
@@ -494,6 +495,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
       },
 
       buildStart() {
+        shouldEmitSsrEntry = false;
         // Only emit the SSR entry chunk during vite build — not vite serve.
         if (isServe) return;
         // `this.meta` is available in Rollup/Rolldown hooks — use it to detect
@@ -520,6 +522,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         }
 
         if (Object.keys(options.exposes).length === 0) return;
+        shouldEmitSsrEntry = true;
 
         if (isRolldown) {
           // Vite 8+ (Rolldown): emit as a proper chunk. Rolldown handles multiple
@@ -531,41 +534,42 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
             fileName: ssrOutputFilename,
             preserveSignature: 'strict',
           });
-        } else {
-          // Vite 5–7 (Rollup): emit as a pre-generated ESM asset instead of a chunk.
-          // Emitting a second Rollup entry chunk that shares transitive deps with
-          // the browser remoteEntry causes Rollup to code-split those deps out of
-          // remoteEntry.js, breaking tests and consuming apps that expect them inlined.
-          // Generating the ESM asset directly avoids touching the browser module graph.
-          this.emitFile({
-            type: 'asset',
-            fileName: ssrOutputFilename,
-            source: generateRemoteEntrySSR(options),
-          });
         }
       },
 
-      generateBundle(_options, bundle) {
-        const exposesChunk = findNuxtExposesChunk(bundle);
-        const ssrAsset = bundle[ssrOutputFilename];
-        if (exposesChunk && ssrAsset?.type === 'asset' && typeof ssrAsset.source === 'string') {
-          ssrAsset.source = ssrAsset.source.replace(
-            /import\("virtual:mf-exposes-ssr:[^"]+"\)/g,
-            `import("./${exposesChunk}")`
-          );
-        }
+      generateBundle: {
+        order: 'post',
+        handler(_options, bundle) {
+          const exposesChunk = findNuxtExposesChunk(bundle);
+          if (!isRolldown && shouldEmitSsrEntry) {
+            let source = generateRemoteEntrySSR(options);
+            if (exposesChunk) {
+              source = source.replace(
+                /import\("virtual:mf-exposes-ssr:[^"]+"\)/g,
+                `import("./${exposesChunk}")`
+              );
+            }
+            // Vite removes SSR assets when `ssrEmitAssets` is false. Emit after its
+            // cleanup hook so this required entry survives without enabling all assets.
+            this.emitFile({
+              type: 'asset',
+              fileName: ssrOutputFilename,
+              source,
+            });
+          }
 
-        if ((this as { environment?: { name?: string } }).environment?.name === 'ssr') {
-          ssrOutputFiles = collectEntryOutputFiles(bundle, ssrOutputFilename);
-        }
+          if ((this as { environment?: { name?: string } }).environment?.name === 'ssr') {
+            ssrOutputFiles = collectEntryOutputFiles(bundle, ssrOutputFilename);
+          }
 
-        // Vite 8+ (Rolldown) only — the chunk was emitted via the chunk path in buildStart.
-        // No post-processing needed; Rolldown emits ESM natively.
-        // On Vite 5–7 the SSR entry was emitted as a pre-generated asset, so nothing to do here.
-        if (!isRolldown) return;
-        const chunk = bundle[ssrOutputFilename];
-        if (!chunk || chunk.type !== 'chunk') return;
-        // Verify the chunk exists and was emitted correctly — no transform needed for Rolldown.
+          // Vite 8+ (Rolldown) only — the chunk was emitted via the chunk path in buildStart.
+          // No post-processing needed; Rolldown emits ESM natively.
+          // On Vite 5–7 the SSR entry was emitted as a pre-generated asset, so nothing to do here.
+          if (!isRolldown) return;
+          const chunk = bundle[ssrOutputFilename];
+          if (!chunk || chunk.type !== 'chunk') return;
+          // Verify the chunk exists and was emitted correctly — no transform needed for Rolldown.
+        },
       },
 
       writeBundle(outputOptions) {


### PR DESCRIPTION
Ensures Vite 5–7 emits remoteEntry.ssr.js even when ssrEmitAssets is disabled, without enabling unrelated SSR assets.

