### PR TITLE
fix: await both SSR share-load queues

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -416,6 +416,9 @@ describe('pluginAddEntry', () => {
 
     expect(result?.code).toContain('__mfModuleCache.pendingShareLoads');
     expect(result?.code).toContain('await Promise.all(__mfModuleCache.pendingShareLoads)');
+    expect(result?.code).toContain(
+      'await Promise.all(__mfReactServerModuleCache.pendingShareLoads)'
+    );
 
     const bootstrap = result?.code ?? '';
     expect(bootstrap.indexOf('await initHost();')).toBeLessThan(

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -28,6 +28,7 @@ import {
   isDynamicOnlyRemote,
 } from '../virtualModules/virtualRemotes';
 import {
+  getModuleCacheGlobalKey,
   getRuntimeModuleCacheBootstrapCode,
   getRuntimeRemoteCachePrefix,
 } from '../virtualModules/virtualRuntimeInitStatus';
@@ -375,6 +376,10 @@ const __mfCurrentScript = document.currentScript;
     const pendingShareLoadsAwait = `
   if (__mfModuleCache.pendingShareLoads) {
     await Promise.all(__mfModuleCache.pendingShareLoads);
+  }
+  const __mfReactServerModuleCache = globalThis[${JSON.stringify(getModuleCacheGlobalKey(['react-server']))}];
+  if (__mfReactServerModuleCache?.pendingShareLoads) {
+    await Promise.all(__mfReactServerModuleCache.pendingShareLoads);
   }`;
 
     const importCode = `


### PR DESCRIPTION
Close #1078

Entry bootstrap waits for pending React Server shared-module loads before starting the application.