### PR TITLE
fix: ignore export member method calls

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -218,6 +218,9 @@ vi.mock('../../utils/packageUtils', () => ({
     if (pkg === 'mock-package-nested-template-literal') {
       return '/repo/apps/remote/node_modules/mock-package-nested-template-literal/index.js';
     }
+    if (pkg === 'mock-package-export-method-call') {
+      return '/repo/apps/remote/node_modules/mock-package-export-method-call/index.js';
+    }
     if (pkg === 'mock-package-esm-only/stores' || pkg === 'mock-package-esm-only') {
       return '/repo/apps/remote/node_modules/mock-package-esm-only/dist/stores.js';
     }
@@ -690,6 +693,14 @@ export const buttonBase = 1;`;
       return [
         "const body = 'text';",
         'export const injectedHtml = `${`<div>`}${body}${`</div>`}`;',
+      ].join('\n');
+    }
+    if (filePath.endsWith('node_modules/mock-package-export-method-call/index.js')) {
+      return [
+        'const key = globalThis.crypto.subtle;',
+        'export function toJwk() {',
+        "  return key.export({ format: 'jwk' });",
+        '}',
       ].join('\n');
     }
     if (
@@ -2708,6 +2719,10 @@ describe('writeLoadShareModule', () => {
         String(filePath).endsWith('/mock-package-nested-template-literal/index.js')
       )
     ).toHaveLength(1);
+  });
+
+  it('detects named exports when `export` appears as a method name', () => {
+    expect(getSharedNamedExports('mock-package-export-method-call')).toEqual(['toJwk']);
   });
 
   it('uses worker conditional exports for webworker SSR', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -752,10 +752,20 @@ function getNamedExportsViaRegex(
   const exportKeywordRegex = /\bexport\b/g;
   while ((match = exportKeywordRegex.exec(source)) !== null) {
     if (!codePositions[match.index]) continue;
-    if (!recognizedExportStarts.has(match.index)) {
-      scanState.complete = false;
-      break;
+    if (recognizedExportStarts.has(match.index)) continue;
+
+    // A member named `export` is not an export declaration.
+    let previousCodeIndex = match.index - 1;
+    while (
+      previousCodeIndex >= 0 &&
+      (/\s/.test(source[previousCodeIndex]) || !codePositions[previousCodeIndex])
+    ) {
+      previousCodeIndex--;
     }
+    if (source[previousCodeIndex] === '.') continue;
+
+    scanState.complete = false;
+    break;
   }
 
   return Array.from(names);


### PR DESCRIPTION
Close #1084

Prevents .export() from breaking shared-package named-export detection.