### PR TITLE
fix: avoid Webpack provider init deadlock

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -506,7 +506,7 @@ describe('module parse wiring', () => {
 
     callHook(parseEnd.moduleParsed, ctx, { id: '/src/main.ts' } as never);
 
-    expect(await resolvesQuickly(Promise.resolve(pendingRemoteEntry))).toBe(true);
+    expect(await Promise.resolve(pendingRemoteEntry)).toEqual(expect.any(String));
   });
 
   it('keeps the complete import:false export surface when parse analysis is incomplete', async () => {

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -355,6 +355,22 @@ describe('pluginProxySharedModule_preBuild', () => {
       expect(findSharedKey('missing-dep/subpath', shared)).toBeUndefined();
       expect(findSharedKey('missing-dep/subpath', shared)).toBeUndefined();
     });
+
+    it('does not implicitly share common subpaths when the package uses import:false', () => {
+      const shared = makeShared();
+      shared.react.shareConfig.import = false;
+
+      expect(findSharedKey('react', shared)).toBe('react');
+      expect(findSharedKey('react/jsx-runtime', shared)).toBeUndefined();
+
+      const explicitlyShared = makeShared();
+      explicitlyShared.react.shareConfig.import = false;
+      explicitlyShared['react/jsx-runtime'] = {
+        ...explicitlyShared.react,
+        name: 'react/jsx-runtime',
+      };
+      expect(findSharedKey('react/jsx-runtime', explicitlyShared)).toBe('react/jsx-runtime');
+    });
   });
 
   beforeEach(() => {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -135,12 +135,18 @@ function getSharedKeyMatcher(shared: NormalizedShared | undefined): SharedKeyMat
 
   for (const key of keys) {
     const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
+    const shareItem = shared[key];
 
     if (!vueKey && keyBase === 'vue') vueKey = key;
     if (key.endsWith('/')) wildcardKeys.push({ key, base: keyBase });
 
-    for (const subpath of getCommonSharedSubpaths(keyBase)) {
-      if (!commonSubpathKeys.has(subpath)) commonSubpathKeys.set(subpath, key);
+    // `import: false` applies to the configured key only. Treating common
+    // subpaths as implicit shares creates unfulfillable runtime-only entries
+    // for hosts which provide the bare package but not every package export.
+    if (shareItem.shareConfig?.import !== false) {
+      for (const subpath of getCommonSharedSubpaths(keyBase)) {
+        if (!commonSubpathKeys.has(subpath)) commonSubpathKeys.set(subpath, key);
+      }
     }
   }
 

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -993,7 +993,9 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('return [...new Set([...configuredScopes, ...shareScopeNames])]');
     expect(code).toContain('getShareScope(getShareScopeName(pkg, usedShare))');
     expect(code).toContain('for (const shareScopeName of shareScopeNames)');
-    expect(code).toContain('initRes.initShareScopeMap(shareScopeName, scopeShare)');
+    expect(code).toContain(
+      'initRes.initShareScopeMap(\n        shareScopeName,\n        __mfGetRuntimeShareScope(shareScopeName, scopeShare)\n      );'
+    );
     expect(code).toContain('initRes.initializeSharing(shareScopeName');
   });
 
@@ -1136,6 +1138,7 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('exposesMapPromise = retrySharedInit(() => import("virtual:exposes"))');
     expect(code).toContain('.then((mod) => mod.default ?? mod)');
     expect(code).toContain('const {usedShared, usedRemotes} = await getLocalSharedImportMap()');
+    expect(code).toContain('const __mfGetPendingExternalSharedProvider =');
     expect(code).toContain('const exposesMap = await getExposesMap()');
     expect(code).toContain('const mfName = "host"');
     expect(code).toContain('await Promise.all(__mfModuleCache.pendingShareLoads)');
@@ -2304,7 +2307,7 @@ describe('virtualRemoteEntry', () => {
     );
 
     const runtimeInitCall = code.indexOf('const initRes = runtimeInit({');
-    const initShareScopeMapCall = code.indexOf("initRes.initShareScopeMap('default', shared);");
+    const initShareScopeMapCall = code.indexOf("__mfGetRuntimeShareScope('default', shared)");
     const materializedBridgeCall = code.indexOf(
       'await __mfBridgeMaterializedProvider(pkg, usedShare, initialShared[pkg]);'
     );
@@ -2388,7 +2391,10 @@ describe('virtualRemoteEntry', () => {
     const initializeSharingCall = code.indexOf(
       `await Promise.all(await initRes.initializeSharing('default'`
     );
-    const lateBridgeCall = code.indexOf('await __mfBridgeExternalSharedProvider(\n        pkg');
+    const lateBridgeCall = code.indexOf(
+      'await __mfBridgeExternalSharedProvider(',
+      initializeSharingCall
+    );
 
     expect(localSharedCode).toContain('canLiveRebind: true');
     expect(materializedBridgeCode).toContain(
@@ -2396,6 +2402,9 @@ describe('virtualRemoteEntry', () => {
     );
     expect(initializeSharingCall).toBeGreaterThan(-1);
     expect(lateBridgeCall).toBeGreaterThan(initializeSharingCall);
+    expect(code).toContain('let __mfLateBridgeShared');
+    expect(code).toContain('__mfLateBridgeShared = async () =>');
+    expect(code).toContain('if (__mfLateBridgeShared) await __mfLateBridgeShared()');
   });
 
   it('seeds import:false shared modules in hostAutoInit during serve', async () => {
@@ -2633,12 +2642,15 @@ describe('virtualRemoteEntry', () => {
     expect(bridgeHelperCode).not.toContain('const cacheDescriptor =');
     expect(bridgeHelperCode.match(/__mfWriteSharedCache\(/g)).toHaveLength(1);
     expect(bridgeHelperCode).toContain("Failed to bridge external shared module \"' + pkg + '\"'");
-    const exactBridgeCall = code.indexOf('await __mfBridgeExternalSharedProvider(\n        pkg');
-    expect(code.indexOf('if (initScope.indexOf(initToken) >= 0) return;')).toBeLessThan(
-      exactBridgeCall
-    );
     const initializeSharingCall = code.indexOf(
       `await Promise.all(await initRes.initializeSharing('default'`
+    );
+    const exactBridgeCall = code.indexOf(
+      'await __mfBridgeExternalSharedProvider(',
+      initializeSharingCall
+    );
+    expect(code.indexOf('if (initScope.indexOf(initToken) >= 0) return;')).toBeLessThan(
+      exactBridgeCall
     );
     expect(initializeSharingCall).toBeGreaterThan(-1);
     expect(initializeSharingCall).toBeLessThan(exactBridgeCall);
@@ -2778,6 +2790,82 @@ describe('virtualRemoteEntry', () => {
         'version-first'
       )
     ).toBeUndefined();
+  });
+
+  it('defers only unresolved Webpack providers during remote init', async () => {
+    normalizedSharedMock.mockReturnValue({
+      'react-dom': {
+        name: 'react-dom',
+        from: '',
+        version: '18.3.1',
+        scope: 'default',
+        shareConfig: {
+          singleton: false,
+          requiredVersion: '^18.3.1',
+          strictVersion: false,
+        },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react-dom');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+    const materializedBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeMaterializedProvider ='),
+      code.indexOf('const __mfBridgeExternalSharedProvider =')
+    );
+    const webpackProviderGuard =
+      'if (!directFactory && !scopeRoot && isWebpackProvider(provider)) return;';
+    const lazyProviderAwait =
+      'if (!directFactory && provider.loading) directFactory = await provider.loading;';
+
+    expect(materializedBridgeCode).toContain(webpackProviderGuard);
+    expect(materializedBridgeCode.indexOf(webpackProviderGuard)).toBeLessThan(
+      materializedBridgeCode.indexOf(lazyProviderAwait)
+    );
+
+    const externalBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeExternalSharedProvider ='),
+      code.indexOf('for (const batch of __mfMaterializedShareBatches)')
+    );
+    const externalProviderGuard =
+      'isWebpackProvider(provider) &&\n          !provider.lib &&\n          !provider.loaded';
+    expect(externalBridgeCode).toContain(externalProviderGuard);
+    expect(code).toContain(
+      "const pendingExternalProvider = typeof __mfGetPendingExternalSharedProvider === 'function'"
+    );
+    expect(externalBridgeCode.indexOf(externalProviderGuard)).toBeLessThan(
+      externalBridgeCode.indexOf('const loadedShare = await __mfLoadPinnedRuntimeShare(')
+    );
+
+    const detectorStart = code.indexOf('function isWebpackProvider(provider) {');
+    const detectorEnd = code.indexOf('const __mfGetSharePackageName', detectorStart);
+    const isWebpackProvider = new Function(
+      `${code.slice(detectorStart, detectorEnd)}; return isWebpackProvider;`
+    )() as (provider: unknown) => boolean;
+    const webpackGet = new Function(
+      'return function webpackGet() { return __webpack_require__("react"); };'
+    )();
+
+    expect(isWebpackProvider({ get: webpackGet })).toBe(true);
+    expect(isWebpackProvider({ get: () => Promise.resolve(() => ({})) })).toBe(false);
+    expect(isWebpackProvider({})).toBe(false);
   });
 
   it('restores a plain host provider from the pre-init snapshot after remote registration', async () => {

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2403,7 +2403,9 @@ describe('virtualRemoteEntry', () => {
     expect(initializeSharingCall).toBeGreaterThan(-1);
     expect(lateBridgeCall).toBeGreaterThan(initializeSharingCall);
     expect(code).toContain('let __mfLateBridgeShared');
-    expect(code).toContain('__mfLateBridgeShared = async () =>');
+    expect(code).toContain('const __mfBridgeSharedProviders = async () =>');
+    expect(code).toContain('if (__mfUsesWebpackShareScope) {');
+    expect(code).toContain('__mfLateBridgeShared = __mfBridgeSharedProviders');
     expect(code).toContain('if (__mfLateBridgeShared) await __mfLateBridgeShared()');
   });
 
@@ -2857,7 +2859,7 @@ describe('virtualRemoteEntry', () => {
     );
 
     const detectorStart = code.indexOf('function isWebpackProvider(provider) {');
-    const detectorEnd = code.indexOf('const __mfGetSharePackageName', detectorStart);
+    const detectorEnd = code.indexOf('const __mfUsesWebpackShareScope', detectorStart);
     const isWebpackProvider = new Function(
       `${code.slice(detectorStart, detectorEnd)}; return isWebpackProvider;`
     )() as (provider: unknown) => boolean;
@@ -2868,6 +2870,12 @@ describe('virtualRemoteEntry', () => {
     expect(isWebpackProvider({ get: webpackGet })).toBe(true);
     expect(isWebpackProvider({ get: () => Promise.resolve(() => ({})) })).toBe(false);
     expect(isWebpackProvider({})).toBe(false);
+    expect(code).toContain('const isWebpackScope = !scopeRoot &&');
+    expect(code).toContain(
+      'const runtimeScope = isWebpackScope ? __mfCloneShareScope(hostScope) : hostScope;'
+    );
+    expect(code).toContain('if (webpackScopes.length === 0) return;');
+    expect(code).toContain('for (const { host, runtime } of webpackScopes)');
   });
 
   it('restores a plain host provider from the pre-init snapshot after remote registration', async () => {

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2830,8 +2830,7 @@ describe('virtualRemoteEntry', () => {
       code.indexOf('const __mfBridgeMaterializedProvider ='),
       code.indexOf('const __mfBridgeExternalSharedProvider =')
     );
-    const webpackProviderGuard =
-      'if (!directFactory && !scopeRoot && isWebpackProvider(provider)) return;';
+    const webpackProviderGuard = 'if (!directFactory && isWebpackProvider(provider)) return;';
     const lazyProviderAwait =
       'if (!directFactory && provider.loading) directFactory = await provider.loading;';
 
@@ -2849,6 +2848,9 @@ describe('virtualRemoteEntry', () => {
     expect(externalBridgeCode).toContain(externalProviderGuard);
     expect(code).toContain(
       "const pendingExternalProvider = typeof __mfGetPendingExternalSharedProvider === 'function'"
+    );
+    expect(code).toContain(
+      'if (__mfGetPendingExternalSharedProvider(pkg, share, initialShared[pkg])) return;'
     );
     expect(externalBridgeCode.indexOf(externalProviderGuard)).toBeLessThan(
       externalBridgeCode.indexOf('const loadedShare = await __mfLoadPinnedRuntimeShare(')

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1252,7 +1252,7 @@ export function generateRemoteEntry(
       const parts = pkg.split('/');
       return pkg.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
     };
-    const __mfGetPendingExternalSharedProvider = (pkg, share) => {
+    const __mfGetPendingExternalSharedProvider = (pkg, share, versionMap) => {
       if (typeof __mfSelectExternalSharedProvider !== 'function') return undefined;
       const packageName = __mfGetSharePackageName(pkg);
       const candidates = packageName === pkg
@@ -1260,9 +1260,11 @@ export function generateRemoteEntry(
         : [[pkg, share], [packageName, usedShared[packageName]]];
       for (const [candidatePkg, candidateShare] of candidates) {
         if (!candidateShare) continue;
-        const versionMap = ${hasMultipleShareScopes ? 'getShareVersions(candidatePkg, candidateShare)' : 'shared[candidatePkg]'};
+        const candidateVersionMap = versionMap
+          ? (candidatePkg === pkg ? versionMap : initialShared[candidatePkg])
+          : ${hasMultipleShareScopes ? 'getShareVersions(candidatePkg, candidateShare)' : 'shared[candidatePkg]'};
         const provider = __mfSelectExternalSharedProvider(
-          versionMap,
+          candidateVersionMap,
           candidatePkg,
           candidateShare,
           '${options.shareStrategy}'
@@ -1609,7 +1611,7 @@ export function generateRemoteEntry(
           // this container's outer initScope. Materialized providers are already active,
           // so resolve them directly and keep remote initialization on the guarded path.
           let directFactory = provider.lib;
-          if (!directFactory && !scopeRoot && isWebpackProvider(provider)) return;
+          if (!directFactory && isWebpackProvider(provider)) return;
           if (!directFactory && provider.loading) directFactory = await provider.loading;
           if (!directFactory && provider.loaded && typeof provider.get === 'function') {
             directFactory = await provider.get();
@@ -1856,6 +1858,7 @@ export function generateRemoteEntry(
         ? __mfReadTreeShakingSharedSelection(__mfModuleCache.share, cacheDescriptor, mfName)
         : __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor);
       if (share.shareConfig?.import !== false || cachedShare !== undefined) return;
+      if (__mfGetPendingExternalSharedProvider(pkg, share, initialShared[pkg])) return;
       ${normalizeRuntimeShareCode}
       const versionMap = ${hasMultipleShareScopes ? 'getShareVersions(pkg, share)' : 'shared?.[pkg]'};
       const provider = __mfSelectSharedProvider(

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -723,6 +723,12 @@ function generateRuntimeSharedCacheSeedCode(
           );
           return;
         }
+        const pendingExternalProvider = typeof __mfGetPendingExternalSharedProvider === 'function'
+          ? __mfGetPendingExternalSharedProvider(pkg, share)
+          : undefined;
+        if (pendingExternalProvider && !pendingExternalProvider.lib && !pendingExternalProvider.loaded) {
+          return;
+        }
         const providerKey = cacheDescriptor.canonical;
         const resolved = await __mfInitializeProviderOnce(providerKey, async () => {
           const factory = await share.get();
@@ -1112,6 +1118,7 @@ export function generateRemoteEntry(
   const __mfMaterializedShareBatches = ${materializedShareBatches}
   let localSharedImportMapPromise
   let exposesMapPromise
+  let __mfLateBridgeShared
   const shouldRetrySharedInitError = ${command !== 'build'} && ((error) => {
     const message = String((error && error.message) || error || '');
     return message.includes('Importing a module script failed') ||
@@ -1190,6 +1197,30 @@ export function generateRemoteEntry(
           : `instance?.shareScopeMap?.['${options.shareScope}'] === shared`
       }
     );
+    const __mfRuntimeShareScopes = Object.create(null);
+    const __mfCloneShareScope = (hostScope) => {
+      const runtimeScope = Object.create(null);
+      for (const [pkg, versions] of Object.entries(hostScope || {})) {
+        runtimeScope[pkg] = Object.assign(Object.create(null), versions);
+      }
+      return runtimeScope;
+    };
+    const __mfGetRuntimeShareScope = (scopeName, hostScope) => {
+      const runtimeScope = scopeRoot ? hostScope : __mfCloneShareScope(hostScope);
+      __mfRuntimeShareScopes[scopeName] = { host: hostScope, runtime: runtimeScope };
+      return runtimeScope;
+    };
+    const __mfRestoreForeignSharedProviders = () => {
+      if (scopeRoot) return;
+      for (const { host, runtime } of Object.values(__mfRuntimeShareScopes)) {
+        for (const [pkg, versions] of Object.entries(host || {})) {
+          const runtimeVersions = runtime[pkg] ||= Object.create(null);
+          for (const [version, provider] of Object.entries(versions || {})) {
+            runtimeVersions[version] = provider;
+          }
+        }
+      }
+    };
     const initialShared = Object.create(null);
     ${
       hasMultipleShareScopes
@@ -1212,6 +1243,36 @@ export function generateRemoteEntry(
     }`
     }
     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
+    function isWebpackProvider(provider) {
+      if (typeof provider?.get !== 'function') return false;
+      const source = Function.prototype.toString.call(provider.get);
+      return source.includes('__webpack_require__');
+    }
+    const __mfGetSharePackageName = (pkg) => {
+      const parts = pkg.split('/');
+      return pkg.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+    };
+    const __mfGetPendingExternalSharedProvider = (pkg, share) => {
+      if (typeof __mfSelectExternalSharedProvider !== 'function') return undefined;
+      const packageName = __mfGetSharePackageName(pkg);
+      const candidates = packageName === pkg
+        ? [[pkg, share]]
+        : [[pkg, share], [packageName, usedShared[packageName]]];
+      for (const [candidatePkg, candidateShare] of candidates) {
+        if (!candidateShare) continue;
+        const versionMap = ${hasMultipleShareScopes ? 'getShareVersions(candidatePkg, candidateShare)' : 'shared[candidatePkg]'};
+        const provider = __mfSelectExternalSharedProvider(
+          versionMap,
+          candidatePkg,
+          candidateShare,
+          '${options.shareStrategy}'
+        );
+        if (provider && isWebpackProvider(provider) && !provider.lib && !provider.loaded) {
+          return provider;
+        }
+      }
+      return undefined;
+    };
     // handling circular init calls before an external provider can re-enter this container
     ${
       hasMultipleShareScopes
@@ -1260,9 +1321,15 @@ export function generateRemoteEntry(
       hasMultipleShareScopes
         ? `for (const shareScopeName of shareScopeNamesToInitialize) {
       const scopeShare = getShareScope(shareScopeName);
-      initRes.initShareScopeMap(shareScopeName, scopeShare);
+      initRes.initShareScopeMap(
+        shareScopeName,
+        __mfGetRuntimeShareScope(shareScopeName, scopeShare)
+      );
     }`
-        : `initRes.initShareScopeMap('${options.shareScope}', shared);`
+        : `initRes.initShareScopeMap(
+      '${options.shareScope}',
+      __mfGetRuntimeShareScope('${options.shareScope}', shared)
+    );`
     }
     function __mfSharePinLifecyclePlugin() {
       return {
@@ -1542,6 +1609,7 @@ export function generateRemoteEntry(
           // this container's outer initScope. Materialized providers are already active,
           // so resolve them directly and keep remote initialization on the guarded path.
           let directFactory = provider.lib;
+          if (!directFactory && !scopeRoot && isWebpackProvider(provider)) return;
           if (!directFactory && provider.loading) directFactory = await provider.loading;
           if (!directFactory && provider.loaded && typeof provider.get === 'function') {
             directFactory = await provider.get();
@@ -1590,6 +1658,7 @@ export function generateRemoteEntry(
       expectedSelection
     ) => {
       try {
+        if (__mfGetPendingExternalSharedProvider(pkg, usedShare)) return;
         const usedCacheDescriptor = __mfGetSharedCacheDescriptor(pkg, usedShare.shareConfig?.singleton, usedShare.version, usedShare.scope);
         const cachedShare = __mfReadSharedCache(__mfModuleCache.share, usedCacheDescriptor);
         const cachedShareOwner = __mfReadSharedCacheOwner(__mfModuleCache.share, usedCacheDescriptor);
@@ -1640,6 +1709,12 @@ export function generateRemoteEntry(
           providerEntry.registered &&
           !scopeRootProvider &&
           !__mfMatchesSharedProvider(liveProvider, provider)
+        ) return;
+        if (
+          !selectedLocalProvider &&
+          isWebpackProvider(provider) &&
+          !provider.lib &&
+          !provider.loaded
         ) return;
         const loadedShare = await __mfLoadPinnedRuntimeShare(
           pkg,
@@ -1710,19 +1785,23 @@ export function generateRemoteEntry(
     }
     ${generateRuntimeSharedCacheSeedCode(options.shareStrategy, options)}
     ${initializeSharingCode}
+    __mfRestoreForeignSharedProviders();
     // Calling provider.get() marks a provider as loaded. Wait until the Runtime has
     // finalized normal same-version precedence before materializing an external share.
-    for (const batch of __mfMaterializedShareBatches) await Promise.all(batch.map(async (pkg) => {
-      const usedShare = usedShared[pkg];
-      if (!usedShare || usedShare.materialize === false || usedShare.treeShaking) return;
-      await __mfBridgeExternalSharedProvider(
-        pkg,
-        usedShare,
-        ${hasMultipleShareScopes ? 'getShareVersions(pkg, usedShare)' : 'shared[pkg]'},
-        initialShared[pkg],
-        undefined
-      );
-    }));
+    __mfLateBridgeShared = async () => {
+      for (const batch of __mfMaterializedShareBatches) await Promise.all(batch.map(async (pkg) => {
+        const usedShare = usedShared[pkg];
+        if (!usedShare || usedShare.materialize === false || usedShare.treeShaking) return;
+        await __mfBridgeExternalSharedProvider(
+          pkg,
+          usedShare,
+          ${hasMultipleShareScopes ? 'getShareVersions(pkg, usedShare)' : 'shared[pkg]'},
+          initialShared[pkg],
+          undefined
+        );
+      }));
+    };
+    await __mfLateBridgeShared();
     try {
       const allInstances = globalThis.__FEDERATION__?.__SHARE__;
       const globalVersionsByPackage = Object.create(null);
@@ -1870,6 +1949,7 @@ export function generateRemoteEntry(
   async function getExposes(moduleName) {
     const exposesMap = await getExposesMap()
     if (!(moduleName in exposesMap)) throw new Error(\`[Module Federation] Module \${moduleName} does not exist in container.\`)
+    if (__mfLateBridgeShared) await __mfLateBridgeShared()
     if (__mfModuleCache.pendingShareLoads) {
       await Promise.all(__mfModuleCache.pendingShareLoads)
     }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1206,13 +1206,23 @@ export function generateRemoteEntry(
       return runtimeScope;
     };
     const __mfGetRuntimeShareScope = (scopeName, hostScope) => {
-      const runtimeScope = scopeRoot ? hostScope : __mfCloneShareScope(hostScope);
-      __mfRuntimeShareScopes[scopeName] = { host: hostScope, runtime: runtimeScope };
+      const isWebpackScope = !scopeRoot && Object.values(hostScope || {}).some((versions) =>
+        Object.values(versions || {}).some(isWebpackProvider)
+      );
+      const runtimeScope = isWebpackScope ? __mfCloneShareScope(hostScope) : hostScope;
+      __mfRuntimeShareScopes[scopeName] = {
+        host: hostScope,
+        runtime: runtimeScope,
+        isWebpackScope
+      };
       return runtimeScope;
     };
     const __mfRestoreForeignSharedProviders = () => {
-      if (scopeRoot) return;
-      for (const { host, runtime } of Object.values(__mfRuntimeShareScopes)) {
+      const webpackScopes = Object.values(__mfRuntimeShareScopes).filter(
+        ({ isWebpackScope }) => isWebpackScope
+      );
+      if (webpackScopes.length === 0) return;
+      for (const { host, runtime } of webpackScopes) {
         for (const [pkg, versions] of Object.entries(host || {})) {
           const runtimeVersions = runtime[pkg] ||= Object.create(null);
           for (const [version, provider] of Object.entries(versions || {})) {
@@ -1248,6 +1258,9 @@ export function generateRemoteEntry(
       const source = Function.prototype.toString.call(provider.get);
       return source.includes('__webpack_require__');
     }
+    const __mfUsesWebpackShareScope = Object.values(initialShared).some((versions) =>
+      Object.values(versions || {}).some(isWebpackProvider)
+    );
     const __mfGetSharePackageName = (pkg) => {
       const parts = pkg.split('/');
       return pkg.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
@@ -1790,7 +1803,7 @@ export function generateRemoteEntry(
     __mfRestoreForeignSharedProviders();
     // Calling provider.get() marks a provider as loaded. Wait until the Runtime has
     // finalized normal same-version precedence before materializing an external share.
-    __mfLateBridgeShared = async () => {
+    const __mfBridgeSharedProviders = async () => {
       for (const batch of __mfMaterializedShareBatches) await Promise.all(batch.map(async (pkg) => {
         const usedShare = usedShared[pkg];
         if (!usedShare || usedShare.materialize === false || usedShare.treeShaking) return;
@@ -1803,7 +1816,10 @@ export function generateRemoteEntry(
         );
       }));
     };
-    await __mfLateBridgeShared();
+    await __mfBridgeSharedProviders();
+    if (__mfUsesWebpackShareScope) {
+      __mfLateBridgeShared = __mfBridgeSharedProviders;
+    }
     try {
       const allInstances = globalThis.__FEDERATION__?.__SHARE__;
       const globalVersionsByPackage = Object.create(null);


### PR DESCRIPTION
## Summary

- Fix remote initialization deadlock with plain Webpack hosts.
- Defer only unresolved Webpack-compatible shared providers.
- Preserve normal materialization behavior for non-Webpack providers.
- Bridge the host shared modules after runtime initialization and before expose evaluation.
- Clarify that shared package subpaths require trailing-slash prefix matching, such as `react-dom/`.
  See the [Module Federation shared dependency documentation](https://module-federation.io/configure/shared#prefix-matching-with-trailing-slash).

Closes #1064

## Root Cause

A plain Webpack host can register a shared provider whose `get()` function waits for Webpack's own consume initialization. Calling that provider during the remote's `init()` creates a circular wait.

The workaround is now limited to providers whose getter contains `__webpack_require__`, instead of treating every unresolved foreign provider the same way.

## Validation

- `pnpm test`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm build`
- `pnpm fmt.check`
- Webpack host reproduction:
  - Remote build succeeded
  - Webpack host build succeeded
  - Remote widget rendered
  - Clicking the widget changed `0` to `1`