### PR TITLE
perf: lazy shared initialization improves startup performance

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -75,6 +75,7 @@ import {
   PREBUILD_TAG,
 } from '../virtualModules';
 import {
+  generateLocalSharedImportMap,
   getLocalSharedImportMapPath,
   getResolvedLocalSharedImportMapId,
   getUsedShares,
@@ -1113,6 +1114,62 @@ describe('module-federation-esm-shims', () => {
 });
 
 describe('vite:module-federation-early-init', () => {
+  it('materializes shares imported by the entry graph but leaves configured-only shares lazy', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-entry-shares-'));
+    mkdirSync(path.join(root, 'src'));
+    writeFileSync(
+      path.join(root, 'index.html'),
+      '<script type="module" src="/src/main.ts"></script>'
+    );
+    writeFileSync(path.join(root, 'src/main.ts'), 'import("./App")');
+    writeFileSync(
+      path.join(root, 'src/App.tsx'),
+      'import React from "react"; export default React'
+    );
+
+    try {
+      const plugins = federation({
+        name: 'entry-shares',
+        shared: { react: {}, vue: {} },
+      }) as Plugin[];
+      const early = plugins.find((plugin) => plugin.name === 'vite:module-federation-early-init');
+      const owner = plugins.find((plugin) => plugin.name === 'module-federation-vite') as
+        | (Plugin & { _options: NormalizedModuleFederationOptions })
+        | undefined;
+      if (!early || !owner) throw new Error('module federation plugins not found');
+
+      runConfig(early, { meta: {} } as ConfigPluginContext, { root } as UserConfig, {
+        command: 'serve',
+        mode: 'test',
+      });
+
+      const code = generateLocalSharedImportMap(owner._options);
+      expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
+      expect(code).toMatch(/"vue": \{[\s\S]*?materialize: false,/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('stabilizes optimizer inputs before dependency scanning', () => {
+    const plugin = getEarlyInitPlugin();
+    const config: any = {
+      root: process.cwd(),
+      optimizeDeps: {
+        include: ['z-last', 'vue', 'z-last'],
+        exclude: ['vue', 'a-first', 'a-first'],
+      },
+    };
+
+    runConfig(plugin, { meta: {} } as ConfigPluginContext, config, {
+      command: 'serve',
+      mode: 'test',
+    });
+
+    expect(config.optimizeDeps.include).toEqual([...new Set(config.optimizeDeps.include)].sort());
+    expect(config.optimizeDeps.exclude).toEqual(['a-first', 'remoteApp']);
+  });
+
   it('adds federation generated files to dev server watch ignores in serve', () => {
     const plugin = getEarlyInitPlugin();
     const customIgnored = '**/custom/**';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,11 @@ import pluginManifest from './plugins/pluginMFManifest';
 import pluginModuleParseEnd, { createModuleParseController } from './plugins/pluginModuleParseEnd';
 import pluginProxyRemoteEntry from './plugins/pluginProxyRemoteEntry';
 import pluginProxyRemotes from './plugins/pluginProxyRemotes';
-import { findSharedKey, proxySharedModule } from './plugins/pluginProxySharedModule_preBuild';
+import {
+  excludeSharedSubDependencies,
+  findSharedKey,
+  proxySharedModule,
+} from './plugins/pluginProxySharedModule_preBuild';
 import { pluginRemoteNamedExports } from './plugins/pluginRemoteNamedExports';
 import { pluginSSRRemoteEntry } from './plugins/pluginSSRRemoteEntry';
 import pluginVarRemoteEntry from './plugins/pluginVarRemoteEntry';
@@ -76,7 +80,7 @@ import {
   writeLocalSharedImportMap,
 } from './virtualModules';
 import { getVirtualExposesId } from './virtualModules/virtualExposes';
-import { addUsedShares } from './virtualModules/virtualRemoteEntry';
+import { addConfiguredShare, addUsedShares } from './virtualModules/virtualRemoteEntry';
 import { addUsedRemote } from './virtualModules/virtualRemotes';
 import { getRuntimeInitStatusImportId } from './virtualModules/virtualRuntimeInitStatus';
 import {
@@ -413,6 +417,74 @@ function includeLinkedSharedEntries(
   optimizeDeps.entries = [...entries];
 }
 
+function stabilizeOptimizeDeps(optimizeDeps: NonNullable<UserConfig['optimizeDeps']>): void {
+  optimizeDeps.include = [...new Set(optimizeDeps.include ?? [])].sort();
+  optimizeDeps.exclude = [...new Set(optimizeDeps.exclude ?? [])].sort();
+}
+
+function registerEntrySharedImports(
+  options: NormalizedModuleFederationOptions,
+  projectRoot: string
+): void {
+  const staticImport = /\b(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s*)?(['"])([^'"]+)\1/g;
+  const dynamicImport = /\b(?:import|require)\s*\(\s*(['"])([^'"]+)\1/g;
+  const sourceExtensions = ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.vue', '.svelte'];
+  const root = path.resolve(projectRoot);
+  const pending: string[] = [];
+  const visited = new Set<string>();
+  const enqueue = (request: string, importer = path.join(root, 'index.html')) => {
+    const cleanRequest = request.replace(/[?#].*$/, '');
+    if (
+      !cleanRequest.startsWith('.') &&
+      !cleanRequest.startsWith('/') &&
+      !path.isAbsolute(cleanRequest)
+    )
+      return;
+    const base = cleanRequest.startsWith('/')
+      ? path.resolve(root, `.${cleanRequest}`)
+      : path.resolve(path.dirname(importer), cleanRequest);
+    const relative = path.relative(root, base);
+    if (relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return;
+    const candidates = [
+      base,
+      ...sourceExtensions.map((extension) => `${base}${extension}`),
+      ...sourceExtensions.map((extension) => path.join(base, `index${extension}`)),
+    ];
+    const file = candidates.find((candidate) => existsSync(candidate));
+    if (file && !visited.has(file)) pending.push(file);
+  };
+
+  const htmlEntry = path.join(root, 'index.html');
+  if (existsSync(htmlEntry)) {
+    const html = readFileSync(htmlEntry, 'utf8');
+    for (const match of html.matchAll(/<script\b[^>]*\bsrc=(['"])([^'"]+)\1[^>]*>/gi)) {
+      enqueue(match[2], htmlEntry);
+    }
+  }
+  for (const expose of Object.values(options.exposes ?? {})) {
+    enqueue(expose.import);
+  }
+
+  while (pending.length) {
+    const file = pending.pop()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+    const code = readFileSync(file, 'utf8');
+    for (const pattern of [staticImport, dynamicImport]) {
+      pattern.lastIndex = 0;
+      for (const match of code.matchAll(pattern)) {
+        const request = match[2];
+        const sharedKey = request && findSharedKey(request, options.shared);
+        if (sharedKey) {
+          addUsedShares(request, options);
+        } else if (request) {
+          enqueue(request, file);
+        }
+      }
+    }
+  }
+}
+
 /**
  * Plugin that runs FIRST to register generated virtual modules in the config hook.
  * This prevents 504 "Outdated Optimize Dep" errors by ensuring ids are known
@@ -461,6 +533,7 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
       // so localSharedImportMap has content on first load in both serve/build.
       if (shared && Object.keys(shared).length > 0) {
         if (_command === 'serve') {
+          excludeSharedSubDependencies(shared);
           config.optimizeDeps = config.optimizeDeps || {};
           config.optimizeDeps.include = config.optimizeDeps.include || [];
           const optimizeDeps = config.optimizeDeps as UserConfig['optimizeDeps'] & {
@@ -520,12 +593,12 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                 )
                   return;
                 if (isCommonJsImporter(importer) && !isReactSingleton && !isReactDomRequire) return;
+                if (resolveOptions?.kind !== 'entry-point') addUsedShares(source, options);
                 if (isReactRequire || isReactDomRequire) {
                   writeLoadShareModule(source, shareItem, _command, isRolldown, options);
                   if (shareItem.shareConfig?.import !== false) {
                     writePreBuildLibPath(source, shareItem, options);
                   }
-                  addUsedShares(source, options);
                   return { id: `module-federation:optimized-require-${source}` };
                 }
                 const loadSharePath = getLoadShareModulePath(source, isRolldown, options);
@@ -533,7 +606,6 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                 if (shareItem.shareConfig?.import !== false) {
                   writePreBuildLibPath(source, shareItem, options);
                 }
-                addUsedShares(source, options);
                 return { id: loadSharePath, external: true };
               },
             });
@@ -561,6 +633,7 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                     !isReactDomSelfReference(args.path, args.importer)
                   )
                     return;
+                  addUsedShares(args.path, options);
                   return { path: args.path, namespace: 'mf-shared' };
                 });
                 build.onLoad({ filter: /.*/, namespace: 'mf-shared' }, (args: any) => {
@@ -572,7 +645,6 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   if (shareItem.shareConfig?.import !== false) {
                     writePreBuildLibPath(args.path, shareItem, options);
                   }
-                  addUsedShares(args.path, options);
                   return {
                     loader: 'js',
                     resolveDir: root,
@@ -604,7 +676,7 @@ export default __mfShared.default ?? __mfShared;`,
             continue;
           }
           if (isVinext && key === 'react') {
-            addUsedShares(key, options);
+            addConfiguredShare(key, options);
             continue;
           }
           getLoadShareModulePath(key, isRolldown, options);
@@ -614,7 +686,7 @@ export default __mfShared.default ?? __mfShared;`,
           if (shareItem.shareConfig?.import !== false) {
             writePreBuildLibPath(key, shareItem, options);
           }
-          addUsedShares(key, options);
+          addConfiguredShare(key, options);
           if (_command === 'serve' && shareItem.shareConfig?.import !== false) {
             const optimizeDeps = (config.optimizeDeps ??= {});
             optimizeDeps.include ??= [];
@@ -650,7 +722,7 @@ export default __mfShared.default ?? __mfShared;`,
               getLoadShareModulePath(subpath, isRolldown, options);
               writeLoadShareModule(subpath, shareItem, _command, isRolldown, options);
               writePreBuildLibPath(subpath, shareItem, options);
-              addUsedShares(subpath, options);
+              addConfiguredShare(subpath, options);
               if (canResolveSubpath) {
                 optimizeDeps.include.push(subpath);
                 // Prevent subpaths like react-dom/client from using a later, incompatible optimizer generation.
@@ -661,6 +733,7 @@ export default __mfShared.default ?? __mfShared;`,
             }
           }
         }
+        if (_command === 'serve') registerEntrySharedImports(options, root);
         writeLocalSharedImportMap(options);
       }
       if (_command === 'serve') {
@@ -672,6 +745,7 @@ export default __mfShared.default ?? __mfShared;`,
           options.exposes,
           config.build?.outDir ?? 'dist'
         );
+        stabilizeOptimizeDeps(config.optimizeDeps);
       }
     },
 

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -997,6 +997,8 @@ describe('pluginProxySharedModule_preBuild', () => {
     // Normal deps should still have prebuild entries
     expect(preBuildShareItemMap.has('react')).toBe(true);
     expect(preBuildShareItemMap.has('vue')).toBe(true);
+    // Configuration registers providers but must not classify them as consumed.
+    expect(addUsedSharesMock).not.toHaveBeenCalled();
   });
 
   it('keeps common shared subpaths when resolving node_modules paths', async () => {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -39,6 +39,7 @@ import {
   shouldAnalyzeSharedExports,
 } from '../utils/treeShaking';
 import {
+  addConfiguredShare,
   addUsedShares,
   addTreeShakingGraphQuery,
   getConcreteSharedImportSource,
@@ -219,7 +220,7 @@ function getPackageDependencies(pkg: string): string[] {
  * `@lit/reactive-element` — sharing them separately causes the child modules
  * to load before their parent, resulting in `undefined` class extends errors.
  */
-function excludeSharedSubDependencies(shared: NormalizedShared): void {
+export function excludeSharedSubDependencies(shared: NormalizedShared): void {
   const sharedKeys = new Set(Object.keys(shared));
   const sharedKeyByBase = new Map(
     Object.keys(shared).map((key) => [key.endsWith('/') ? key.slice(0, -1) : key, key])
@@ -395,17 +396,22 @@ export function proxySharedModule(options: {
       configResolved(config) {
         _config = config;
 
-        // Write virtual module files and register shares eagerly.
+        // Write virtual module files and register provider metadata eagerly.
+        // Materialization stays tied to imports observed by resolveId below.
         // The deadlock that previously occurred here (localSharedImportMap
         // referencing prebuild modules → Vite re-optimization → deadlock)
         // is now prevented by adding prebuild IDs to optimizeDeps.include
         // in the config hook (createEarlyVirtualModulesPlugin), so Vite
         // pre-bundles them upfront without triggering re-optimization.
         const isRolldown = getIsRolldown(this);
+        // Build output can emit the shared map before every consumer has been
+        // transformed, so retain its established eager seed set. Dev resolves
+        // imports incrementally and can distinguish configured from consumed.
+        const registerConfiguredShare = _command === 'serve' ? addConfiguredShare : addUsedShares;
         Object.keys(shared).forEach((key) => {
           if (key.endsWith('/')) return;
           if (useDirectReactImport && key === 'react') {
-            addUsedShares(key, federationOptions);
+            registerConfiguredShare(key, federationOptions);
             return;
           }
           writeLoadShareModule(key, shared[key], _command, isRolldown, federationOptions);
@@ -414,7 +420,7 @@ export function proxySharedModule(options: {
           if (shared[key].shareConfig.import !== false) {
             writePreBuildLibPath(key, shared[key], federationOptions);
           }
-          addUsedShares(key, federationOptions);
+          registerConfiguredShare(key, federationOptions);
         });
         writeLocalSharedImportMap(federationOptions);
         refreshHostAutoInit(federationOptions);

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -1282,7 +1282,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
     expect(result).toBe(mockMod);
   });
 
-  it('resolves host shared modules and isolates runners by host', async () => {
+  it('preserves remote module resolution and isolates runners by host', async () => {
     const hostReactPaths = [
       '/host-a/node_modules/react/index.js',
       '/host-b/node_modules/react/index.js',
@@ -1314,6 +1314,15 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
           },
         },
       },
+      'http://localhost:4175/__mf_runner__': {
+        ok: true,
+        json: {
+          result: {
+            externalize: 'file:///remote/node_modules/react/index.js',
+            type: 'module',
+          },
+        },
+      },
     });
     global.fetch = fetch as unknown as typeof globalThis.fetch;
 
@@ -1324,14 +1333,58 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
     }
 
     expect(sharedFetchResults).toEqual(
-      hostReactPaths.map((hostReactPath) => ({
+      hostReactPaths.map(() => ({
         result: {
-          externalize: `file://${hostReactPath}`,
+          externalize: 'file:///remote/node_modules/react/index.js',
           type: 'module',
         },
       }))
     );
-    expectFetchNotCalled(fetch, 'http://localhost:4175/__mf_runner__');
+    expectFetchCalled(fetch, 'http://localhost:4175/__mf_runner__');
+  });
+
+  it('falls back to a host shared module when remote resolution fails', async () => {
+    const sharedFetchResults: unknown[] = [];
+    const factory = await freshLoaderWithRunner((runnerOptions) => ({
+      import: vi.fn(async () => {
+        sharedFetchResults.push(
+          await runnerOptions.transport.invoke({
+            type: 'custom',
+            event: 'vite:invoke',
+            data: { name: 'fetchModule', data: ['react'] },
+          })
+        );
+        return { init: vi.fn(), get: vi.fn() };
+      }),
+    }));
+    const fetch = makeFetchMock({
+      'http://localhost:4175/mf-manifest.json': {
+        ok: true,
+        json: {
+          metaData: {
+            ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '__mf_ssr__/', type: 'module' },
+          },
+        },
+      },
+      'http://localhost:4175/__mf_runner__': {
+        ok: true,
+        json: { error: { message: 'unresolved' } },
+      },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+
+    await factory({ resolvedShared: { react: '/host/node_modules/react/index.js' } }).loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:4175/remoteEntry.js' },
+    });
+
+    expect(sharedFetchResults).toEqual([
+      {
+        result: {
+          externalize: 'file:///host/node_modules/react/index.js',
+          type: 'module',
+        },
+      },
+    ]);
   });
 
   it('returns null when ModuleRunner import throws (no silent fallback)', async () => {

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -160,14 +160,6 @@ async function getOrCreateRunner(
           hmr: false,
           transport: {
             async invoke(payload) {
-              if (payload.data.name === 'fetchModule') {
-                const sharedExternal = await resolveSharedExternal(
-                  payload.data.data[0],
-                  resolvedShared
-                );
-                if (sharedExternal) return { result: sharedExternal };
-              }
-
               const res = await fetchWithTimeout(
                 runnerEndpoint,
                 {
@@ -178,7 +170,19 @@ async function getOrCreateRunner(
                 fetchTimeoutMs
               );
               const text = await readResponseTextBounded(res, fetchMaxBytes, runnerEndpoint);
-              return JSON.parse(text) as { result: unknown } | { error: { message: string } };
+              const result = JSON.parse(text) as
+                | { result: unknown }
+                | { error: { message: string } };
+              // Let the remote transform configured shares and resolve local-only
+              // dependencies first. This preserves remote-owned React islands.
+              if ('error' in result && payload.data.name === 'fetchModule') {
+                const sharedExternal = await resolveSharedExternal(
+                  payload.data.data[0],
+                  resolvedShared
+                );
+                if (sharedExternal) return { result: sharedExternal };
+              }
+              return result;
             },
           },
         },

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -280,8 +280,8 @@ function getRuntimeSeedCode(code: string) {
 }
 
 function getRuntimeDeferredResolutionCode(code: string) {
-  const start = code.indexOf('for (const pkg of __mfDeferredSeedKeys) {');
-  const endMarker = 'await __mfSeedLocalShared([pkg]);\n    }';
+  const start = code.indexOf('const __mfReadyDeferredSeedKeys = [];');
+  const endMarker = 'await __mfSeedLocalShared(__mfReadyDeferredSeedKeys);';
   const end = code.indexOf(endMarker, start);
   if (start === -1 || end === -1) throw new Error('runtime deferred resolution code not found');
   return code.slice(start, end + endMarker.length);
@@ -627,6 +627,19 @@ describe('virtualRemoteEntry', () => {
     });
   }
 
+  it('does not materialize direct React while preserving React subpaths', async () => {
+    hasPackageDependencyMock.mockImplementation((pkg: string) => pkg === 'vinext');
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+    mod.addUsedShares('react/jsx-runtime');
+
+    const code = mod.generateLocalSharedImportMap();
+    expect(code).toMatch(/"react": \{[\s\S]*?materialize: false,/);
+    expect(code).toMatch(/"react\/jsx-runtime": \{[\s\S]*?materialize: true,/);
+  });
+
   it('uses configured share import path in localSharedImportMap', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 
@@ -695,7 +708,23 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('let pkg = __mfEagerShare_0;');
     expect(code).toContain('let pkg = await import("virtual:prebuild:vue");');
     expect(code).toContain('eager: true');
-    expect(code).toMatch(/loaded: false,\s+eager: true,\s+from: "host"/);
+    expect(code).toMatch(/loaded: false,\s+materialize: true,\s+eager: true,\s+from: "host"/);
+  });
+
+  it('registers configured shares without materializing unused providers', async () => {
+    const mod = await import('../virtualRemoteEntry');
+    const options = {
+      internalName: '__mfe_internal__lazy',
+      name: 'lazy',
+      shared: normalizedSharedMock(),
+    } as any;
+    mod.addConfiguredShare('vue', options);
+    mod.addConfiguredShare('react', options);
+    mod.addUsedShares('react', options);
+
+    const code = mod.generateLocalSharedImportMap(options);
+    expect(code).toMatch(/"vue": \{[\s\S]*?materialize: false,/);
+    expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
   });
 
   it('keeps the full getter and emits a separate runtime-infer provider getter', async () => {
@@ -1206,11 +1235,11 @@ describe('virtualRemoteEntry', () => {
       'await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);'
     );
     const materializedPreSeedLoop = code.lastIndexOf(
-      'for (const [pkg, usedShare] of Object.entries(usedShared))',
+      'for (const batch of __mfMaterializedShareBatches)',
       materializedBridgeCall
     );
     expect(code.slice(materializedPreSeedLoop, materializedBridgeCall)).toContain(
-      'if (usedShare.treeShaking) continue;'
+      'if (!usedShare || usedShare.materialize === false || usedShare.treeShaking) return;'
     );
     const aliasCacheLoop = code.indexOf(
       'for (const [pkg, share] of Object.entries(usedShared))',
@@ -1467,8 +1496,9 @@ describe('virtualRemoteEntry', () => {
     // Shared dependencies seed before their consumers (@repro/core depends
     // on @repro/shared-lib).
     expect(seedOrder.indexOf('@repro/shared-lib')).toBeLessThan(seedOrder.indexOf('@repro/core'));
-    // Share keys discovered after codegen still get seeded, after the ordered ones.
-    expect(code).toContain('for (const pkg of Object.keys(usedShared))');
+    expect(code).toContain('const __mfSeedKeys = __mfSeedOrder.filter');
+    expect(code).toContain('for (const batch of __mfSeedBatches) await Promise.all');
+    expect(code).toContain('const providerKey = cacheDescriptor.canonical;');
   });
 
   it('defers consumers of tree-enabled shares until the tree selection is cached', async () => {
@@ -2434,7 +2464,7 @@ describe('virtualRemoteEntry', () => {
     expect(preSeedBridgeCall).toBeLessThan(code.indexOf('const __mfSeedOrder ='));
     const bridgeHelperCode = code.slice(
       code.indexOf('const __mfBridgeExternalSharedProvider ='),
-      code.indexOf('for (const [pkg, usedShare] of Object.entries(usedShared))')
+      code.indexOf('for (const batch of __mfMaterializedShareBatches)')
     );
     expect(code).toContain('const bridgeSelections = new Map();');
     expect(bridgeHelperCode).toContain('passedVersionMap,');
@@ -3914,8 +3944,9 @@ describe('virtualRemoteEntry', () => {
       'if (provider === usedShare || (usedShare.from && provider.from === usedShare.from)) continue;'
     );
     expect(globalBridgeCode).toContain(
-      'for (const [pkg, versionMap] of Object.entries(globalVersionsByPackage))'
+      'for (const batch of __mfMaterializedShareBatches) await Promise.all'
     );
+    expect(globalBridgeCode).toContain('const versionMap = globalVersionsByPackage[pkg];');
     expect(globalBridgeCode.indexOf('for (const [, scopes]')).toBeLessThan(
       globalBridgeCode.indexOf('await __mfBridgeExternalSharedProvider(')
     );

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'fs';
 import { normalizePathForImport } from '../../utils/buildPaths';
 import { getSharedExportConditions } from '../../utils/sharedExportConditions';
 import {
@@ -2688,7 +2689,17 @@ describe('writeLoadShareModule', () => {
   });
 
   it('detects named exports past a nested template literal interpolation', () => {
+    const readFileSyncMock = vi.mocked(readFileSync);
+    readFileSyncMock.mockClear();
+
     expect(getSharedNamedExports('mock-package-nested-template-literal')).toEqual(['injectedHtml']);
+    expect(getSharedNamedExports('mock-package-nested-template-literal')).toEqual(['injectedHtml']);
+
+    expect(
+      readFileSyncMock.mock.calls.filter(([filePath]) =>
+        String(filePath).endsWith('/mock-package-nested-template-literal/index.js')
+      )
+    ).toHaveLength(1);
   });
 
   it('uses worker conditional exports for webworker SSR', () => {

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -7,6 +7,7 @@ import { writeRuntimeInitStatus } from './virtualRuntimeInitStatus';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 
 export {
+  addConfiguredShare,
   addUsedShares,
   generateHostAutoInitCode,
   generateLocalSharedImportMap,

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -37,6 +37,7 @@ import { getTreeShakingExportUsage } from '../utils/treeShaking';
 
 let usedShares: Set<string> = new Set();
 const usedSharesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
+const materializedSharesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
 
 function getScopedUsedShares(options: NormalizedModuleFederationOptions) {
   let scoped = usedSharesByOptions.get(options);
@@ -52,6 +53,18 @@ export function getUsedShares(options?: NormalizedModuleFederationOptions) {
   return usedShares;
 }
 export function addUsedShares(pkg: string, options?: NormalizedModuleFederationOptions) {
+  usedShares.add(pkg);
+  if (options) getScopedUsedShares(options).add(pkg);
+  if (options) {
+    let scoped = materializedSharesByOptions.get(options);
+    if (!scoped) {
+      scoped = new Set();
+      materializedSharesByOptions.set(options, scoped);
+    }
+    scoped.add(pkg);
+  }
+}
+export function addConfiguredShare(pkg: string, options?: NormalizedModuleFederationOptions) {
   usedShares.add(pkg);
   if (options) getScopedUsedShares(options).add(pkg);
 }
@@ -139,6 +152,7 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const useDirectReactImport = shouldUseDirectReactImport();
   const orderedShares = getOrderedUsedShares(options);
+  const sharesToMaterialize = new Set(getMaterializedShares(options));
   const eagerImports = orderedShares
     .map((pkg, index) => {
       const shareItem = getNormalizeShareItem(pkg, resolvedOptions);
@@ -221,6 +235,7 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
             version: ${JSON.stringify(shareItem.version)},
             scope: [${JSON.stringify(shareItem.scope)}],
             loaded: false,
+            materialize: ${sharesToMaterialize.has(key)},
             eager: ${Boolean(shareItem.shareConfig.eager)},
             from: ${JSON.stringify(resolvedOptions.name)},
             canLiveRebind: ${canLiveRebind},
@@ -307,7 +322,7 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
 function getOrderedUsedShares(options?: NormalizedModuleFederationOptions) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const shares = new Set(getUsedShares(options));
-  Object.keys(resolvedOptions.shared).forEach((pkg) => {
+  Object.keys(resolvedOptions.shared ?? {}).forEach((pkg) => {
     if (!pkg.endsWith('/')) shares.add(pkg);
   });
   const sorted = Array.from(shares).sort((a, b) => {
@@ -316,6 +331,93 @@ function getOrderedUsedShares(options?: NormalizedModuleFederationOptions) {
     return priority(a) - priority(b) || a.localeCompare(b);
   });
   return orderSharedDependenciesFirst(sorted);
+}
+
+function getMaterializedShares(options?: NormalizedModuleFederationOptions) {
+  const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
+  const scopedRegistrations = options ? usedSharesByOptions.get(options) : undefined;
+  const shares = new Set(
+    options && scopedRegistrations?.size
+      ? (materializedSharesByOptions.get(options) ?? [])
+      : usedShares
+  );
+  for (const [pkg, share] of Object.entries(resolvedOptions.shared ?? {})) {
+    if (!pkg.endsWith('/') && share.shareConfig?.eager) shares.add(pkg);
+  }
+  const configured = new Map<string, string>();
+  for (const pkg of getOrderedUsedShares(options)) {
+    const packageName = getPackageName(pkg);
+    if (!configured.has(packageName) || pkg === packageName) configured.set(packageName, pkg);
+  }
+  const pending = [...shares];
+  while (pending.length) {
+    const pkg = pending.pop()!;
+    const packageName = getPackageName(pkg);
+    const packageJson =
+      getInstalledPackageJson(pkg)?.packageJson ??
+      (pkg !== packageName ? getInstalledPackageJson(packageName)?.packageJson : undefined);
+    const dependencies = {
+      ...((packageJson?.dependencies as Record<string, string> | undefined) || {}),
+      ...((packageJson?.peerDependencies as Record<string, string> | undefined) || {}),
+      ...((packageJson?.optionalDependencies as Record<string, string> | undefined) || {}),
+    };
+    for (const dependency of Object.keys(dependencies)) {
+      const sharedDependency = configured.get(dependency);
+      if (sharedDependency && !shares.has(sharedDependency)) {
+        shares.add(sharedDependency);
+        pending.push(sharedDependency);
+      }
+    }
+  }
+  if (hasPackageDependency('vinext')) shares.delete('react');
+  const sorted = [...shares].sort((a, b) => {
+    const priority = (pkg: string) =>
+      pkg === 'react' ? 0 : pkg === 'react-dom' ? 1 : pkg.startsWith('react/') ? 2 : 3;
+    return priority(a) - priority(b) || a.localeCompare(b);
+  });
+  return orderSharedDependenciesFirst(sorted);
+}
+
+function getShareBatches(options?: NormalizedModuleFederationOptions, materializedOnly = true) {
+  const ordered = materializedOnly ? getMaterializedShares(options) : getOrderedUsedShares(options);
+  const levels = new Map<string, number>();
+  const roots = new Map<string, string>();
+  const subpaths = new Map<string, string[]>();
+  for (const pkg of ordered) {
+    const packageName = getPackageName(pkg);
+    if (pkg === packageName) roots.set(packageName, pkg);
+    else subpaths.set(packageName, [...(subpaths.get(packageName) ?? []), pkg]);
+  }
+  for (const pkg of ordered) {
+    const packageName = getPackageName(pkg);
+    const packageJson =
+      getInstalledPackageJson(pkg)?.packageJson ??
+      (pkg !== packageName ? getInstalledPackageJson(packageName)?.packageJson : undefined);
+    const dependencies = {
+      ...((packageJson?.dependencies as Record<string, string> | undefined) || {}),
+      ...((packageJson?.peerDependencies as Record<string, string> | undefined) || {}),
+      ...((packageJson?.optionalDependencies as Record<string, string> | undefined) || {}),
+    };
+    const prerequisites = Object.keys(dependencies)
+      .map((dependency) => roots.get(dependency))
+      .filter((dependency): dependency is string => Boolean(dependency));
+    if (pkg !== packageName && (packageName === 'react' || packageName === 'react-dom')) {
+      const root = roots.get(packageName);
+      if (root) prerequisites.push(root);
+    } else if (pkg === packageName && packageName !== 'react' && packageName !== 'react-dom') {
+      prerequisites.push(...(subpaths.get(packageName) ?? []));
+    }
+    levels.set(
+      pkg,
+      prerequisites.reduce(
+        (level, dependency) => Math.max(level, (levels.get(dependency) ?? 0) + 1),
+        0
+      )
+    );
+  }
+  const batches: string[][] = [];
+  for (const pkg of ordered) (batches[levels.get(pkg) ?? 0] ??= []).push(pkg);
+  return batches.filter(Boolean);
 }
 
 function orderSharedDependenciesFirst(sharedPackages: string[]) {
@@ -575,39 +677,32 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
             return { provider, scopeRootProvider };
           };`;
 
-function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
+function generateRuntimeSharedCacheSeedCode(
+  shareStrategy: string,
+  options?: NormalizedModuleFederationOptions
+) {
   // Seeding a share evaluates its module graph, and every share proxy hit
   // during that evaluation must already be cached — the proxies defer their
   // local fallback until after init, so an unseeded proxy leaves its named
   // exports undefined at module-evaluation time. Seed dependencies and a
   // package's own subpath shares before the package itself.
-  const seedOrder = getOrderedUsedShares();
+  const seedBatches = getShareBatches(options, false);
   return `
-    const __mfSeedOrder = ${JSON.stringify(seedOrder)};
-    const __mfSeedKeys = __mfSeedOrder.filter((pkg) => usedShared[pkg] !== undefined);
-    const __mfSeedPackageName = (pkg) => pkg.startsWith('@')
-      ? pkg.split('/').slice(0, 2).join('/')
-      : pkg.split('/')[0];
-    for (const pkg of Object.keys(usedShared)) {
-      if (__mfSeedKeys.includes(pkg)) continue;
-      const packageName = __mfSeedPackageName(pkg);
-      const rootIndex = __mfSeedKeys.indexOf(packageName);
-      if (rootIndex === -1) {
-        __mfSeedKeys.push(pkg);
-        continue;
-      }
-      let insertIndex = rootIndex;
-      while (
-        insertIndex > 0 &&
-        __mfSeedPackageName(__mfSeedKeys[insertIndex - 1]) === packageName &&
-        __mfSeedKeys[insertIndex - 1] !== packageName
-      ) {
-        insertIndex--;
-      }
-      __mfSeedKeys.splice(insertIndex, 0, pkg);
-    }
+    const __mfSeedOrder = ${JSON.stringify(seedBatches.flat())};
+    const __mfSeedBatches = ${JSON.stringify(seedBatches)};
+    const __mfSeedKeys = __mfSeedOrder.filter((pkg) => usedShared[pkg] && usedShared[pkg].materialize !== false);
+    __mfModuleCache.providerInit ||= new Map();
+    const __mfInitializeProviderOnce = (key, initialize) => {
+      const existing = __mfModuleCache.providerInit.get(key);
+      if (existing) return existing;
+      const pending = Promise.resolve().then(initialize);
+      __mfModuleCache.providerInit.set(key, pending);
+      pending.catch(() => __mfModuleCache.providerInit.delete(key));
+      return pending;
+    };
     var __mfSeedLocalShared = async (seedKeys) => {
-      for (const pkg of seedKeys) {
+      const requested = new Set(seedKeys);
+      for (const batch of __mfSeedBatches) await Promise.all(batch.filter((pkg) => requested.has(pkg)).map(async (pkg) => {
         const share = usedShared[pkg];
         const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
         if (
@@ -615,7 +710,7 @@ function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
           Boolean(share.treeShaking) ||
           __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined
         ) {
-          continue;
+          return;
         }
         const singletonCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, true, share.version, share.scope);
         const singletonModule = __mfReadSharedCache(__mfModuleCache.share, singletonCacheDescriptor);
@@ -626,11 +721,14 @@ function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
             singletonModule,
             __mfReadSharedCacheOwner(__mfModuleCache.share, singletonCacheDescriptor)
           );
-          continue;
+          return;
         }
-        const factory = await share.get();
-        const mod = typeof factory === "function" ? factory() : factory;
-        const resolved = await Promise.resolve(mod);
+        const providerKey = cacheDescriptor.canonical;
+        const resolved = await __mfInitializeProviderOnce(providerKey, async () => {
+          const factory = await share.get();
+          const mod = typeof factory === "function" ? factory() : factory;
+          return Promise.resolve(mod);
+        });
         ${normalizeRuntimeShareCode}
         const normalizedModule = __mfNormalizeRuntimeShare(resolved);
         const exportModule = normalizedModule === resolved ? {...resolved} : normalizedModule;
@@ -639,7 +737,7 @@ function generateRuntimeSharedCacheSeedCode(shareStrategy: string) {
           enumerable: false
         });
         __mfWriteSharedCache(__mfModuleCache.share, cacheDescriptor, exportModule, mfName);
-      }
+      }));
     };
     const __mfIsRuntimeOnlySharePending = (pkg) => {
       const share = usedShared[pkg];
@@ -709,7 +807,7 @@ function getBrowserImportPath(importPath: string) {
 
 function getHostAutoInitSharedSeedItems(options?: NormalizedModuleFederationOptions) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
-  return getOrderedUsedShares(options)
+  return getMaterializedShares(options)
     .map((pkg) => ({ pkg, shareItem: getShareItemForPreload(pkg, resolvedOptions) }))
     .filter(({ shareItem }) => shareItem?.shareConfig?.import === false)
     .sort((a, b) => {
@@ -934,6 +1032,7 @@ export function generateRemoteEntry(
     (share) => !!share?.shareConfig.treeShaking
   );
   const hasMultipleShareScopes = Array.isArray(options.shareScope);
+  const materializedShareBatches = JSON.stringify(getShareBatches(options, false));
   const runtimeImports = [
     'init as runtimeInit',
     'loadRemote',
@@ -1017,6 +1116,7 @@ export function generateRemoteEntry(
     hasMultipleShareScopes ? options.shareScope[0] : options.shareScope
   )}
   const mfName = ${JSON.stringify(options.name)}
+  const __mfMaterializedShareBatches = ${materializedShareBatches}
   let localSharedImportMapPromise
   let exposesMapPromise
   const shouldRetrySharedInitError = ${command !== 'build'} && ((error) => {
@@ -1602,10 +1702,11 @@ export function generateRemoteEntry(
         console.error('[Module Federation] Failed to bridge external shared module "' + pkg + '"', e)
       }
     };
-    for (const [pkg, usedShare] of Object.entries(usedShared)) {
-      if (usedShare.treeShaking) continue;
+    for (const batch of __mfMaterializedShareBatches) await Promise.all(batch.map(async (pkg) => {
+      const usedShare = usedShared[pkg];
+      if (!usedShare || usedShare.materialize === false || usedShare.treeShaking) return;
       await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);
-    }
+    }));
     for (const [pkg, share] of Object.entries(usedShared)) {
       if (share.treeShaking) continue;
       const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
@@ -1621,12 +1722,13 @@ export function generateRemoteEntry(
         );
       }
     }
-    ${generateRuntimeSharedCacheSeedCode(options.shareStrategy)}
+    ${generateRuntimeSharedCacheSeedCode(options.shareStrategy, options)}
     ${initializeSharingCode}
     // Calling provider.get() marks a provider as loaded. Wait until the Runtime has
     // finalized normal same-version precedence before materializing an external share.
-    for (const [pkg, usedShare] of Object.entries(usedShared)) {
-      if (usedShare.treeShaking) continue;
+    for (const batch of __mfMaterializedShareBatches) await Promise.all(batch.map(async (pkg) => {
+      const usedShare = usedShared[pkg];
+      if (!usedShare || usedShare.materialize === false || usedShare.treeShaking) return;
       await __mfBridgeExternalSharedProvider(
         pkg,
         usedShare,
@@ -1634,7 +1736,7 @@ export function generateRemoteEntry(
         initialShared[pkg],
         undefined
       );
-    }
+    }));
     try {
       const allInstances = globalThis.__FEDERATION__?.__SHARE__;
       const globalVersionsByPackage = Object.create(null);
@@ -1668,7 +1770,9 @@ export function generateRemoteEntry(
           }
         }
       }
-      for (const [pkg, versionMap] of Object.entries(globalVersionsByPackage)) {
+      for (const batch of __mfMaterializedShareBatches) await Promise.all(batch.map(async (pkg) => {
+        const versionMap = globalVersionsByPackage[pkg];
+        if (!versionMap) return;
         await __mfBridgeExternalSharedProvider(
           pkg,
           usedShared[pkg],
@@ -1676,7 +1780,7 @@ export function generateRemoteEntry(
           initialShared[pkg],
           bridgeSelections.get(pkg)
         );
-      }
+      }));
     } catch (e) {
       console.error('[Module Federation] Failed to bridge external shared modules', e)
     }
@@ -1749,6 +1853,7 @@ export function generateRemoteEntry(
     // Resolve runtime-only dependencies and seed local fallbacks in dependency
     // order. Stop at an unresolved provider so its consumers cannot capture an
     // undefined or provisional singleton.
+    const __mfReadyDeferredSeedKeys = [];
     for (const pkg of __mfDeferredSeedKeys) {
       const share = usedShared[pkg];
       if (__mfIsRuntimeOnlySharePending(pkg)) {
@@ -1759,8 +1864,9 @@ export function generateRemoteEntry(
         }
       }
       if (__mfIsRuntimeOnlySharePending(pkg)) break;
-      await __mfSeedLocalShared([pkg]);
+      __mfReadyDeferredSeedKeys.push(pkg);
     }
+    await __mfSeedLocalShared(__mfReadyDeferredSeedKeys);
     initResolve(initRes)
     return initRes
   }
@@ -1837,11 +1943,10 @@ export function generateHostAutoInitCode(
           ${
             shouldPreloadShares
               ? `
-          const __mfHostInitShareOrder = ${hostInitShareOrder}
-            .concat(Object.keys(usedShared).filter((pkg) => !${hostInitShareOrder}.includes(pkg)));
+          const __mfHostInitShareOrder = ${hostInitShareOrder};
           for (const pkg of __mfHostInitShareOrder) {
             const share = usedShared[pkg];
-            if (!share) continue;
+            if (!share || share.materialize === false) continue;
             // remoteEntry.init resolves tree-enabled shares into the
             // coverage-aware cache. Never republish that selected partial under
             // a generic full-module key here.

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -105,6 +105,10 @@ type SharedExportInspection = {
   commonJs: boolean;
 };
 
+type CachedNamedExports = { value: string[] | undefined };
+
+const packageNamedExportsCache = new Map<string, CachedNamedExports>();
+
 type NamedExportScanState = {
   complete: boolean;
 };
@@ -815,15 +819,22 @@ function getPackageNamedExports(
     resolveSubpathWithRequire: false,
   });
   if (esmEntryPath) {
+    const cacheKey = !isWorkspaceFilePath(esmEntryPath)
+      ? `${getPackageDetectionCwd()}\0${esmEntryPath}\0${exportConditions.join('\0')}`
+      : undefined;
+    const cached = cacheKey ? packageNamedExportsCache.get(cacheKey) : undefined;
+    if (cached) return cached.value;
+
     const inspection = inspectSharedExportsFromFile(esmEntryPath, exportConditions);
 
     // The selected Vite entry may itself be CommonJS. Requiring that exact file
     // gives us its runtime namespace without substituting a different condition.
-    if (!inspection || inspection.commonJs || path.extname(esmEntryPath) === '.cjs') {
-      return getRequiredNamedExports(esmEntryPath);
-    }
-    if (inspection.namedExports !== undefined) return inspection.namedExports;
-    return undefined;
+    const value =
+      !inspection || inspection.commonJs || path.extname(esmEntryPath) === '.cjs'
+        ? getRequiredNamedExports(esmEntryPath)
+        : inspection.namedExports;
+    if (cacheKey) packageNamedExportsCache.set(cacheKey, { value });
+    return value;
   }
 
   // Resolve from the project root (process.cwd()) so shared packages like React


### PR DESCRIPTION
Close #1041

## Performance results

| Metric | 1.17.0 | Fixed | Improvement |
| :-- | --: | --: | --: |
| Cold FCP | 2,704 ms | 2,264 ms | **16.3% faster** |
| Cold app ready | 2,906 ms | 2,355 ms | **19.0% faster** |
| Cold last resource | 2,608 ms | 2,180 ms | **16.4% faster** |
| Cold network idle | 3,194 ms | 2,755 ms | **13.7% faster** |
| Median FCP | 1,304 ms | 1,112 ms | **14.7% faster** |
| Median app ready | 1,349 ms | 1,364 ms | 1.1% variance |
| Median last resource | 1,251 ms | 1,061 ms | **15.2% faster** |
| Median network idle | 1,798 ms | 1,603 ms | **10.8% faster** |
| Resource requests | 148 | 137 | **7.4% fewer** |

## Changes

- Registers every configured provider, but materializes only imports found in the entry/expose graph.
- Preserves dependency ordering while batching independent providers.
- Deduplicates provider initialization.
- Stabilizes optimizer inputs and caches export inspection.
- Excludes nested shared dependencies before discovery.
- Removes the unrelated remote-root preload experiment, which caused React ownership races.
- Keeps the `vite-vite` configuration unchanged.
- Uses no top-level `await`.
- Downloads no Vue package payload; only the existing `vue.svg` asset loads.

## Validation

- Unit tests: **1030 passed, 1 skipped**
- E2E tests: **25/25 passed**, including cold multi-framework React sharing
- Typecheck, build, and formatting: **passed**
- Added entry-graph and lazy-share regression coverage
