### PR TITLE
chore(build): migrate deprecated tsdown option

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   deps: {
-    onlyAllowBundle: false,
+    onlyBundle: false,
   },
 });


### PR DESCRIPTION
## Summary

Replace the deprecated `deps.onlyAllowBundle` option with the recommended `deps.onlyBundle` option in the tsdown configuration.

## Background

Running `pnpm build` produced the following deprecation warning:

```text
deps.onlyAllowBundle is deprecated. Use deps.onlyBundle instead.
```

The official tsdown documentation lists `deps.onlyBundle` as the replacement for `deps.onlyAllowBundle`.

## Changes

```diff
- onlyAllowBundle: false
+ onlyBundle: false
```

The `false` value preserves the existing behavior of suppressing dependency bundling warnings and checks.

Reference: [tsdown documentation](https://tsdown.dev/options/dependencies#migration-from-deprecated-options)

## Validation

- `pnpm build` passes.
- The `deps.onlyAllowBundle` deprecation warning is no longer emitted.