### PR TITLE
fix: isolate SSR entry emission by environment

### DIFF
--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -958,6 +958,63 @@ describe('pluginSSRRemoteEntry', () => {
       expect(emitFile).not.toHaveBeenCalled();
     });
 
+    it.each([
+      ['SSR starts before client', 'ssr-first'],
+      ['client starts before SSR', 'client-first'],
+    ])('keeps SSR emission scoped to its environment (%s)', (_label, order) => {
+      getIsRolldownMock.mockReturnValue(false);
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        command: 'build',
+        environments: { client: {}, ssr: {} },
+      } as unknown as ResolvedConfig);
+
+      const ssrEmitFile = makeEmitFile();
+      const clientEmitFile = makeEmitFile();
+      const ssrContext = {
+        emitFile: ssrEmitFile,
+        meta: makePluginMeta(false),
+        environment: { name: 'ssr' },
+      } as unknown as Rollup.PluginContext;
+      const clientContext = {
+        emitFile: clientEmitFile,
+        meta: makePluginMeta(false),
+        environment: { name: 'client' },
+      } as unknown as Rollup.PluginContext;
+
+      const startContexts =
+        order === 'ssr-first' ? [ssrContext, clientContext] : [clientContext, ssrContext];
+      for (const context of startContexts) {
+        callHook(mainPlugin.buildStart, context, {} as Rollup.NormalizedInputOptions);
+      }
+
+      callHook(
+        mainPlugin.generateBundle,
+        ssrContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {} as Rollup.OutputBundle,
+        false
+      );
+      callHook(
+        mainPlugin.generateBundle,
+        clientContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {} as Rollup.OutputBundle,
+        false
+      );
+
+      expect(ssrEmitFile).toHaveBeenCalledTimes(1);
+      expect(ssrEmitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'asset',
+          fileName: 'remoteEntry.ssr.js',
+        })
+      );
+      expect(clientEmitFile).not.toHaveBeenCalled();
+    });
+
     it('skips emit in the ssr environment when only a client environment exists', () => {
       const emitFile = makeEmitFile();
       const plugins = pluginSSRRemoteEntry(makeOptions());

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { Plugin, Rollup, ResolvedConfig } from 'vite';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Plugin, ResolvedConfig, Rollup } from 'vite';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 import { normalizeModuleFederationOptions } from '../../utils/normalizeModuleFederationOptions';
 
@@ -49,8 +49,9 @@ vi.mock('../../virtualModules/virtualRemoteEntrySSR', () => ({
   }),
 }));
 
-import { pluginSSRRemoteEntry } from '../pluginSSRRemoteEntry';
+import { getActiveResourcesInfo } from 'node:process';
 import { generateRemoteEntrySSR } from '../../virtualModules/virtualRemoteEntrySSR';
