### PR TITLE
perf(shared): cache concrete shared import source resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import {
   getPreBuildLibImportId,
   materializeCachedLoadShareModule,
   prependWorkspaceSingletonSsrImport,
+  resetConcreteSharedImportSourceCache,
   writeLoadShareModule,
   writePreBuildLibPath,
 } from './virtualModules/virtualShared_preBuild';
@@ -500,6 +501,7 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
       if (_command === 'serve') ignoreFederationGeneratedFiles(config, options);
 
       const root = config.root || process.cwd();
+      resetConcreteSharedImportSourceCache();
       setPackageDetectionCwd(root);
       const isVinext = hasPackageDependency('vinext');
 

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -15,6 +15,7 @@ import {
   getTreeShakingGraphToken,
   getTreeShakingSharedProviderImportId,
   hasTreeShakingSharedProvider,
+  resetConcreteSharedImportSourceCache,
   stripTreeShakingGraphQuery,
   writeLoadShareModule,
   writePreBuildLibPath,
@@ -2863,16 +2864,20 @@ describe('writeLoadShareModule', () => {
     );
   });
 
-  it('memoizes concrete shared import resolution by package and project root', () => {
+  it('memoizes by package and root and supports lifecycle invalidation', () => {
     const pkg = 'memoized-shared-package';
 
     expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
     expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
     expect(createRequireSpy).toHaveBeenCalledTimes(1);
 
-    packageDetectionCwdMock.mockReturnValue('/repo/apps/other');
+    resetConcreteSharedImportSourceCache();
     expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
     expect(createRequireSpy).toHaveBeenCalledTimes(2);
+
+    packageDetectionCwdMock.mockReturnValue('/repo/apps/other');
+    expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
+    expect(createRequireSpy).toHaveBeenCalledTimes(3);
   });
 
   it('uses project require resolution for package subpath import paths', () => {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -25,8 +25,10 @@ const { writeSyncSpy, mfWarnSpy } = vi.hoisted(() => ({
   mfWarnSpy: vi.fn(),
 }));
 
-const { hasPackageDependencyMock } = vi.hoisted(() => ({
+const { hasPackageDependencyMock, packageDetectionCwdMock, createRequireSpy } = vi.hoisted(() => ({
   hasPackageDependencyMock: vi.fn<(pkg: string) => boolean>(() => false),
+  packageDetectionCwdMock: vi.fn(() => '/repo/apps/remote'),
+  createRequireSpy: vi.fn(),
 }));
 
 const { sideEffectChannels, openLoopKeepingChannel } = vi.hoisted(() => ({
@@ -190,7 +192,7 @@ vi.mock('../../utils/packageUtils', () => ({
           };`,
   packageNameEncode: (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, '_'),
   hasPackageDependency: hasPackageDependencyMock,
-  getPackageDetectionCwd: vi.fn(() => '/repo/apps/remote'),
+  getPackageDetectionCwd: packageDetectionCwdMock,
   resolveImportPath: vi.fn(() => '/repo/node_modules/@module-federation/runtime/dist/index.js'),
   getInstalledPackageEntry: vi.fn((pkg: string, opts?: { cwd?: string; conditions?: string[] }) => {
     if (pkg === 'react/jsx-runtime') {
@@ -954,6 +956,7 @@ vi.mock('module', async (importOriginal) => {
   return {
     ...actual,
     createRequire: (from: string | URL) => {
+      createRequireSpy(from);
       const fromPath = String(from);
       const req = ((pkg: string) => {
         if (pkg === 'mock-package-side-effect') {
@@ -1207,6 +1210,9 @@ describe('writeLoadShareModule', () => {
     mfWarnSpy.mockClear();
     hasPackageDependencyMock.mockReset();
     hasPackageDependencyMock.mockReturnValue(false);
+    packageDetectionCwdMock.mockReset();
+    packageDetectionCwdMock.mockReturnValue('/repo/apps/remote');
+    createRequireSpy.mockClear();
     normalizeModuleFederationOptions({ name: 'test' });
   });
 
@@ -2855,6 +2861,18 @@ describe('writeLoadShareModule', () => {
     expect(getConcreteSharedImportSource('workspace-parent-dual-format')).toBe(
       '/repo/packages/workspace-parent-dual-format/dist/index.js'
     );
+  });
+
+  it('memoizes concrete shared import resolution by package and project root', () => {
+    const pkg = 'memoized-shared-package';
+
+    expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
+    expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
+    expect(createRequireSpy).toHaveBeenCalledTimes(1);
+
+    packageDetectionCwdMock.mockReturnValue('/repo/apps/other');
+    expect(getConcreteSharedImportSource(pkg)).toBeUndefined();
+    expect(createRequireSpy).toHaveBeenCalledTimes(2);
   });
 
   it('uses project require resolution for package subpath import paths', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1063,6 +1063,10 @@ function tryResolveImportFromPackageRoot(pkg: string, root: string): string | un
  */
 const concreteSharedImportSourceCache = new Map<string, string | undefined>();
 
+export function resetConcreteSharedImportSourceCache() {
+  concreteSharedImportSourceCache.clear();
+}
+
 export function getConcreteSharedImportSource(
   pkg: string,
   shareItem?: ShareItem

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1055,6 +1055,14 @@ function tryResolveImportFromPackageRoot(pkg: string, root: string): string | un
   }
 }
 
+/**
+ * Resolution walks from the project root up to the filesystem root, probing
+ * every level, and the shared-module resolver asks for the same few packages
+ * tens of thousands of times on a cold dev start. The detection cwd is part of
+ * the key because `setPackageDetectionCwd` can move it between config hooks.
+ */
+const concreteSharedImportSourceCache = new Map<string, string | undefined>();
+
 export function getConcreteSharedImportSource(
   pkg: string,
   shareItem?: ShareItem
@@ -1063,6 +1071,16 @@ export function getConcreteSharedImportSource(
   if (typeof configuredImport === 'string') return configuredImport;
 
   const projectRoot = getPackageDetectionCwd();
+  const cacheKey = JSON.stringify([projectRoot, pkg]);
+  if (concreteSharedImportSourceCache.has(cacheKey)) {
+    return concreteSharedImportSourceCache.get(cacheKey);
+  }
+  const resolved = resolveConcreteSharedImportSource(pkg, projectRoot);
+  concreteSharedImportSourceCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+function resolveConcreteSharedImportSource(pkg: string, projectRoot: string): string | undefined {
   if (tryResolveImportFromPackageRoot(pkg, projectRoot)) {
     return undefined;
   }


### PR DESCRIPTION
`getConcreteSharedImportSource` walks from the project root up to the filesystem root, probing module resolution at every level. The shared-module resolver injected into Vite's dependency optimizer asks for the same handful of packages tens of thousands of times on a cold dev start — measured on one host: 26,279 calls returning the same answers.

Cache the resolution. The package detection cwd is part of the key because `setPackageDetectionCwd` can move it between config hooks, so a plain per-package cache would return another root's answer.