### PR TITLE
fix: preserve React isolation for worker SSR

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -643,8 +643,13 @@ describe('virtualRemoteEntry', () => {
     const clientInit = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build', undefined, [
       'browser',
     ]);
+    const workerInit = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build', undefined, [
+      'worker',
+      'browser',
+    ]);
     expect(serverInit).toContain('const localFactory = await share.get()');
     expect(clientInit).not.toContain('const localFactory = await share.get()');
+    expect(workerInit).toContain('const localFactory = await share.get()');
   });
 
   it('uses configured share import path in localSharedImportMap', async () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2031,7 +2031,8 @@ export function generateHostAutoInitCode(
   const hostInitShareOrder = JSON.stringify(getOrderedUsedShares(options));
   const cacheOwner = JSON.stringify(resolvedOptions.name);
   const preferLocalVinextReact =
-    hasPackageDependency('vinext') && !exportConditions?.includes('browser');
+    hasPackageDependency('vinext') &&
+    (!exportConditions?.includes('browser') || exportConditions.includes('worker'));
   return `
     ${getRuntimeModuleCacheBootstrapCode(exportConditions)}
     let hostInitPromise;


### PR DESCRIPTION
Close #1077

Treat worker environments as SSR even when their export conditions include browser, preserving local React selection.