### PR TITLE
fix(build): preserve pluginDts lazy loading

### DIFF
--- a/src/plugins/pluginDts.ts
+++ b/src/plugins/pluginDts.ts
@@ -13,6 +13,7 @@ import { rpc, type DTSManagerOptions } from '@module-federation/dts-plugin/core'
 import * as path from 'node:path';
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
 import { normalizePathForImport } from '../utils/buildPaths';
+import { DEFAULT_PUBLIC_TYPES_FOLDER } from '../utils/dtsConstants';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency, resolveImportPath } from '../utils/packageUtils';
 import { createModuleFederationError, mfError } from '../utils/logger';
@@ -34,7 +35,6 @@ const DYNAMIC_HINTS_PLUGIN = '@module-federation/dts-plugin/dynamic-remote-type-
 const getIPv4 = () => process.env['FEDERATION_IPV4'] || '127.0.0.1';
 
 const DEV_TYPES_FOLDER = '.dev-server';
-export const DEFAULT_PUBLIC_TYPES_FOLDER = '@mf-types';
 
 type DevWorkerOptions = DTSManagerOptions & {
   name: string;

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -26,8 +26,8 @@ import {
 } from '../utils/cssModuleHelpers';
 import { resolvePublicPath } from '../utils/pathNormalization';
 import { normalizePathForImport } from '../utils/buildPaths';
+import { DEFAULT_PUBLIC_TYPES_FOLDER } from '../utils/dtsConstants';
 import { getSsrRemoteEntryFileName } from '../virtualModules/virtualRemoteEntrySSR';
-import { DEFAULT_PUBLIC_TYPES_FOLDER } from './pluginDts';
 
 /**
  * Resolves the build version for the module federation manifest.

--- a/src/utils/dtsConstants.ts
+++ b/src/utils/dtsConstants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PUBLIC_TYPES_FOLDER = '@mf-types';


### PR DESCRIPTION
## Summary

Make the existing `pluginDts` dynamic import effective by removing an unintended static dependency from `pluginMFManifest`.

## Background

`src/index.ts` dynamically imports `pluginDts` so the DTS implementation can be code-split and loaded only when needed. However, `pluginMFManifest.ts` statically imported the `DEFAULT_PUBLIC_TYPES_FOLDER` constant from `pluginDts.ts`.

That static import pulled the entire `pluginDts` module into the main bundle, so Rolldown emitted:

```text
[INEFFECTIVE_DYNAMIC_IMPORT] src/plugins/pluginDts.ts is dynamically imported by src/index.ts but also statically imported by src/plugins/pluginMFManifest.ts, dynamic import will not move module into another chunk.
```

This was not a functional failure, but it defeated the intended lazy-loading boundary and eagerly included DTS-related code in the main bundle.

## Changes

- Move `DEFAULT_PUBLIC_TYPES_FOLDER` to `src/utils/dtsConstants.ts`.
- Import the constant directly from the new module in both `pluginDts.ts` and `pluginMFManifest.ts`.
- Preserve the existing `@mf-types` default and manifest behavior.

## AS-IS / TO-BE

| Item | AS-IS | TO-BE |
| --- | --- | --- |
| `INEFFECTIVE_DYNAMIC_IMPORT` warning | Emitted | Removed |
| `pluginDts` output | Included in `lib/index.js` | Emitted as `lib/pluginDts-BNCg4Gri.js` |
| Main bundle | 462.99 kB | 431.58 kB |
| Main bundle gzip | 108.43 kB | 101.43 kB |

The total output size increases slightly because the bundler now emits shared and dynamic chunks. The main entry is smaller, and the `pluginDts` chunk is not loaded when DTS is disabled.

## Validation

- `pnpm build` passes.
- The `INEFFECTIVE_DYNAMIC_IMPORT` warning is no longer emitted.
- `pnpm test` passes: 49 test files, 1051 passed, 1 skipped.
- DTS and manifest tests pass: 36 tests.
- `pnpm typecheck` passes.


## Compatibility

No package export or runtime behavior changes are intended. This change only restores the code-splitting boundary that was already intended by the existing dynamic import.