### PR TITLE
fix: fix SSR shared singleton resolution

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -40,4 +40,34 @@ describe('virtualRemoteEntrySSR', () => {
     expect(code).toContain('initRes.initShareScopeMap(scopeName, scopeShare)');
     expect(code).toContain('initRes.initializeSharing(scopeName');
   });
+
+  it('caches host-provided SSR singletons during container init', () => {
+    const options = getDefaultMockOptions({
+      name: 'remote',
+      shared: {
+        react: {
+          name: 'react',
+          version: '19.0.0',
+          scope: 'default',
+          from: '',
+          shareConfig: { singleton: true, requiredVersion: '^19.0.0' },
+        },
+        lodash: {
+          name: 'lodash',
+          version: '4.17.21',
+          scope: 'default',
+          from: '',
+          shareConfig: { singleton: false, requiredVersion: '^4.17.21' },
+        },
+      },
+    } as any);
+
+    const code = generateRemoteEntrySSR(options);
+
+    expect(code).toContain('const sharedSingletons = {"react"');
+    expect(code).not.toContain('"lodash"');
+    expect(code).toContain('const factory = await initRes.loadShare(pkg');
+    expect(code).toContain("cache[scopeName + ':' + pkg] ??= module");
+    expect(code.slice(0, code.indexOf('async function'))).not.toContain('await ');
+  });
 });

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -28,10 +28,14 @@ export function getSsrRemoteEntryFileName(browserFilename: string): string {
  */
 export function generateRemoteEntrySSR(options: NormalizedModuleFederationOptions): string {
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
+  const sharedSingletons = Object.fromEntries(
+    Object.entries(options.shared).filter(([, share]) => share.shareConfig.singleton)
+  );
 
   return `
   import { init as runtimeInit } from "@module-federation/runtime";
 
+  const sharedSingletons = ${JSON.stringify(sharedSingletons)};
   let exposesMapPromise;
 
   async function getExposesMap() {
@@ -68,6 +72,18 @@ export function generateRemoteEntrySSR(options: NormalizedModuleFederationOption
               initScope,
             })
           );
+          for (const [pkg, shareInfo] of Object.entries(sharedSingletons)) {
+            if (shareInfo.scope !== scopeName || !scopeShare[pkg]) continue;
+            const factory = await initRes.loadShare(pkg, {
+              customShareInfo: { ...shareInfo, scope: [scopeName] },
+            });
+            if (typeof factory !== 'function') continue;
+            const module = await factory();
+            const moduleCache = (globalThis.__mf_module_cache__ ||= { share: {}, remote: {} });
+            const cache = (moduleCache.share ||= {});
+            cache[scopeName + ':' + pkg] ??= module;
+            if (scopeName === 'default') cache[pkg] ??= module;
+          }
         } catch (e) {
           console.error('[Module Federation SSR]', e);
         }


### PR DESCRIPTION
Close #1049

Seed SSR’s shared cache from runtime-selected host singletons during container initialization.
Prevents remotes silently using local copies.