### PR TITLE
perf: cache generated SSR remote entry source

### DIFF
--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -1152,6 +1152,68 @@ describe('pluginSSRRemoteEntry', () => {
         })
       );
     });
+
+    it('caches the base SSR entry across outputs while rewriting Nuxt imports per output', () => {
+      getIsRolldownMock.mockReturnValue(false);
+      vi.mocked(generateRemoteEntrySSR).mockReturnValueOnce(
+        'const map = import("virtual:mf-exposes-ssr:remote");'
+      );
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+
+      callHook(
+        mainPlugin.configResolved,
+        {} as Rollup.PluginContext,
+        { command: 'build', base: '/_nuxt/', build: { ssr: true } } as ResolvedConfig
+      );
+      callHook(
+        mainPlugin.buildStart,
+        { meta: makePluginMeta(false) } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+
+      const firstEmitFile = makeEmitFile();
+      callHook(
+        mainPlugin.generateBundle,
+        { emitFile: firstEmitFile } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {
+          '_nuxt/virtualExposes-first.js': {
+            type: 'chunk',
+            fileName: '_nuxt/virtualExposes-first.js',
+            code: 'export default {"./Widget": () => import("./Widget.js")}',
+          },
+        } as unknown as Rollup.OutputBundle,
+        false
+      );
+
+      const secondEmitFile = makeEmitFile();
+      callHook(
+        mainPlugin.generateBundle,
+        { emitFile: secondEmitFile } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {
+          '_nuxt/virtualExposes-second.js': {
+            type: 'chunk',
+            fileName: '_nuxt/virtualExposes-second.js',
+            code: 'export default {"./Widget": () => import("./Widget.js")}',
+          },
+        } as unknown as Rollup.OutputBundle,
+        false
+      );
+
+      expect(generateRemoteEntrySSR).toHaveBeenCalledTimes(1);
+      expect(firstEmitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'const map = import("./_nuxt/virtualExposes-first.js");',
+        })
+      );
+      expect(secondEmitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'const map = import("./_nuxt/virtualExposes-second.js");',
+        })
+      );
+    });
   });
 
   describe('main plugin — writeBundle', () => {

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -214,6 +214,7 @@ function readBoundedRunnerBody(
 export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions): Plugin[] {
   const remoteEntrySSRId = getRemoteEntrySSRId(options);
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
+  let cachedSsrRemoteEntrySource: string | undefined;
   let isRolldown = false;
   let shouldEmitSsrEntry = false;
   let ssrOutputFilename = '';
@@ -249,6 +250,16 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let viteConfig: ResolvedConfig | undefined;
   let isNuxtProject = false;
   let reactIslandExposes: ReadonlySet<string> = new Set();
+
+  // The plugin instance is created for a build and may serve multiple Rollup
+  // outputs. Reuse the stable base source across those outputs; Nuxt-specific
+  // rewrites are intentionally applied to a local copy in generateBundle.
+  const getSsrRemoteEntrySource = () => {
+    if (cachedSsrRemoteEntrySource === undefined) {
+      cachedSsrRemoteEntrySource = generateRemoteEntrySSR(options);
+    }
+    return cachedSsrRemoteEntrySource;
+  };
 
   const findNuxtExposesChunk = (
     bundle: Record<string, { type: string; fileName: string; code?: string }>
@@ -542,7 +553,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         handler(_options, bundle) {
           const exposesChunk = findNuxtExposesChunk(bundle);
           if (!isRolldown && shouldEmitSsrEntry) {
-            let source = generateRemoteEntrySSR(options);
+            let source = getSsrRemoteEntrySource();
             if (exposesChunk) {
               source = source.replace(
                 /import\("virtual:mf-exposes-ssr:[^"]+"\)/g,


### PR DESCRIPTION
## Summary

- Cache the generated SSR remote-entry source within each plugin instance.
- Reuse the stable base source across multiple Rollup outputs.
- Preserve independent Nuxt expose-chunk rewriting for every output.
- Add multi-output coverage proving one generation and two correctly rewritten assets.

## Motivation

Rollup can invoke output-generation hooks for multiple outputs. The generated SSR entry depends only on normalized federation options, so regenerating the same base source for every output is unnecessary.

## Scope

This is intentionally limited to the SSR source-generation path. It does not change environment gating, publication, dev-server behavior, or generated output semantics.

## Validation

- `git diff --check`
- Added focused multi-output Nuxt unit coverage.
- Vitest, typecheck, and formatting could not run in this checkout because `node_modules` is unavailable.

This is a small optimization; the benefit is proportional to the number of Rollup outputs and may be most useful for multi-output builds.