### PR TITLE
fix: resolve directory imports in the entry shared-import scan

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1151,6 +1151,49 @@ describe('vite:module-federation-early-init', () => {
     }
   });
 
+  it('resolves directory imports in the entry graph to their index file', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-entry-dir-import-'));
+    mkdirSync(path.join(root, 'src'));
+    mkdirSync(path.join(root, 'src/provider'));
+    writeFileSync(
+      path.join(root, 'index.html'),
+      '<script type="module" src="/src/main.ts"></script>'
+    );
+    // A bare directory request: `src/provider` exists as a directory, so reading
+    // it as source would fail with EISDIR instead of picking up its index file.
+    writeFileSync(path.join(root, 'src/main.ts'), 'import { Provider } from "./provider"');
+    writeFileSync(
+      path.join(root, 'src/provider/index.ts'),
+      'import React from "react"; export const Provider = React'
+    );
+
+    try {
+      const plugins = federation({
+        name: 'entry-dir-import',
+        shared: { react: {}, vue: {} },
+      }) as Plugin[];
+      const early = plugins.find((plugin) => plugin.name === 'vite:module-federation-early-init');
+      const owner = plugins.find((plugin) => plugin.name === 'module-federation-vite') as
+        | (Plugin & { _options: NormalizedModuleFederationOptions })
+        | undefined;
+      if (!early || !owner) throw new Error('module federation plugins not found');
+
+      expect(() =>
+        runConfig(early, { meta: {} } as ConfigPluginContext, { root } as UserConfig, {
+          command: 'serve',
+          mode: 'test',
+        })
+      ).not.toThrow();
+
+      // The directory's index file was crawled, so its react import is materialized.
+      const code = generateLocalSharedImportMap(owner._options);
+      expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
+      expect(code).toMatch(/"vue": \{[\s\S]*?materialize: false,/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('stabilizes optimizer inputs before dependency scanning', () => {
     const plugin = getEarlyInitPlugin();
     const config: any = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'url';
@@ -422,6 +422,14 @@ function stabilizeOptimizeDeps(optimizeDeps: NonNullable<UserConfig['optimizeDep
   optimizeDeps.exclude = [...new Set(optimizeDeps.exclude ?? [])].sort();
 }
 
+function isFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
 function registerEntrySharedImports(
   options: NormalizedModuleFederationOptions,
   projectRoot: string
@@ -450,7 +458,7 @@ function registerEntrySharedImports(
       ...sourceExtensions.map((extension) => `${base}${extension}`),
       ...sourceExtensions.map((extension) => path.join(base, `index${extension}`)),
     ];
-    const file = candidates.find((candidate) => existsSync(candidate));
+    const file = candidates.find(isFile);
     if (file && !visited.has(file)) pending.push(file);
   };
 


### PR DESCRIPTION
`registerEntrySharedImports` crawls the entry graph to decide which shared packages to materialize. Its candidate list starts with the bare request path and is filtered with `existsSync`, which is also true for directories, so a directory request wins before the `index.*` candidates below it are tried. The crawl then reads that candidate and dies:

    Error: EISDIR: illegal operation on a directory, read
      at registerEntrySharedImports

This takes down `vite dev` startup entirely, and a bare directory import is ordinary code — `import { AppContextProvider } from './provider'` where `src/provider/` holds an `index.ts` is enough to trigger it.

Accept a candidate only when it is a file, so a directory request falls through to the `index.*` candidates that were already there for exactly this case.

Verified against a real host that could not start on 1.20.5: dev server now boots and serves, and the regression test reproduces the original EISDIR without the fix.