### PR TITLE
fix: revert accidental automatic dependency sharing

### DIFF
--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -734,92 +734,29 @@ describe('normalizeModuleFederationOption', () => {
       setPackageDetectionCwd(process.cwd());
     });
 
-    it('skips Nuxt module packages from implicit shared deps', () => {
+    it('does not implicitly share dependencies', () => {
       const fixtureRoot = require('node:path').join(
         require('node:os').tmpdir(),
-        'mf-vite-nuxt-auto-share'
+        'mf-vite-no-auto-share'
       );
       require('node:fs').rmSync(fixtureRoot, { force: true, recursive: true });
-      require('node:fs').mkdirSync(
-        require('node:path').join(fixtureRoot, 'node_modules/@pinia/nuxt/dist'),
-        {
-          recursive: true,
-        }
-      );
-      require('node:fs').mkdirSync(
-        require('node:path').join(fixtureRoot, 'node_modules/@module-federation/vite/lib'),
-        {
-          recursive: true,
-        }
-      );
-      require('node:fs').mkdirSync(
-        require('node:path').join(fixtureRoot, 'node_modules/nuxt/dist'),
-        {
-          recursive: true,
-        }
-      );
-      require('node:fs').mkdirSync(
-        require('node:path').join(fixtureRoot, 'node_modules/vue/dist'),
-        {
-          recursive: true,
-        }
-      );
+      require('node:fs').mkdirSync(fixtureRoot, { recursive: true });
       require('node:fs').writeFileSync(
         require('node:path').join(fixtureRoot, 'package.json'),
         JSON.stringify({
-          name: 'nuxt-app',
-          dependencies: {
-            '@module-federation/vite': '^1.14.5',
-            '@pinia/nuxt': '^0.11.3',
-            nuxt: '^4.3.1',
-            vue: '^3.5.29',
-          },
-        })
-      );
-      require('node:fs').writeFileSync(
-        require('node:path').join(fixtureRoot, 'node_modules/@module-federation/vite/package.json'),
-        JSON.stringify({
-          name: '@module-federation/vite',
-          exports: {
-            '.': {
-              import: './lib/index.mjs',
-            },
-          },
-        })
-      );
-      require('node:fs').writeFileSync(
-        require('node:path').join(fixtureRoot, 'node_modules/@pinia/nuxt/package.json'),
-        JSON.stringify({
-          name: '@pinia/nuxt',
-          exports: './dist/module.mjs',
-          main: './dist/module.mjs',
-        })
-      );
-      require('node:fs').writeFileSync(
-        require('node:path').join(fixtureRoot, 'node_modules/nuxt/package.json'),
-        JSON.stringify({
-          name: 'nuxt',
-          module: './dist/index.mjs',
-          exports: './dist/index.mjs',
-        })
-      );
-      require('node:fs').writeFileSync(
-        require('node:path').join(fixtureRoot, 'node_modules/vue/package.json'),
-        JSON.stringify({
-          name: 'vue',
-          module: 'dist/vue.runtime.esm-bundler.js',
+          name: 'consumer-app',
+          dependencies: { vue: '^3.5.29' },
+          peerDependencies: { react: '^19.0.0' },
         })
       );
       setPackageDetectionCwd(fixtureRoot);
 
-      const shared = normalizeModuleFederationOptions(minimalOptions).shared;
-
-      expect(shared['@module-federation/vite']).toBeUndefined();
-      expect(shared['@pinia/nuxt']).toBeUndefined();
-      expect(shared.nuxt).toBeUndefined();
-      expect(shared.vue).toBeDefined();
-
-      setPackageDetectionCwd(process.cwd());
+      try {
+        expect(normalizeModuleFederationOptions(minimalOptions).shared).toEqual({});
+      } finally {
+        setPackageDetectionCwd(process.cwd());
+        require('node:fs').rmSync(fixtureRoot, { force: true, recursive: true });
+      }
     });
   });
 

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -25,12 +25,7 @@ export type RemoteEntryType =
 import * as fs from 'fs';
 import * as path from 'node:path';
 import { createModuleFederationError, mfWarn } from './logger';
-import {
-  getInstalledPackageJson,
-  getPackageDetectionCwd,
-  getPackageName,
-  resolveImportPath,
-} from './packageUtils';
+import { getInstalledPackageJson, getPackageName, resolveImportPath } from './packageUtils';
 import { getCommonSharedSubpaths } from './pathNormalization';
 import { normalizePathForImport } from './buildPaths';
 
@@ -317,32 +312,7 @@ function normalizeShared(
     | undefined
 ): NormalizedShared {
   explicitSharedKeys = new Set();
-  if (!shared) {
-    const result: NormalizedShared = {};
-    const packageJsonPath = path.join(getPackageDetectionCwd(), 'package.json');
-
-    try {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
-        name?: string;
-        dependencies?: Record<string, string>;
-      };
-      if (packageJson.name === '@module-federation/vite') return result;
-
-      Object.keys(packageJson.dependencies || {})
-        .filter((key) => shouldAutoShareDependency(key))
-        .forEach((key) => {
-          result[key] = normalizeShareItem(key, {
-            name: key,
-            import: undefined,
-            singleton: true,
-          });
-        });
-    } catch {
-      return result;
-    }
-
-    return result;
-  }
+  if (!shared) return {};
   const result: NormalizedShared = {};
   const sourceEntries: Array<[string, string | Record<string, any>]> = [];
   if (Array.isArray(shared)) {
@@ -386,39 +356,6 @@ function normalizeShared(
 
 function isModuleFederationRuntimePackage(key: string): boolean {
   return key === '@module-federation/runtime' || key === '@module-federation/runtime-core';
-}
-
-function shouldAutoShareDependency(key: string): boolean {
-  const installed = getInstalledPackageJson(key);
-  const pkg = installed?.packageJson as
-    | {
-        browser?: unknown;
-        exports?: unknown;
-        module?: string;
-        main?: string;
-      }
-    | undefined;
-
-  if (!pkg) return false;
-  if (!pkg.browser && !pkg.exports && typeof pkg.module !== 'string') return false;
-
-  if (key === '@module-federation/vite' || isModuleFederationRuntimePackage(key)) {
-    return false;
-  }
-
-  const entry = [pkg.module, pkg.main, typeof pkg.exports === 'string' ? pkg.exports : undefined]
-    .find((value): value is string => typeof value === 'string')
-    ?.replace(/\\/g, '/');
-
-  if (key === 'nuxt' || key === 'nuxt-nightly') {
-    return false;
-  }
-
-  if (key.includes('nuxt') && entry?.endsWith('/dist/module.mjs')) {
-    return false;
-  }
-
-  return true;
 }
 
 function normalizeLibrary(library: any): any {


### PR DESCRIPTION
Removes automatic dependency sharing, introduced accidentally during a large refactor. Restores explicit configuration and alignment with Rspack (https://rspack.dev/plugins/webpack/module-federation-plugin#shared) and webpack (https://webpack.js.org/plugins/module-federation-plugin/#sharing-libraries).

```
Correct behavior:

// Shares nothing
federation({ name: 'remote' });

// Shares React explicitly
federation({
  name: 'remote',
  shared: {
    react: { singleton: true },
  },
});
```

My main concern is keeping the Vite, Rspack, and webpack implementations aligned as much as possible. The Module Federation specification is the result of extensive research and was carefully designed for predictable, optimal behaviour.

Since Rspack and webpack require explicit shared configuration, Vite should follow the same semantics and avoid implicit dependency detection. This reduces surprises and makes migration between bundlers easier.