### PR TITLE
fix: include peerDependencies in automatic shared detection

### DIFF
--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -591,6 +591,116 @@ describe('normalizeModuleFederationOption', () => {
       }
     });
 
+    it('auto-shares installed peer dependencies from a component remote', () => {
+      const path = require('node:path');
+      const fs = require('node:fs');
+      const fixtureRoot = path.join(require('node:os').tmpdir(), 'mf-vite-peer-auto-share');
+      const reactDir = path.join(fixtureRoot, 'node_modules/react');
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      fs.mkdirSync(reactDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'package.json'),
+        JSON.stringify({
+          name: 'component-remote',
+          peerDependencies: {
+            react: '^19.0.0',
+            'missing-peer': '^1.0.0',
+          },
+          devDependencies: {
+            react: '19.2.4',
+          },
+        })
+      );
+      fs.writeFileSync(
+        path.join(reactDir, 'package.json'),
+        JSON.stringify({ name: 'react', version: '19.2.4', exports: './index.js' })
+      );
+      fs.writeFileSync(path.join(reactDir, 'index.js'), '');
+
+      setPackageDetectionCwd(fixtureRoot);
+
+      try {
+        const shared = normalizeModuleFederationOptions(minimalOptions).shared;
+
+        expect(shared.react).toMatchObject({
+          name: 'react',
+          version: '19.2.4',
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^19.0.0',
+          },
+        });
+        expect(shared['missing-peer']).toBeUndefined();
+      } finally {
+        setPackageDetectionCwd(process.cwd());
+        fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      }
+    });
+
+    it('preserves the peer range when a package is also a direct dependency', () => {
+      const path = require('node:path');
+      const fs = require('node:fs');
+      const fixtureRoot = path.join(require('node:os').tmpdir(), 'mf-vite-peer-range-precedence');
+      const reactDir = path.join(fixtureRoot, 'node_modules/react');
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      fs.mkdirSync(reactDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'package.json'),
+        JSON.stringify({
+          name: 'component-remote',
+          dependencies: {
+            react: '^19.2.0',
+          },
+          peerDependencies: {
+            react: '^19.0.0',
+          },
+        })
+      );
+      fs.writeFileSync(
+        path.join(reactDir, 'package.json'),
+        JSON.stringify({ name: 'react', version: '19.2.4', exports: './index.js' })
+      );
+      fs.writeFileSync(path.join(reactDir, 'index.js'), '');
+
+      setPackageDetectionCwd(fixtureRoot);
+
+      try {
+        const shared = normalizeModuleFederationOptions(minimalOptions).shared;
+
+        expect(shared.react.version).toBe('19.2.4');
+        expect(shared.react.shareConfig.requiredVersion).toBe('^19.0.0');
+      } finally {
+        setPackageDetectionCwd(process.cwd());
+        fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      }
+    });
+
+    it('does not auto-share peer dependencies when shared is explicitly empty', () => {
+      const path = require('node:path');
+      const fs = require('node:fs');
+      const fixtureRoot = path.join(require('node:os').tmpdir(), 'mf-vite-peer-explicit-empty');
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      fs.mkdirSync(fixtureRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'package.json'),
+        JSON.stringify({
+          name: 'component-remote',
+          peerDependencies: { react: '^19.0.0' },
+        })
+      );
+
+      setPackageDetectionCwd(fixtureRoot);
+
+      try {
+        expect(normalizeModuleFederationOptions({ ...minimalOptions, shared: {} }).shared).toEqual(
+          {}
+        );
+      } finally {
+        setPackageDetectionCwd(process.cwd());
+        fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      }
+    });
+
     it('ignores module federation runtime packages in explicit shared arrays', () => {
       const shared = normalizeModuleFederationOptions({
         ...minimalOptions,

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -325,18 +325,27 @@ function normalizeShared(
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
         name?: string;
         dependencies?: Record<string, string>;
+        peerDependencies?: Record<string, string>;
       };
       if (packageJson.name === '@module-federation/vite') return result;
 
-      Object.keys(packageJson.dependencies || {})
-        .filter((key) => shouldAutoShareDependency(key))
-        .forEach((key) => {
-          result[key] = normalizeShareItem(key, {
-            name: key,
-            import: undefined,
-            singleton: true,
-          });
+      const peerDependencies = packageJson.peerDependencies || {};
+      const dependencyNames = new Set([
+        ...Object.keys(packageJson.dependencies || {}),
+        ...Object.keys(peerDependencies),
+      ]);
+
+      dependencyNames.forEach((key) => {
+        if (!shouldAutoShareDependency(key)) return;
+
+        const peerRequiredVersion = peerDependencies[key];
+        result[key] = normalizeShareItem(key, {
+          name: key,
+          import: undefined,
+          singleton: true,
+          ...(peerRequiredVersion ? { requiredVersion: peerRequiredVersion } : {}),
         });
+      });
     } catch {
       return result;
     }


### PR DESCRIPTION
## Summary

Component remotes commonly declare framework packages such as React or Vue in `peerDependencies` and `devDependencies`, while omitting an explicit `shared` configuration. Those framework packages could be missed by automatic shared detection. This change includes installed `peerDependencies` in the automatic shared candidates so the remote and host can use the same singleton instance.

## Root Cause

When `shared` was omitted, automatic detection only iterated over `packageJson.dependencies` and ignored `peerDependencies`.

As a result:

- The remote bundled its own React instance.
- The host provided a different React singleton.
- The two React instances conflicted at runtime.
- The application could fail with `Invalid hook call`, `useState` errors, or broken context identity.

## Changes

- Include `peerDependencies` in automatic shared detection.
- Register only peers that are installed and resolvable.
- Preserve the peer range as `shareConfig.requiredVersion`.
- Continue using the installed package version as `version`.
- When a package is declared in both `dependencies` and `peerDependencies`, use the peer range as the required version while retaining the installed version.
- Preserve the existing behavior where explicit `shared: {}` disables automatic detection.

The shape passed to runtime-core remains unchanged:

```ts
{
  version: "19.2.4",
  shareConfig: {
    singleton: true,
    requiredVersion: "^19.0.0",
  },
}
```

## Tests

Added regression coverage for:

- Automatically sharing React declared only in `peerDependencies + devDependencies`.
- Ignoring an uninstalled peer without failing the build.
- Handling a package declared in both `dependencies` and `peerDependencies`.
- Preserving the explicit `shared: {}` opt-out.

Verification:

- `pnpm test`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm build`

## Scope and Compatibility

- Explicit shared configurations are unchanged.
- Existing `dependencies`-based automatic sharing is preserved.
- `optionalDependencies` are intentionally outside the scope of this change.