### PR TITLE
fix: defer remote singleton fallback imports

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -3560,7 +3560,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('import * as __mfLocalShare from "lit";');
+    expect(generatedCode).not.toContain('import * as __mfLocalShare from "lit";');
     expect(generatedCode).toContain('if (import.meta.env.SSR');
     expect(generatedCode).toContain('import("lit").then((mod) => {');
     expect(generatedCode).toContain('export { __mf_default as default };');
@@ -3597,7 +3597,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain('import * as __mfLocalShare from "lit";');
+    expect(generatedCode).not.toContain('import * as __mfLocalShare from "lit";');
     expect(generatedCode).toContain('if (import.meta.env.SSR');
     expect(generatedCode).toContain('import("lit").then((mod) => {');
     expect(generatedCode).toContain('export { __mf_default as default };');
@@ -3713,7 +3713,7 @@ describe('writeLoadShareModule', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    expect(generatedCode).toContain(
+    expect(generatedCode).not.toContain(
       'import * as __mfLocalShare from "lit/directives/class-map.js";'
     );
     expect(generatedCode).toContain('if (import.meta.env.SSR');

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1990,6 +1990,7 @@ export function writeLoadShareModule(
   const usesEagerWorkspaceFallback =
     hasCompleteExportCoverage &&
     isWorkspaceSingleton &&
+    !servesRemoteSingletonFallback &&
     (isConsumedByPeerSingleton || shareItem.shareConfig.eager === true);
   const usesDeferredTreeShakingFallback = hasCompleteExportCoverage && Boolean(treeShakingConsumer);
   const reactMixedModeGuard = pkg === 'react' ? createReactMixedModeRuntimeGuard() : '';
@@ -2004,7 +2005,8 @@ export function writeLoadShareModule(
       cacheOwner,
       treeShakingConsumer,
       command !== 'build' &&
-        (isWorkspaceSingleton || isWorkspacePackage || servesRemoteSingletonFallback),
+        !servesRemoteSingletonFallback &&
+        (isWorkspaceSingleton || isWorkspacePackage),
       liveNamedExports
     );
   } else if (usesEagerWorkspaceFallback || usesEntryInjectedRemoteFallback) {
@@ -2025,7 +2027,8 @@ export function writeLoadShareModule(
       cacheOwner,
       treeShakingConsumer,
       command !== 'build' &&
-        (isWorkspaceSingleton || isWorkspacePackage || servesRemoteSingletonFallback),
+        !servesRemoteSingletonFallback &&
+        (isWorkspaceSingleton || isWorkspacePackage),
       liveNamedExports
     );
   } else if (detectedNamedExports === undefined) {
@@ -2124,10 +2127,10 @@ export function writeLoadShareModule(
     usesEagerWorkspaceFallback || usesEntryInjectedRemoteFallback
       ? ''
       : usesDeferredSingletonFallback || usesDeferredTreeShakingFallback
-        ? servesRemoteSingletonFallback ||
-          (usesDeferredSingletonFallback &&
-            command !== 'build' &&
-            (isWorkspaceSingleton || isWorkspacePackage))
+        ? !servesRemoteSingletonFallback &&
+          usesDeferredSingletonFallback &&
+          command !== 'build' &&
+          (isWorkspaceSingleton || isWorkspacePackage)
           ? `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(lazyLocalFallbackSource)};`
           : ''
         : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(staticLocalShareSource)};`;


### PR DESCRIPTION
Close #1085

Remote dev wrappers now check the shared cache before loading their local fallback, preventing duplicate singleton evaluation.
