### PR TITLE
fix: isolate remote caches across environments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ import {
   LOAD_REMOTE_TAG,
   LOAD_SHARE_TAG,
   PREBUILD_TAG,
+  refreshRemoteModuleForEnvironment,
   TREE_SHAKING_GRAPH_QUERY,
   TREE_SHAKING_PROVIDER_TAG,
   writeLocalSharedImportMap,
@@ -1014,6 +1015,17 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
     });
   };
 
+  const refreshLoadRemoteModuleForEnvironment = (
+    id: string,
+    context: LoadHookContext,
+    loadOptions?: LoadHookOptions
+  ) =>
+    refreshRemoteModuleForEnvironment(
+      id,
+      options,
+      getLoadHookExportConditions(context, loadOptions)
+    );
+
   const refreshPreBuildModuleForEnvironment = (
     id: string,
     context: LoadHookContext,
@@ -1114,6 +1126,12 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         return virtualModule.getResolvedId();
       },
       load(id: string, loadOptions?: LoadHookOptions) {
+        if (
+          id.includes(LOAD_REMOTE_TAG) &&
+          !refreshLoadRemoteModuleForEnvironment(id, this as LoadHookContext, loadOptions)
+        ) {
+          return;
+        }
         if (
           command !== 'build' &&
           id.includes(LOAD_SHARE_TAG) &&
@@ -1525,6 +1543,12 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           importFalseExportUsage?: ReturnType<typeof getSharedExportUsage>
         ) => {
           if (!id.includes(LOAD_SHARE_TAG) && !id.includes(LOAD_REMOTE_TAG)) return;
+          if (
+            id.includes(LOAD_REMOTE_TAG) &&
+            !refreshLoadRemoteModuleForEnvironment(id, this as LoadHookContext, loadOptions)
+          ) {
+            return;
+          }
           if (
             id.includes(LOAD_SHARE_TAG) &&
             refreshLoadShareModuleForEnvironment(

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -9,6 +9,7 @@ import {
   isDynamicOnlyRemote,
   markDynamicRemote,
   markStaticRemote,
+  refreshRemoteModuleForEnvironment,
   resolveRemoteInitMode,
 } from '../virtualRemotes';
 
@@ -153,6 +154,20 @@ describe('generateRemotes', () => {
     expect(client.getImportId()).not.toBe(server.getImportId());
     expect(client.code).toContain('hostInitPromise');
     expect(server.code).not.toContain('.then(initResolve, initReject)');
+  });
+
+  it('refreshes server wrappers with their environment cache', () => {
+    const options = {
+      internalName: 'host',
+      shareStrategy: 'version-first',
+      remotes: {},
+    } as never;
+    const remote = getRemoteVirtualModule('remote/Button', 'serve', true, 'server', options);
+
+    expect(refreshRemoteModuleForEnvironment(remote.getImportId(), options, ['react-server'])).toBe(
+      true
+    );
+    expect(remote.code).toContain('__mf_module_cache_react_server__');
   });
   beforeEach(() => {
     mockOptions.shareStrategy = 'version-first';

--- a/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
+++ b/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
@@ -22,6 +22,7 @@ describe('virtualRuntimeInitStatus', () => {
   beforeEach(() => {
     writeSyncSpy.mockClear();
     delete (globalThis as Record<string, unknown>)['__mf_module_cache__'];
+    delete (globalThis as Record<string, unknown>)['__mf_module_cache_react_server__'];
     delete (globalThis as Record<string, unknown>)['__mf_init__virtual:runtimeInit__'];
   });
 
@@ -54,6 +55,23 @@ describe('virtualRuntimeInitStatus', () => {
     expect(getModuleCacheGlobalKey(['react-server', 'node'])).toBe(
       '__mf_module_cache_react_server__'
     );
+  });
+
+  it('selects the current environment cache for an existing owner', async () => {
+    const { getRuntimeInitBootstrapCode } = await import('../virtualRuntimeInitStatus');
+    const owner = 'virtual:owner';
+    const run = (conditions?: string[]) =>
+      runCode<any>(
+        getRuntimeInitBootstrapCode(false, owner, undefined, owner, conditions),
+        'return globalThis[globalKey].moduleCache;'
+      );
+
+    const ssrCache = run(['node']);
+    const reactServerCache = run(['react-server', 'node']);
+
+    expect(reactServerCache).not.toBe(ssrCache);
+    expect(reactServerCache).toBe((globalThis as any).__mf_module_cache_react_server__);
+    delete (globalThis as any)['__mf_init__virtual:owner__'];
   });
 
   it('aliases default-scoped and legacy share cache keys both ways', async () => {

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -29,6 +29,7 @@ export {
   getUsedRemotesMap,
   markDynamicRemote,
   markStaticRemote,
+  refreshRemoteModuleForEnvironment,
   LOAD_REMOTE_TAG,
 } from './virtualRemotes';
 

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -16,6 +16,16 @@ import {
 } from './virtualRuntimeInitStatus';
 
 const cacheRemoteMap = new WeakMap<NormalizedModuleFederationOptions, Map<string, VirtualModule>>();
+const remoteModuleMetadata = new WeakMap<
+  VirtualModule,
+  {
+    remote: string;
+    command: string;
+    enableSsrInit: boolean;
+    consumer: RemoteConsumer;
+    options: NormalizedModuleFederationOptions;
+  }
+>();
 const remoteOptionsIds = new WeakMap<NormalizedModuleFederationOptions, number>();
 let nextRemoteOptionsId = 1;
 
@@ -52,9 +62,31 @@ export function getRemoteVirtualModule(
     const virtualName = `${consumerName}${MF_OWNER_INFIX}${getRemoteOptionsId(options)}`;
     const virtual = new VirtualModule(virtualName, LOAD_REMOTE_TAG, '.js', options.internalName);
     virtual.writeSync(generateRemotes(remote, command, enableSsrInit, consumer, options));
+    remoteModuleMetadata.set(virtual, { remote, command, enableSsrInit, consumer, options });
     instanceCache.set(cacheKey, virtual);
   }
   return instanceCache.get(cacheKey)!;
+}
+
+export function refreshRemoteModuleForEnvironment(
+  id: string,
+  options: NormalizedModuleFederationOptions,
+  exportConditions?: readonly string[]
+) {
+  const virtual = VirtualModule.findById(id);
+  const metadata = virtual && remoteModuleMetadata.get(virtual);
+  if (!virtual || !metadata || metadata.options !== options) return false;
+  virtual.write(
+    generateRemotes(
+      metadata.remote,
+      metadata.command,
+      metadata.enableSsrInit,
+      metadata.consumer,
+      options,
+      exportConditions
+    )
+  );
+  return true;
 }
 const usedRemotesMap: Record<string, Set<string>> = {
   // remote1: {remote1/App, remote1, remote1/Button}
@@ -349,7 +381,8 @@ export function generateRemotes(
   command: string,
   enableSsrInit = false,
   consumer: RemoteConsumer = 'unified',
-  options?: NormalizedModuleFederationOptions
+  options?: NormalizedModuleFederationOptions,
+  exportConditions?: readonly string[]
 ) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const isLoadedFirst = resolvedOptions.shareStrategy === 'loaded-first';
@@ -383,13 +416,14 @@ export function generateRemotes(
     enableSsrInit,
     getRuntimeInitStatusImportId(options),
     ssrRemotes,
-    hostAutoInitPath
+    hostAutoInitPath,
+    exportConditions
   )}
     const { initPromise, initResolve, initReject, moduleCache: __mfModuleCache } = globalThis[globalKey];`;
   const devHostInitLine = command === 'serve' && consumer !== 'server' ? browserHostInitCode : '';
   const importLine =
     command === 'build'
-      ? `${getRuntimeModuleCacheBootstrapCode()}
+      ? `${getRuntimeModuleCacheBootstrapCode(exportConditions)}
     import { hostInitPromise as __mfHostInitPromise } from ${JSON.stringify(hostAutoInitPath)};`
       : `${devRuntimeBootstrap}
     ${devHostInitLine}`;

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -188,7 +188,7 @@ if (${SERVER_ENV_GUARD} && !globalThis[globalKey].ssrInitStarted) {
 }`
     : ''
 }
-globalThis[globalKey].moduleCache ||= globalThis[moduleCacheGlobalKey];
+globalThis[globalKey].moduleCache = globalThis[moduleCacheGlobalKey];
 globalThis[globalKey].moduleCache.share ||= {};
 globalThis[globalKey].moduleCache.remote ||= {};
 `;


### PR DESCRIPTION
Close #1074

Completes environment isolation for remote-module caches, extending the shared-module isolation.