### PR TITLE
fix: preserve tree-shaking environment cache isolation

### DIFF
--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -282,6 +282,16 @@ export function proxySharedModule(options: {
   const hasAnalyzableShares = Object.values(shared).some((share) =>
     shouldAnalyzeSharedExports(share)
   );
+  const getEnvironmentConditions = (context: unknown): string[] | undefined =>
+    (context as { environment?: { config?: { resolve?: { conditions?: string[] } } } }).environment
+      ?.config?.resolve?.conditions;
+  const refreshTreeShakingForEnvironment = (context: unknown) =>
+    refreshTreeShakingModules(
+      federationOptions,
+      _command,
+      getIsRolldown(context),
+      getEnvironmentConditions(context)
+    );
 
   const normalizeTreeShakingOutputPath = (value: string) => {
     const normalized = normalizePathForImport(value);
@@ -360,7 +370,7 @@ export function proxySharedModule(options: {
             // Export analysis is additive across the module graph. Materialize
             // and emit optimized providers only when the shared map itself is
             // finalized, immediately before Rollup discovers their imports.
-            refreshTreeShakingModules(federationOptions);
+            refreshTreeShakingForEnvironment(this);
             const providerPackages = new Set([
               ...Object.keys(shared).filter((pkg) => !pkg.endsWith('/')),
               ...getUsedShares(federationOptions),
@@ -435,7 +445,7 @@ export function proxySharedModule(options: {
         if (_command !== 'build') return;
         resetTreeShakingExports(federationOptions);
         emittedTreeShakingProviders.clear();
-        refreshTreeShakingModules(federationOptions);
+        refreshTreeShakingForEnvironment(this);
       },
       shouldTransformCachedModule() {
         // Watch builds must revisit cached importers after the per-build usage
@@ -456,7 +466,7 @@ export function proxySharedModule(options: {
           (sharedKey, request) =>
             markTreeShakingPackageUnsafe(sharedKey, request, federationOptions)
         );
-        refreshTreeShakingModules(federationOptions);
+        refreshTreeShakingForEnvironment(this);
       },
     },
     {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -15,6 +15,7 @@ import {
   getTreeShakingGraphToken,
   getTreeShakingSharedProviderImportId,
   hasTreeShakingSharedProvider,
+  refreshTreeShakingModules,
   resetConcreteSharedImportSourceCache,
   stripTreeShakingGraphQuery,
   writeLoadShareModule,
@@ -2735,6 +2736,27 @@ describe('writeLoadShareModule', () => {
 
     expect(generatedCode).toContain('__mf_0 as workerOnly');
     expect(generatedCode).not.toContain('serverOnly');
+  });
+
+  it('preserves react-server conditions when refreshing tree-shaken shares', () => {
+    const options = normalizeModuleFederationOptions({
+      name: 'host',
+      shared: {
+        react: {
+          singleton: true,
+          treeShaking: { mode: 'runtime-infer', usedExports: ['useState'] },
+        },
+      },
+    });
+    const shareItem = options.shared.react;
+
+    writePreBuildLibPath('react', shareItem, options);
+    writeSyncSpy.mockClear();
+    refreshTreeShakingModules(options, 'serve', false, ['react-server']);
+
+    const generatedCode = writeSyncSpy.mock.calls.map(([code]) => code).join('\n');
+    expect(generatedCode).toContain('__mf_module_cache_react_server__');
+    expect(generatedCode).not.toContain('const __mfCacheGlobalKey = "__mf_module_cache__"');
   });
 
   it.each([

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1460,12 +1460,17 @@ export function writePreBuildLibPath(
 }
 
 /** Re-render already materialized wrappers after import analysis discovers exports. */
-export function refreshTreeShakingModules(options?: NormalizedModuleFederationOptions) {
+export function refreshTreeShakingModules(
+  options?: NormalizedModuleFederationOptions,
+  command = 'build',
+  isRolldown = false,
+  exportConditions?: string[]
+) {
   const { preBuildShareItemMap } = getSharedVirtualModuleState(options);
   for (const [pkg, shareItem] of Object.entries(preBuildShareItemMap)) {
     if (!shareItem?.shareConfig.treeShaking) continue;
-    writePreBuildLibPath(pkg, shareItem, options);
-    writeLoadShareModule(pkg, shareItem, 'build', false, options);
+    writePreBuildLibPath(pkg, shareItem, options, exportConditions);
+    writeLoadShareModule(pkg, shareItem, command, isRolldown, options, exportConditions);
   }
 }
 export function getPreBuildLibImportId(


### PR DESCRIPTION
Close #1076

SSR/RSC-only bug environments. Client-only builds are unaffected.
Keeps refreshed shared wrappers bound to their original export conditions, command, and bundler mode. Prevents React server shares from falling into the default cache.