### PR TITLE
fix: emit SSR entry for client-only remotes again

### DIFF
--- a/e2e/vite-ssr/ssr.spec.ts
+++ b/e2e/vite-ssr/ssr.spec.ts
@@ -3,14 +3,20 @@ import { expect, test } from '@playwright/test';
 // Guards the SSR-consumption architecture: a client-only remote publishes
 // remoteEntry.ssr.js with its client assets, and an SSR host's Node server
 // fetches it over HTTP to render federated components before hydration.
-// Regressed in #1024 (no SSR entry emitted → hosts crashed with
-// ERR_UNSUPPORTED_ESM_URL_SCHEME and served no federated content).
+// Regression (#1024): no SSR entry emitted → hosts crashed with
+// ERR_UNSUPPORTED_ESM_URL_SCHEME and served no federated content.
 
 test('client-only remote publishes its SSR entry as JavaScript', async ({ request }) => {
   const response = await request.get('http://localhost:5177/remoteEntry.ssr.js');
   expect(response.status()).toBe(200);
   // Guard against an SPA index.html fallback masquerading as a 200.
   expect(response.headers()['content-type']).toContain('javascript');
+  const body = await response.text();
+  expect(body.trimStart()).not.toMatch(/^</);
+  // The container contract: named `init` and `get` exports. Local identifiers
+  // are minified, but the exported names survive (`export{s as get,o as init}`).
+  expect(body).toMatch(/export\s*\{[^}]*\binit\b/);
+  expect(body).toMatch(/export\s*\{[^}]*\bget\b/);
 });
 
 test('host serves the federated widget as server-rendered HTML', async ({ request }) => {
@@ -22,11 +28,27 @@ test('host serves the federated widget as server-rendered HTML', async ({ reques
 });
 
 test('server-rendered widget hydrates and responds to input', async ({ page }) => {
+  // React logs hydration mismatches to the console (or throws) instead of
+  // failing the render — collect them so a "successful" click on a
+  // client-re-rendered tree can't mask a broken SSR payload.
+  const hydrationErrors: string[] = [];
+  page.on('console', (message) => {
+    if (/hydrat/i.test(message.text()) || /did not match/i.test(message.text())) {
+      hydrationErrors.push(message.text());
+    }
+  });
+  page.on('pageerror', (error) => {
+    if (/hydrat/i.test(error.message) || /did not match/i.test(error.message)) {
+      hydrationErrors.push(error.message);
+    }
+  });
   await page.goto('/');
   const button = page.getByRole('button', { name: /Remote count: 0/ });
   await expect(button).toBeVisible();
   // The server-rendered button is inert until hydration attaches handlers.
   await page.locator('body[data-hydrated="true"]').waitFor();
+  expect(hydrationErrors).toEqual([]);
   await button.click();
   await expect(page.getByRole('button', { name: /Remote count: 1/ })).toBeVisible();
+  expect(hydrationErrors).toEqual([]);
 });

--- a/e2e/vite-ssr/ssr.spec.ts
+++ b/e2e/vite-ssr/ssr.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+// Guards the SSR-consumption architecture: a client-only remote publishes
+// remoteEntry.ssr.js with its client assets, and an SSR host's Node server
+// fetches it over HTTP to render federated components before hydration.
+// Regressed in #1024 (no SSR entry emitted → hosts crashed with
+// ERR_UNSUPPORTED_ESM_URL_SCHEME and served no federated content).
+
+test('client-only remote publishes its SSR entry as JavaScript', async ({ request }) => {
+  const response = await request.get('http://localhost:5177/remoteEntry.ssr.js');
+  expect(response.status()).toBe(200);
+  // Guard against an SPA index.html fallback masquerading as a 200.
+  expect(response.headers()['content-type']).toContain('javascript');
+});
+
+test('host serves the federated widget as server-rendered HTML', async ({ request }) => {
+  const response = await request.get('/');
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+  expect(html).toContain('SSR remote widget');
+  expect(html).toContain('Remote count:');
+});
+
+test('server-rendered widget hydrates and responds to input', async ({ page }) => {
+  await page.goto('/');
+  const button = page.getByRole('button', { name: /Remote count: 0/ });
+  await expect(button).toBeVisible();
+  // The server-rendered button is inert until hydration attaches handlers.
+  await page.locator('body[data-hydrated="true"]').waitFor();
+  await button.click();
+  await expect(page.getByRole('button', { name: /Remote count: 1/ })).toBeVisible();
+});

--- a/examples/vite-ssr/vite-host/index.html
+++ b/examples/vite-ssr/vite-host/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SSR example host</title>
+  </head>
+  <body>
+    <div id="root"><!--ssr-outlet--></div>
+    <script type="module" src="/src/entry-client.jsx"></script>
+  </body>
+</html>

--- a/examples/vite-ssr/vite-host/package.json
+++ b/examples/vite-ssr/vite-host/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "examples-vite-ssr-host",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build --outDir dist/client && vite build --ssr src/entry-server.jsx --outDir dist/server",
+    "preview": "npm run build && node server.mjs"
+  },
+  "dependencies": {
+    "@module-federation/vite": "workspace:*",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "vite": "8.2.0"
+  }
+}

--- a/examples/vite-ssr/vite-host/server.mjs
+++ b/examples/vite-ssr/vite-host/server.mjs
@@ -30,6 +30,16 @@ const CONTENT_TYPES = {
 const server = http.createServer(async (req, res) => {
   const urlPath = (req.url ?? '/').split('?')[0];
 
+  // Playwright's webServer readiness probe. Deliberately independent of the
+  // remote: if the readiness URL required a successful render, a missing
+  // remote SSR entry would surface as a 120s webServer timeout instead of
+  // the spec's own assertion failures.
+  if (urlPath === '/healthz') {
+    res.setHeader('Content-Type', 'text/plain');
+    res.end('ok');
+    return;
+  }
+
   if (urlPath !== '/') {
     const filePath = path.resolve(root, 'dist/client', `.${urlPath}`);
     if (filePath.startsWith(path.resolve(root, 'dist/client')) && fs.existsSync(filePath)) {

--- a/examples/vite-ssr/vite-host/server.mjs
+++ b/examples/vite-ssr/vite-host/server.mjs
@@ -9,12 +9,18 @@ const template = fs.readFileSync(path.resolve(root, 'dist/client/index.html'), '
 // The federation plugin adds its own entries to the SSR build, so the app
 // entry is emitted under assets/ with a content hash.
 const serverAssetsDir = path.resolve(root, 'dist/server/assets');
-const entryFileName = fs
+const entryFileNames = fs
   .readdirSync(serverAssetsDir)
-  .find((file) => file.startsWith('entry-server-') && file.endsWith('.js'));
-if (!entryFileName) {
-  throw new Error(`No entry-server-*.js found in ${serverAssetsDir}`);
+  .filter((file) => file.startsWith('entry-server-') && file.endsWith('.js'));
+if (entryFileNames.length !== 1) {
+  // More than one match means a stale or interrupted build left old hashed
+  // copies behind; loading an arbitrary one would render outdated code.
+  throw new Error(
+    `Expected exactly one entry-server-*.js in ${serverAssetsDir}, ` +
+      `found ${entryFileNames.length}: [${entryFileNames.join(', ')}]`
+  );
 }
+const [entryFileName] = entryFileNames;
 const { render } = await import(
   new URL(`./dist/server/assets/${entryFileName}`, import.meta.url).href
 );
@@ -26,6 +32,14 @@ const CONTENT_TYPES = {
   '.json': 'application/json',
   '.svg': 'image/svg+xml',
 };
+
+function isFile(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
 
 const server = http.createServer(async (req, res) => {
   const urlPath = (req.url ?? '/').split('?')[0];
@@ -41,16 +55,31 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (urlPath !== '/') {
-    const filePath = path.resolve(root, 'dist/client', `.${urlPath}`);
-    if (filePath.startsWith(path.resolve(root, 'dist/client')) && fs.existsSync(filePath)) {
+    const clientDir = path.resolve(root, 'dist/client');
+    const filePath = path.resolve(clientDir, `.${urlPath}`);
+    // Compare with a trailing separator so `../` can't escape to sibling
+    // directories that merely share the prefix (e.g. dist/client-extra).
+    if (filePath.startsWith(clientDir + path.sep) && isFile(filePath)) {
       res.setHeader(
         'Content-Type',
         CONTENT_TYPES[path.extname(filePath)] ?? 'application/octet-stream'
       );
-      fs.createReadStream(filePath).pipe(res);
+      const stream = fs.createReadStream(filePath);
+      // A read failure (file replaced mid-stream, EISDIR, ...) must end the
+      // response, not crash the process.
+      stream.on('error', (error) => {
+        console.error('[ssr-host] static read failed:', error);
+        if (!res.headersSent) {
+          res.statusCode = 500;
+          res.setHeader('Content-Type', 'text/plain');
+        }
+        res.end('Internal server error');
+      });
+      stream.pipe(res);
       return;
     }
     res.statusCode = 404;
+    res.setHeader('Content-Type', 'text/plain');
     res.end('Not found');
     return;
   }
@@ -58,12 +87,15 @@ const server = http.createServer(async (req, res) => {
   try {
     const appHtml = await render();
     res.setHeader('Content-Type', 'text/html');
-    res.end(template.replace('<!--ssr-outlet-->', appHtml));
+    // Function replacement so `$`-sequences in the rendered HTML are not
+    // interpreted as replacement patterns.
+    res.end(template.replace('<!--ssr-outlet-->', () => appHtml));
   } catch (error) {
     // Keep the process alive: Playwright's webServer readiness check polls
     // this URL and the remote may still be booting on the first requests.
     console.error('[ssr-host] render failed:', error);
     res.statusCode = 500;
+    res.setHeader('Content-Type', 'text/plain');
     res.end('SSR render failed');
   }
 });

--- a/examples/vite-ssr/vite-host/server.mjs
+++ b/examples/vite-ssr/vite-host/server.mjs
@@ -1,0 +1,63 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const template = fs.readFileSync(path.resolve(root, 'dist/client/index.html'), 'utf-8');
+
+// The federation plugin adds its own entries to the SSR build, so the app
+// entry is emitted under assets/ with a content hash.
+const serverAssetsDir = path.resolve(root, 'dist/server/assets');
+const entryFileName = fs
+  .readdirSync(serverAssetsDir)
+  .find((file) => file.startsWith('entry-server-') && file.endsWith('.js'));
+if (!entryFileName) {
+  throw new Error(`No entry-server-*.js found in ${serverAssetsDir}`);
+}
+const { render } = await import(
+  new URL(`./dist/server/assets/${entryFileName}`, import.meta.url).href
+);
+
+const CONTENT_TYPES = {
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+};
+
+const server = http.createServer(async (req, res) => {
+  const urlPath = (req.url ?? '/').split('?')[0];
+
+  if (urlPath !== '/') {
+    const filePath = path.resolve(root, 'dist/client', `.${urlPath}`);
+    if (filePath.startsWith(path.resolve(root, 'dist/client')) && fs.existsSync(filePath)) {
+      res.setHeader(
+        'Content-Type',
+        CONTENT_TYPES[path.extname(filePath)] ?? 'application/octet-stream'
+      );
+      fs.createReadStream(filePath).pipe(res);
+      return;
+    }
+    res.statusCode = 404;
+    res.end('Not found');
+    return;
+  }
+
+  try {
+    const appHtml = await render();
+    res.setHeader('Content-Type', 'text/html');
+    res.end(template.replace('<!--ssr-outlet-->', appHtml));
+  } catch (error) {
+    // Keep the process alive: Playwright's webServer readiness check polls
+    // this URL and the remote may still be booting on the first requests.
+    console.error('[ssr-host] render failed:', error);
+    res.statusCode = 500;
+    res.end('SSR render failed');
+  }
+});
+
+server.listen(5178, () => {
+  console.log('SSR host listening on http://localhost:5178');
+});

--- a/examples/vite-ssr/vite-host/src/App.jsx
+++ b/examples/vite-ssr/vite-host/src/App.jsx
@@ -1,0 +1,8 @@
+export default function App({ RemoteWidget }) {
+  return (
+    <main>
+      <h1>SSR host</h1>
+      <RemoteWidget />
+    </main>
+  );
+}

--- a/examples/vite-ssr/vite-host/src/App.jsx
+++ b/examples/vite-ssr/vite-host/src/App.jsx
@@ -1,4 +1,12 @@
+import { useEffect } from 'react';
+
 export default function App({ RemoteWidget }) {
+  // Signals tests that hydration has committed and event handlers are
+  // attached — the flag reflects commit, not scheduling. Clicks before this
+  // point would land on inert server-rendered markup.
+  useEffect(() => {
+    document.body.dataset.hydrated = 'true';
+  }, []);
   return (
     <main>
       <h1>SSR host</h1>

--- a/examples/vite-ssr/vite-host/src/entry-client.jsx
+++ b/examples/vite-ssr/vite-host/src/entry-client.jsx
@@ -1,0 +1,12 @@
+import { hydrateRoot } from 'react-dom/client';
+import App from './App';
+
+// Await the federated module before hydrating so the client tree matches the
+// server-rendered tree (no Suspense fallback mismatch).
+const { default: RemoteWidget } = await import('ssrRemote/Widget');
+
+hydrateRoot(document.getElementById('root'), <App RemoteWidget={RemoteWidget} />);
+
+// Signals tests that event handlers are attached; clicks before this point
+// would land on inert server-rendered markup.
+document.body.dataset.hydrated = 'true';

--- a/examples/vite-ssr/vite-host/src/entry-client.jsx
+++ b/examples/vite-ssr/vite-host/src/entry-client.jsx
@@ -6,7 +6,3 @@ import App from './App';
 const { default: RemoteWidget } = await import('ssrRemote/Widget');
 
 hydrateRoot(document.getElementById('root'), <App RemoteWidget={RemoteWidget} />);
-
-// Signals tests that event handlers are attached; clicks before this point
-// would land on inert server-rendered markup.
-document.body.dataset.hydrated = 'true';

--- a/examples/vite-ssr/vite-host/src/entry-server.jsx
+++ b/examples/vite-ssr/vite-host/src/entry-server.jsx
@@ -1,0 +1,9 @@
+import { renderToString } from 'react-dom/server';
+import App from './App';
+
+export async function render() {
+  // Resolved through Module Federation: the plugin's SSR entry loader fetches
+  // the remote's remoteEntry.ssr.js over HTTP and evaluates it in Node.
+  const { default: RemoteWidget } = await import('ssrRemote/Widget');
+  return renderToString(<App RemoteWidget={RemoteWidget} />);
+}

--- a/examples/vite-ssr/vite-host/vite.config.js
+++ b/examples/vite-ssr/vite-host/vite.config.js
@@ -1,0 +1,28 @@
+import { federation } from '@module-federation/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// A classic dual-build SSR host (`vite build` + `vite build --ssr`): its Node
+// server renders the federated widget before hydration, which requires the
+// remote to publish remoteEntry.ssr.js with its client assets.
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'ssrHost',
+      remotes: {
+        ssrRemote: {
+          type: 'module',
+          name: 'ssrRemote',
+          entry: 'http://localhost:5177/remoteEntry.js',
+        },
+      },
+      dts: false,
+      shared: {
+        react: { singleton: true, requiredVersion: '^19.2.4' },
+        'react-dom': { singleton: true, requiredVersion: '^19.2.4' },
+      },
+    }),
+  ],
+  build: { target: 'chrome89' },
+});

--- a/examples/vite-ssr/vite-remote/index.html
+++ b/examples/vite-ssr/vite-remote/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SSR example remote</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/examples/vite-ssr/vite-remote/package.json
+++ b/examples/vite-ssr/vite-remote/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite build && vite preview --port 5177 --strictPort"
+    "preview": "vite build && vite preview"
   },
   "dependencies": {
     "@module-federation/vite": "workspace:*",

--- a/examples/vite-ssr/vite-remote/package.json
+++ b/examples/vite-ssr/vite-remote/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "examples-vite-ssr-remote",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite build && vite preview --port 5177 --strictPort"
+  },
+  "dependencies": {
+    "@module-federation/vite": "workspace:*",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "vite": "8.2.0"
+  }
+}

--- a/examples/vite-ssr/vite-remote/src/Widget.jsx
+++ b/examples/vite-ssr/vite-remote/src/Widget.jsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export default function Widget() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <section>
+      <h2>SSR remote widget</h2>
+      <button type="button" onClick={() => setCount((current) => current + 1)}>
+        Remote count: {count}
+      </button>
+    </section>
+  );
+}

--- a/examples/vite-ssr/vite-remote/src/main.jsx
+++ b/examples/vite-ssr/vite-remote/src/main.jsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client';
+import Widget from './Widget';
+
+createRoot(document.getElementById('root')).render(<Widget />);

--- a/examples/vite-ssr/vite-remote/vite.config.js
+++ b/examples/vite-ssr/vite-remote/vite.config.js
@@ -1,0 +1,27 @@
+import { federation } from '@module-federation/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// A client-only remote: it has exposes but no ssr Vite environment of its
+// own. Its remoteEntry.ssr.js is consumed by the SSR host's Node server over
+// HTTP, so it must be emitted alongside the client assets.
+export default defineConfig({
+  server: { open: false, port: 5177 },
+  preview: { port: 5177, strictPort: true },
+  plugins: [
+    react(),
+    federation({
+      name: 'ssrRemote',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './Widget': './src/Widget.jsx',
+      },
+      dts: false,
+      shared: {
+        react: { singleton: true, requiredVersion: '^19.2.4' },
+        'react-dom': { singleton: true, requiredVersion: '^19.2.4' },
+      },
+    }),
+  ],
+  build: { target: 'chrome89' },
+});

--- a/examples/vite-ssr/vite-remote/vite.config.js
+++ b/examples/vite-ssr/vite-remote/vite.config.js
@@ -6,7 +6,9 @@ import { defineConfig } from 'vite';
 // own. Its remoteEntry.ssr.js is consumed by the SSR host's Node server over
 // HTTP, so it must be emitted alongside the client assets.
 export default defineConfig({
-  server: { open: false, port: 5177 },
+  // Dev port differs from preview so a leftover `vite dev` can never be
+  // mistaken for the preview server on 5177 by Playwright's reuseExistingServer.
+  server: { open: false, port: 5179 },
   preview: { port: 5177, strictPort: true },
   plugins: [
     react(),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     },
     {
       command: 'pnpm --filter examples-vite-ssr-host run preview',
-      url: 'http://localhost:5178',
+      url: 'http://localhost:5178/healthz',
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,18 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
+    {
+      command: 'pnpm --filter examples-vite-ssr-remote run preview',
+      url: 'http://localhost:5177',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: 'pnpm --filter examples-vite-ssr-host run preview',
+      url: 'http://localhost:5178',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
   ],
   use: {
     trace: 'retain-on-failure',
@@ -70,6 +82,14 @@ export default defineConfig({
       testDir: 'e2e/vite-runtime-register',
       use: {
         baseURL: 'http://localhost:4175',
+        browserName: 'chromium',
+      },
+    },
+    {
+      name: 'vite-ssr',
+      testDir: 'e2e/vite-ssr',
+      use: {
+        baseURL: 'http://localhost:5178',
         browserName: 'chromium',
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,56 @@ importers:
         specifier: 8.2.0
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)
 
+  examples/vite-ssr/vite-host:
+    dependencies:
+      '@module-federation/vite':
+        specifier: workspace:*
+        version: link:../../..
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@8.0.0)(rolldown@1.2.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3))
+      vite:
+        specifier: 8.2.0
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)
+
+  examples/vite-ssr/vite-remote:
+    dependencies:
+      '@module-federation/vite':
+        specifier: workspace:*
+        version: link:../../..
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@8.0.0)(rolldown@1.2.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3))
+      vite:
+        specifier: 8.2.0
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)
+
   examples/vite-vite/shared-consumer:
     dependencies:
       '@vite-vite/shared-lib':

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -1001,6 +1001,42 @@ describe('pluginSSRRemoteEntry', () => {
       expect(emitFile).not.toHaveBeenCalled();
     });
 
+    it('emits SSR entry during the client build when no ssr environment exists', () => {
+      // A client-only remote (e.g. a vinext/SSR host's federated remote) has no
+      // ssr Vite environment of its own — its SSR entry is consumed by the
+      // host's server over HTTP, so it must ship with the client assets.
+      // Regressed in #1024: client-only remotes stopped emitting
+      // remoteEntry.ssr.js and SSR hosts fell back to importing the browser
+      // entry (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+      getIsRolldownMock.mockReturnValue(true);
+      const emitFile = makeEmitFile();
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        command: 'build',
+        build: {},
+        environments: { client: {} },
+      } as unknown as ResolvedConfig);
+
+      callHook(
+        mainPlugin.buildStart,
+        {
+          meta: makePluginMeta(true),
+          emitFile,
+          environment: { name: 'client' },
+        } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+
+      expect(emitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'chunk',
+          fileName: 'remoteEntry.ssr.js',
+        })
+      );
+    });
+
     it('emits in the ssr environment when environments.ssr is configured', () => {
       getIsRolldownMock.mockReturnValue(true);
       const emitFile = makeEmitFile();
@@ -1282,7 +1318,7 @@ describe('pluginSSRRemoteEntry', () => {
       expect(() =>
         callHook(
           mainPlugin.generateBundle,
-          {} as Rollup.PluginContext,
+          { emitFile } as unknown as Rollup.PluginContext,
           {} as Rollup.NormalizedOutputOptions,
           {} as unknown as Rollup.OutputBundle,
           false

--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -1001,6 +1001,42 @@ describe('pluginSSRRemoteEntry', () => {
       expect(emitFile).not.toHaveBeenCalled();
     });
 
+    it('does not emit the client-only SSR entry for Rollup builds', () => {
+      // Regression (#1024) scope note: the Rollup asset path has never produced
+      // a working client-only SSR entry — its virtual:mf-exposes-ssr import is
+      // only rewritten for Nuxt, so the emitted file fails at first expose load
+      // (verified identical on 1.20.1). Emitting nothing preserves main's
+      // behavior on Vite <=7; the restored client-pass emission is Rolldown-only.
+      getIsRolldownMock.mockReturnValue(false);
+      const emitFile = makeEmitFile();
+      const plugins = pluginSSRRemoteEntry(makeOptions());
+      const mainPlugin = plugins[1];
+      const configResolved = mainPlugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved?.({
+        command: 'build',
+        build: {},
+        environments: { client: {} },
+      } as unknown as ResolvedConfig);
+
+      callHook(
+        mainPlugin.buildStart,
+        {
+          meta: makePluginMeta(false),
+          emitFile,
+        } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedInputOptions
+      );
+      callHook(
+        mainPlugin.generateBundle,
+        { emitFile } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        {} as Rollup.OutputBundle,
+        false
+      );
+
+      expect(emitFile).not.toHaveBeenCalled();
+    });
+
     it('emits SSR entry during the client build when no ssr environment exists', () => {
       // A client-only remote (e.g. a vinext/SSR host's federated remote) has no
       // ssr Vite environment of its own — its SSR entry is consumed by the
@@ -1315,10 +1351,13 @@ describe('pluginSSRRemoteEntry', () => {
         {} as Rollup.NormalizedInputOptions
       );
 
+      // No emitFile in the context on purpose: with client-only emission
+      // scoped to Rolldown, this non-Rolldown no-config call must stay a
+      // no-op — reaching for emitFile here would throw and fail the test.
       expect(() =>
         callHook(
           mainPlugin.generateBundle,
-          { emitFile } as unknown as Rollup.PluginContext,
+          {} as Rollup.PluginContext,
           {} as Rollup.NormalizedOutputOptions,
           {} as unknown as Rollup.OutputBundle,
           false

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -252,17 +252,22 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let reactIslandExposes: ReadonlySet<string> = new Set();
 
   const isSsrRemoteEntryBuild = (environment?: { name?: string; config?: ResolvedConfig }) => {
+    if (Object.keys(options.exposes).length === 0) return false;
     const environmentName = environment?.name;
     const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
     const isLegacySsrBuild = Boolean(environment?.config?.build?.ssr ?? viteConfig?.build?.ssr);
 
-    return (
-      Object.keys(options.exposes).length > 0 &&
-      !(
-        (hasSsrEnvironment && environmentName !== 'ssr') ||
-        (!hasSsrEnvironment && !isLegacySsrBuild)
-      )
-    );
+    // Environment API (client + ssr): emit only in the ssr environment so
+    // exposes are bundled with the Node SSR graph (nested loadRemote stays on
+    // the server); writeBundle copies the entry into the client output dir.
+    if (hasSsrEnvironment) return environmentName === 'ssr';
+    // Legacy `vite build --ssr` pass (e.g. vue-ssr dual build:server).
+    if (isLegacySsrBuild) return true;
+    // Client-only remotes (no ssr environment of their own, e.g. a plain SPA
+    // remote consumed by an SSR host) ship the SSR entry with their client
+    // assets — the consuming host fetches it over HTTP. Regressed in #1024,
+    // which stopped emitting any SSR entry for these apps.
+    return environmentName === undefined || environmentName === 'client';
   };
 
   // The shared plugin instance may serve multiple build environments and Rollup

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -251,23 +251,30 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   let isNuxtProject = false;
   let reactIslandExposes: ReadonlySet<string> = new Set();
 
-  const isSsrRemoteEntryBuild = (environment?: { name?: string; config?: ResolvedConfig }) => {
+  const isSsrRemoteEntryBuild = (
+    environment: { name?: string; config?: ResolvedConfig } | undefined,
+    isRolldown: boolean
+  ) => {
     if (Object.keys(options.exposes).length === 0) return false;
     const environmentName = environment?.name;
     const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
-    const isLegacySsrBuild = Boolean(environment?.config?.build?.ssr ?? viteConfig?.build?.ssr);
 
     // Environment API (client + ssr): emit only in the ssr environment so
     // exposes are bundled with the Node SSR graph (nested loadRemote stays on
     // the server); writeBundle copies the entry into the client output dir.
     if (hasSsrEnvironment) return environmentName === 'ssr';
     // Legacy `vite build --ssr` pass (e.g. vue-ssr dual build:server).
+    const isLegacySsrBuild = Boolean(environment?.config?.build?.ssr ?? viteConfig?.build?.ssr);
     if (isLegacySsrBuild) return true;
     // Client-only remotes (no ssr environment of their own, e.g. a plain SPA
     // remote consumed by an SSR host) ship the SSR entry with their client
-    // assets — the consuming host fetches it over HTTP. Regressed in #1024,
-    // which stopped emitting any SSR entry for these apps.
-    return environmentName === undefined || environmentName === 'client';
+    // assets — the consuming host fetches it over HTTP. Regression (#1024):
+    // emission stopped entirely for these apps. Rolldown only: the Rollup
+    // asset path cannot bundle the SSR exposes graph, so its entry has never
+    // resolved its virtual:mf-exposes-ssr import (verified identical on
+    // 1.20.1) — emitting nothing there keeps Vite <=7 at parity with main
+    // instead of shipping a file that fails at first expose load.
+    return isRolldown && (environmentName === undefined || environmentName === 'client');
   };
 
   // The shared plugin instance may serve multiple build environments and Rollup
@@ -540,7 +547,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         // Environment API (client + ssr): emit only in the ssr environment so exposes
         // are bundled with the Node SSR graph (nested loadRemote stays on the server).
         // Emit only for an SSR environment or legacy `vite build --ssr`.
-        if (!isSsrRemoteEntryBuild(environment)) return;
+        if (!isSsrRemoteEntryBuild(environment, isRolldown)) return;
 
         if (isRolldown) {
           // Vite 8+ (Rolldown): emit as a proper chunk. Rolldown handles multiple
@@ -565,7 +572,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
             }
           ).environment;
           const exposesChunk = findNuxtExposesChunk(bundle);
-          if (!isRolldown && isSsrRemoteEntryBuild(environment)) {
+          if (!isRolldown && isSsrRemoteEntryBuild(environment, isRolldown)) {
             let source = getSsrRemoteEntrySource();
             if (exposesChunk) {
               source = source.replace(


### PR DESCRIPTION
## Problem

Since #1024 (1.20.2), client-only remotes — apps with `exposes` but no `ssr` Vite environment of their own — no longer emit `remoteEntry.ssr.js`. Their SSR entry is consumed by the *host's* server over HTTP, so it must ship with the client assets. Consuming SSR hosts (e.g. vinext) now fall back to importing the browser remote entry with Node's ESM loader and crash:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. Received protocol 'http:'
```

Found while validating #1072 against the `module-federation/vinext` example apps: bisected to 09c08e5 (#1024).

## Why the regression happened

#1024's model — "the SSR entry belongs to SSR builds" — is correct for apps that have their own `environments.ssr`, but for a client-only remote the SSR entry is not an internal build artifact: it's a cross-app deliverable that a *different* app's server fetches over HTTP. The only comment documenting that invariant was attached to the Nuxt carve-out (also removed in #1024), so the general case read as accidental behavior that was safe to clean up, and the tests asserting it were inverted to match the new model rather than treated as a contract.

## Fix

`isSsrRemoteEntryBuild` regains the pre-#1024 client-pass emission for apps with no ssr environment and no legacy `--ssr` build — **Rolldown builds only (Vite 8+ / rolldown-vite)**. Unchanged from #1024: `environments.ssr` setups still emit only in the ssr environment, and the `?? viteConfig?.build?.ssr` legacy-detection fallback is kept.

**Why Rolldown-only:** review of this PR surfaced that the Rollup asset path has *never* produced a working client-only SSR entry — its `virtual:mf-exposes-ssr` import is only rewritten for Nuxt, so the emitted file throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` at first expose load. We reproduced this byte-identically on published **1.20.1** with a minimal vite@7 remote (runtime `get('./Widget')` fails). Emitting nothing on Rollup keeps Vite ≤7 at exact parity with current main — a missing file fails fast in the loader, where a present-but-broken one returns 200 and masks the fallbacks. Bundling the SSR exposes graph into Rollup client builds risks the code-splitting side effects the original asset-path comment warns about, so that remains out of scope.

## Test coverage

- **Unit contract**: client-only emission pinned for Rolldown, non-emission pinned for Rollup (with the 1.20.1 evidence in the test comment), plus the pre-existing environment/legacy cases.
- **e2e (new `vite-ssr` example + Playwright project)**: this repo's e2e previously had no coverage of the SSR-consumption architecture — the suite passed while this regression was live on main. The new example (dual-build SSR host + client-only SPA remote) closes that: the spec asserts `remoteEntry.ssr.js` is served as actual JavaScript with the container's `init`/`get` exports, the federated widget appears in raw server-rendered HTML, and it hydrates with **zero hydration-mismatch console errors**. Verified red on main and green with the fix. Readiness probes a `/healthz` endpoint so regressions surface as assertion failures, not webServer timeouts.

The e2e also guards the vinext scenario's server-loading half without any vinext dependency; the React share-cache half is covered by #1072.

## Verification

- Full unit suite green (1055); full Playwright matrix green including the new project.
- vinext example apps rebuilt with this fix + #1072: both e2e tests pass end to end.

Note: the vinext demo needs **both** this PR and #1072; they are independent at the code level (zero file overlap, both based on main) and can merge in either order.
