### PR TITLE
fix: scope shared caches per SSR environment

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2468,6 +2468,9 @@ describe('virtualRemoteEntry', () => {
 
     expect(code).toContain('const __mfGetSharedCacheDescriptor =');
     expect(code).toContain('__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor)');
+    expect(code).toContain(
+      '__mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined'
+    );
     expect(code).toMatch(
       /__mfWriteSharedCache\(\s*__mfModuleCache\.share,\s*cacheDescriptor,\s*resolved,\s*"host"\s*\)/
     );

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultMockOptions } from '../../utils/__tests__/helpers';
 import { generateRemoteEntrySSR, getRemoteEntrySSRId } from '../virtualRemoteEntrySSR';
+import { MODULE_CACHE_SHARE_SCOPE_KEY } from '../virtualRuntimeInitStatus';
 
 type SsrEntry = {
   init: (shared?: Record<string, unknown>, initScope?: unknown[]) => Promise<unknown>;
@@ -250,5 +251,29 @@ describe('virtualRemoteEntrySSR', () => {
       'default:react': { marker: 'host-react' },
       react: { marker: 'host-react' },
     });
+  });
+
+  it('writes negotiated singletons only to the requesting environment cache', async () => {
+    const module = { marker: 'react-server' };
+    const environmentCache = { share: {}, remote: {} };
+    const entry = createEntry(
+      createRuntime(
+        undefined,
+        vi.fn(async () => () => module)
+      ),
+      {
+        shared: { react: singleton('react') },
+      }
+    );
+
+    const shared = { react: {} } as Record<PropertyKey, unknown>;
+    shared[Symbol.for(MODULE_CACHE_SHARE_SCOPE_KEY)] = environmentCache;
+    await entry.init(shared as Record<string, unknown>);
+
+    expect(environmentCache.share).toMatchObject({
+      'default:react': module,
+      react: module,
+    });
+    expect((globalThis as any).__mf_module_cache__).toBeUndefined();
   });
 });

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -168,6 +168,7 @@ describe('generateRemotes', () => {
       true
     );
     expect(remote.code).toContain('__mf_module_cache_react_server__');
+    expect(remote.code).toContain('shareScopes[moduleCacheKey] = __mfModuleCache');
   });
   beforeEach(() => {
     mockOptions.shareStrategy = 'version-first';

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2056,7 +2056,10 @@ export function generateHostAutoInitCode(
             // a generic full-module key here.
             if (share.treeShaking) continue;
             const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
-            if (__mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined) {
+            if (
+              __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined &&
+              __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined
+            ) {
               continue;
             }
             await runtime.loadShare(pkg, {

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -1,6 +1,7 @@
 import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { getVirtualExposesSSRId } from './virtualExposesSSR';
 import { getVirtualModuleScopeKey } from './virtualModuleScope';
+import { MODULE_CACHE_SHARE_SCOPE_KEY } from './virtualRuntimeInitStatus';
 
 const REMOTE_ENTRY_SSR_ID = 'virtual:mf-REMOTE_ENTRY_SSR_ID';
 
@@ -36,6 +37,7 @@ export function generateRemoteEntrySSR(options: NormalizedModuleFederationOption
   import { init as runtimeInit } from "@module-federation/runtime";
 
   const sharedSingletons = ${JSON.stringify(sharedSingletons)};
+  const moduleCacheKey = Symbol.for(${JSON.stringify(MODULE_CACHE_SHARE_SCOPE_KEY)});
   let exposesMapPromise;
 
   function createShareInitError(errors) {
@@ -113,7 +115,8 @@ export function generateRemoteEntrySSR(options: NormalizedModuleFederationOption
       throw createShareInitError(shareInitErrors);
     }
     if (cacheEntries.length > 0) {
-      const moduleCache = (globalThis.__mf_module_cache__ ||= { share: {}, remote: {} });
+      const moduleCache = shared?.[moduleCacheKey] ||
+        (globalThis.__mf_module_cache__ ||= { share: {}, remote: {} });
       const cache = (moduleCache.share ||= {});
       for (const { scopeName, pkg, module } of cacheEntries) {
         cache[scopeName + ':' + pkg] ??= module;

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -13,6 +13,7 @@ import {
   getRuntimeRemoteCachePrefix,
   getRuntimeInitStatusImportId,
   getRuntimeModuleCacheBootstrapCode,
+  MODULE_CACHE_SHARE_SCOPE_KEY,
 } from './virtualRuntimeInitStatus';
 
 const cacheRemoteMap = new WeakMap<NormalizedModuleFederationOptions, Map<string, VirtualModule>>();
@@ -446,6 +447,12 @@ export function generateRemotes(
         __mfModuleCache.remote[pendingKey] = ${remoteLoadRuntimePromise}
           .then((runtime) => {
             ${registerRemoteCode}
+            const moduleCacheKey = Symbol.for(${JSON.stringify(MODULE_CACHE_SHARE_SCOPE_KEY)});
+            const shareScopes = runtime.shareScopeMap || {};
+            for (const scope of Object.values(shareScopes)) {
+              if (scope && typeof scope === "object") scope[moduleCacheKey] = __mfModuleCache;
+            }
+            shareScopes[moduleCacheKey] = __mfModuleCache;
             return runtime.loadRemote(${JSON.stringify(runtimeRemoteId)});
           })
           .then((mod) => Promise.resolve(mod?.__mf_remote_dependency_pending).then(() => mod))

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -9,6 +9,7 @@ const runtimeInitOwnerIds = new WeakMap<NormalizedModuleFederationOptions, numbe
 let nextRuntimeInitOwnerId = 1;
 const MODULE_CACHE_GLOBAL_KEY = '__mf_module_cache__';
 const REACT_SERVER_MODULE_CACHE_GLOBAL_KEY = '__mf_module_cache_react_server__';
+export const MODULE_CACHE_SHARE_SCOPE_KEY = 'module-federation.vite-module-cache';
 
 export function getModuleCacheGlobalKey(exportConditions?: readonly string[]) {
   return isReactServerConditions(exportConditions)


### PR DESCRIPTION
Close #1075

SSR remotes now write negotiated singletons into the requesting environment’s cache.
Hosts repair stale unscoped entries from older remotes.