+import { pluginSSRRemoteEntry } from '../pluginSSRRemoteEntry';
 
 function makeOptions(overrides: Record<string, unknown> = {}) {
   return normalizeModuleFederationOptions({
@@ -75,7 +76,10 @@ function makeEmitFile() {
 }
 
 function createMockRequest(method: string, payload?: unknown, rawPayload?: string) {
-  const req = new EventEmitter() as EventEmitter & { method: string; url: string };
+  const req = new EventEmitter() as EventEmitter & {
+    method: string;
+    url: string;
+  };
   req.method = method;
   req.url = '/__mf_runner__';
   queueMicrotask(() => {
@@ -104,14 +108,20 @@ function createMockResponse() {
 
 async function invokeRunnerMiddleware(
   payload: unknown,
-  env: { fetchModule?: unknown; hot?: { handleInvoke?: (payload: unknown) => Promise<unknown> } },
+  env: {
+    fetchModule?: unknown;
+    hot?: { handleInvoke?: (payload: unknown) => Promise<unknown> };
+  },
   rawPayload?: string,
   serverConfig: Record<string, unknown> = { root: '/mock/cwd' },
   method = 'POST'
 ) {
   const plugins = pluginSSRRemoteEntry(makeOptions());
   const mainPlugin = plugins[1];
-  const handlers: { path: string; handler: (req: unknown, res: unknown) => unknown }[] = [];
+  const handlers: {
+    path: string;
+    handler: (req: unknown, res: unknown) => unknown;
+  }[] = [];
 
   callHook(
     mainPlugin.configResolved,
@@ -177,7 +187,12 @@ describe('pluginSSRRemoteEntry', () => {
 
       const config = {
         resolve: {
-          alias: [{ find: '@module-federation/runtime', replacement: '/abs/path/to/runtime.js' }],
+          alias: [
+            {
+              find: '@module-federation/runtime',
+              replacement: '/abs/path/to/runtime.js',
+            },
+          ],
         },
       } as unknown as ResolvedConfig;
 
@@ -192,7 +207,10 @@ describe('pluginSSRRemoteEntry', () => {
         { isEntry: false }
       );
 
-      expect(result).toEqual({ id: '@module-federation/runtime', external: true });
+      expect(result).toEqual({
+        id: '@module-federation/runtime',
+        external: true,
+      });
     });
 
     it('handles regex aliases', () => {
@@ -202,7 +220,10 @@ describe('pluginSSRRemoteEntry', () => {
       const config = {
         resolve: {
           alias: [
-            { find: /^@module-federation\/runtime$/, replacement: '/abs/path/to/runtime.js' },
+            {
+              find: /^@module-federation\/runtime$/,
+              replacement: '/abs/path/to/runtime.js',
+            },
           ],
         },
       } as unknown as ResolvedConfig;
@@ -217,7 +238,10 @@ describe('pluginSSRRemoteEntry', () => {
         { isEntry: false }
       );
 
-      expect(result).toEqual({ id: '@module-federation/runtime', external: true });
+      expect(result).toEqual({
+        id: '@module-federation/runtime',
+        external: true,
+      });
     });
   });
 
@@ -278,7 +302,10 @@ describe('pluginSSRRemoteEntry', () => {
         { isEntry: false }
       );
 
-      expect(result).toEqual({ id: '@module-federation/runtime', external: true });
+      expect(result).toEqual({
+        id: '@module-federation/runtime',
+        external: true,
+      });
     });
 
     it('externalises @module-federation/runtime-core and sdk', () => {
@@ -373,7 +400,9 @@ describe('pluginSSRRemoteEntry', () => {
         { isEntry: false }
       );
 
-      expect(resolveMock).toHaveBeenCalledWith('./assets/helper.js', ssrId, { skipSelf: true });
+      expect(resolveMock).toHaveBeenCalledWith('./assets/helper.js', ssrId, {
+        skipSelf: true,
+      });
     });
   });
 
@@ -462,7 +491,9 @@ describe('pluginSSRRemoteEntry', () => {
       expect(res.statusCode).toBe(200);
       expect(res.headers['Content-Type']).toBe('application/json');
       expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
-      expect(JSON.parse(res.body)).toEqual({ result: { code: 'export default 1' } });
+      expect(JSON.parse(res.body)).toEqual({
+        result: { code: 'export default 1' },
+      });
     });
 
     it('leaves CORS and preflight policy to Vite middleware', async () => {
@@ -495,14 +526,20 @@ describe('pluginSSRRemoteEntry', () => {
         {
           type: 'custom',
           event: 'vite:invoke',
-          data: { id: 'send', name: 'fetchModule', data: ['virtual:safe', null, opts] },
+          data: {
+            id: 'send',
+            name: 'fetchModule',
+            data: ['virtual:safe', null, opts],
+          },
         },
         { fetchModule: vi.fn(), hot: { handleInvoke } }
       );
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('accepts bounded supported fetchModule options', async () => {
@@ -543,7 +580,9 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('rejects invalid runner argument shapes before calling Vite', async () => {
@@ -563,7 +602,9 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('rejects filesystem escape module ids before calling Vite', async () => {
@@ -592,7 +633,9 @@ describe('pluginSSRRemoteEntry', () => {
 
           expect(handleInvoke).not.toHaveBeenCalled();
           expect(res.statusCode).toBe(400);
-          expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+          expect(JSON.parse(res.body)).toEqual({
+            error: { message: 'Invalid runner invoke' },
+          });
         }
       } finally {
         fs.rmSync(outsideRoot, { force: true });
@@ -610,7 +653,11 @@ describe('pluginSSRRemoteEntry', () => {
           {
             type: 'custom',
             event: 'vite:invoke',
-            data: { id: 'send', name: 'fetchModule', data: [`/@fs/${allowedFile}`] },
+            data: {
+              id: 'send',
+              name: 'fetchModule',
+              data: [`/@fs/${allowedFile}`],
+            },
           },
           {
             fetchModule: vi.fn(),
@@ -622,7 +669,9 @@ describe('pluginSSRRemoteEntry', () => {
 
         expect(handleInvoke).toHaveBeenCalled();
         expect(res.statusCode).toBe(200);
-        expect(JSON.parse(res.body)).toEqual({ result: { code: 'export default 1' } });
+        expect(JSON.parse(res.body)).toEqual({
+          result: { code: 'export default 1' },
+        });
       } finally {
         fs.rmSync(allowedDir, { recursive: true, force: true });
       }
@@ -635,7 +684,11 @@ describe('pluginSSRRemoteEntry', () => {
         {
           type: 'custom',
           event: 'vite:invoke',
-          data: { id: 'send', name: 'fetchModule', data: ['..%2F..%2Foutside-root.txt'] },
+          data: {
+            id: 'send',
+            name: 'fetchModule',
+            data: ['..%2F..%2Foutside-root.txt'],
+          },
         },
         {
           fetchModule: vi.fn(),
@@ -645,7 +698,9 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('rejects relative traversal module ids before calling Vite', async () => {
@@ -655,7 +710,11 @@ describe('pluginSSRRemoteEntry', () => {
         {
           type: 'custom',
           event: 'vite:invoke',
-          data: { id: 'send', name: 'fetchModule', data: ['../../outside-root.txt'] },
+          data: {
+            id: 'send',
+            name: 'fetchModule',
+            data: ['../../outside-root.txt'],
+          },
         },
         {
           fetchModule: vi.fn(),
@@ -667,7 +726,9 @@ describe('pluginSSRRemoteEntry', () => {
       // forwarded to Vite, otherwise path traversal validation depends on Vite.
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it.each([
@@ -695,7 +756,9 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('preserves legitimate Vite-encoded internal module ids', async () => {
@@ -738,7 +801,9 @@ describe('pluginSSRRemoteEntry', () => {
       // If decodeURIComponent throws into the outer catch, this becomes a 200.
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('rejects getBuiltins invokes without the Vite invoke envelope', async () => {
@@ -754,7 +819,9 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid runner invoke' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid runner invoke' },
+      });
     });
 
     it('returns 400 for invalid JSON before calling Vite', async () => {
@@ -771,7 +838,9 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(handleInvoke).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body)).toEqual({ error: { message: 'Invalid JSON' } });
+      expect(JSON.parse(res.body)).toEqual({
+        error: { message: 'Invalid JSON' },
+      });
     });
 
     it('rejects oversized runner invoke bodies before calling Vite', async () => {
@@ -957,7 +1026,7 @@ describe('pluginSSRRemoteEntry', () => {
 
       expect(emitFile).not.toHaveBeenCalled();
     });
-
+    getActiveResourcesInfo;
     it.each([
       ['SSR starts before client', 'ssr-first'],
       ['client starts before SSR', 'client-first'],
@@ -1087,7 +1156,10 @@ describe('pluginSSRRemoteEntry', () => {
 
       callHook(
         mainPlugin.buildStart,
-        { meta: makePluginMeta(false), emitFile } as unknown as Rollup.PluginContext,
+        {
+          meta: makePluginMeta(false),
+          emitFile,
+        } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
       );
       callHook(
@@ -1117,7 +1189,10 @@ describe('pluginSSRRemoteEntry', () => {
 
       callHook(
         mainPlugin.buildStart,
-        { meta: makePluginMeta(true), emitFile } as unknown as Rollup.PluginContext,
+        {
+          meta: makePluginMeta(true),
+          emitFile,
+        } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
       );
 
@@ -1148,7 +1223,10 @@ describe('pluginSSRRemoteEntry', () => {
 
       callHook(
         mainPlugin.buildStart,
-        { meta: makePluginMeta(false), emitFile } as unknown as Rollup.PluginContext,
+        {
+          meta: makePluginMeta(false),
+          emitFile,
+        } as unknown as Rollup.PluginContext,
         {} as Rollup.NormalizedInputOptions
       );
 
@@ -1174,7 +1252,11 @@ describe('pluginSSRRemoteEntry', () => {
       callHook(
         mainPlugin.configResolved,
         {} as Rollup.PluginContext,
-        { command: 'build', base: '/_nuxt/', build: { ssr: true } } as ResolvedConfig
+        {
+          command: 'build',
+          base: '/_nuxt/',
+          build: { ssr: true },
+        } as ResolvedConfig
       );
       const emitFile = makeEmitFile();
       callHook(
@@ -1246,9 +1328,18 @@ describe('pluginSSRRemoteEntry', () => {
           fileName: 'mf-assets/exposes-map.js',
           source: 'export default { Widget: () => import("./Widget.js") };',
         },
-        'mf-assets/ssr-only.js': { type: 'chunk', fileName: 'mf-assets/ssr-only.js' },
-        'mf-assets/Widget.js': { type: 'chunk', fileName: 'mf-assets/Widget.js' },
-        'mf-assets/shared.js': { type: 'chunk', fileName: 'mf-assets/shared.js' },
+        'mf-assets/ssr-only.js': {
+          type: 'chunk',
+          fileName: 'mf-assets/ssr-only.js',
+        },
+        'mf-assets/Widget.js': {
+          type: 'chunk',
+          fileName: 'mf-assets/Widget.js',
+        },
+        'mf-assets/shared.js': {
+          type: 'chunk',
+          fileName: 'mf-assets/shared.js',
+        },
       } as unknown as Rollup.OutputBundle;
       callHook(
         mainPlugin.generateBundle,
@@ -1330,7 +1421,9 @@ describe('pluginSSRRemoteEntry', () => {
 
         callHook(
           mainPlugin.writeBundle,
-          { environment: { name: 'client' } } as unknown as Rollup.PluginContext,
+          {
+            environment: { name: 'client' },
+          } as unknown as Rollup.PluginContext,
           { dir: clientDir } as Rollup.NormalizedOutputOptions,
           outputBundle
         );

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -248,10 +248,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let isNuxtProject = false;
   let reactIslandExposes: ReadonlySet<string> = new Set();
 
-  const isSsrRemoteEntryBuild = (environment?: {
-    name?: string;
-    config?: ResolvedConfig;
-  }) => {
+  const isSsrRemoteEntryBuild = (environment?: { name?: string; config?: ResolvedConfig }) => {
     const environmentName = environment?.name;
     const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
     const isLegacySsrBuild = Boolean(environment?.config?.build?.ssr ?? viteConfig?.build?.ssr);
@@ -516,9 +513,11 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         // whether we're running under Rolldown (Vite 8+) so we can choose the
         // right output format and file extension.
         const isRolldown = getIsRolldown(this);
-        const environment = (this as {
-          environment?: { name?: string; config?: ResolvedConfig };
-        }).environment;
+        const environment = (
+          this as {
+            environment?: { name?: string; config?: ResolvedConfig };
+          }
+        ).environment;
 
         // Environment API (client + ssr): emit only in the ssr environment so exposes
         // are bundled with the Node SSR graph (nested loadRemote stays on the server).
@@ -542,9 +541,11 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         order: 'post',
         handler(_options, bundle) {
           const isRolldown = getIsRolldown(this);
-          const environment = (this as {
-            environment?: { name?: string; config?: ResolvedConfig };
-          }).environment;
+          const environment = (
+            this as {
+              environment?: { name?: string; config?: ResolvedConfig };
+            }
+          ).environment;
           const exposesChunk = findNuxtExposesChunk(bundle);
           if (!isRolldown && isSsrRemoteEntryBuild(environment)) {
             let source = generateRemoteEntrySSR(options);

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -214,9 +214,7 @@ function readBoundedRunnerBody(
 export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions): Plugin[] {
   const remoteEntrySSRId = getRemoteEntrySSRId(options);
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
-  let isRolldown = false;
-  let shouldEmitSsrEntry = false;
-  let ssrOutputFilename = '';
+  const ssrOutputFilename = getSsrRemoteEntryFileName(options.filename);
   let ssrOutputFiles = new Set<string>();
   let ssrOutputDir = '';
   let clientOutputDir = '';
@@ -249,6 +247,23 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let viteConfig: ResolvedConfig | undefined;
   let isNuxtProject = false;
   let reactIslandExposes: ReadonlySet<string> = new Set();
+
+  const isSsrRemoteEntryBuild = (environment?: {
+    name?: string;
+    config?: ResolvedConfig;
+  }) => {
+    const environmentName = environment?.name;
+    const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
+    const isLegacySsrBuild = Boolean(environment?.config?.build?.ssr ?? viteConfig?.build?.ssr);
+
+    return (
+      Object.keys(options.exposes).length > 0 &&
+      !(
+        (hasSsrEnvironment && environmentName !== 'ssr') ||
+        (!hasSsrEnvironment && !isLegacySsrBuild)
+      )
+    );
+  };
 
   const findNuxtExposesChunk = (
     bundle: Record<string, { type: string; fileName: string; code?: string }>
@@ -495,34 +510,20 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
       },
 
       buildStart() {
-        shouldEmitSsrEntry = false;
         // Only emit the SSR entry chunk during vite build — not vite serve.
         if (isServe) return;
         // `this.meta` is available in Rollup/Rolldown hooks — use it to detect
         // whether we're running under Rolldown (Vite 8+) so we can choose the
         // right output format and file extension.
-        isRolldown = getIsRolldown(this);
-        ssrOutputFilename = getSsrRemoteEntryFileName(options.filename);
-
-        const environmentName = (this as { environment?: { name?: string } }).environment?.name;
-        const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
-        const isLegacySsrBuild = Boolean(
-          (this as { environment?: { config?: ResolvedConfig } }).environment?.config?.build?.ssr ??
-          viteConfig?.build?.ssr
-        );
+        const isRolldown = getIsRolldown(this);
+        const environment = (this as {
+          environment?: { name?: string; config?: ResolvedConfig };
+        }).environment;
 
         // Environment API (client + ssr): emit only in the ssr environment so exposes
         // are bundled with the Node SSR graph (nested loadRemote stays on the server).
         // Emit only for an SSR environment or legacy `vite build --ssr`.
-        if (
-          (hasSsrEnvironment && environmentName !== 'ssr') ||
-          (!hasSsrEnvironment && !isLegacySsrBuild)
-        ) {
-          return;
-        }
-
-        if (Object.keys(options.exposes).length === 0) return;
-        shouldEmitSsrEntry = true;
+        if (!isSsrRemoteEntryBuild(environment)) return;
 
         if (isRolldown) {
           // Vite 8+ (Rolldown): emit as a proper chunk. Rolldown handles multiple
@@ -540,8 +541,12 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
       generateBundle: {
         order: 'post',
         handler(_options, bundle) {
+          const isRolldown = getIsRolldown(this);
+          const environment = (this as {
+            environment?: { name?: string; config?: ResolvedConfig };
+          }).environment;
           const exposesChunk = findNuxtExposesChunk(bundle);
-          if (!isRolldown && shouldEmitSsrEntry) {
+          if (!isRolldown && isSsrRemoteEntryBuild(environment)) {
             let source = generateRemoteEntrySSR(options);
             if (exposesChunk) {
               source = source.replace(


### PR DESCRIPTION
## Summary

- Remove shared per-build SSR emission state from `pluginSSRRemoteEntry`.
- Re-evaluate SSR eligibility and Rolldown detection for each hook invocation.
- Keep SSR entry emission scoped to the current SSR environment during parallel client/SSR builds.
- Add regression coverage for both client/SSR build-start orderings.

## Root cause

The plugin instance is shared across Vite environments, but `shouldEmitSsrEntry` and `isRolldown` were closure-global. A client build could reset or observe state belonging to the SSR build, causing the SSR entry to be omitted or emitted into the client output.

## Validation

- `git diff --check`
- Added deterministic unit coverage for both interleavings.
- Vitest, typecheck, and formatting could not run in this checkout because `node_modules` is unavailable.
- A real Vite 6/7 parallel Environment API integration test remains a follow-up validation opportunity.

No security or performance behavior is changed by this PR.