### PR TITLE
fix: serve browser remote entries in dev

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -199,11 +199,12 @@ describe('pluginAddEntry', () => {
       middlewares: { use: (handler: Function) => handlers.push(handler) },
     } as unknown as ViteDevServer);
 
-    const req = { url: '/remoteEntry.js?cache=1' };
+    const req = { url: '/remoteEntry.js?cache=1', headers: { 'sec-fetch-dest': 'document' } };
     const next = vi.fn();
     handlers[0](req, {}, next);
 
     expect(req.url).toBe('/@id/virtual:mf-remote-entry');
+    expect(req.headers['sec-fetch-dest']).toBe('script');
     expect(next).toHaveBeenCalledOnce();
   });
 

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -531,6 +531,7 @@ const __mfCurrentScript = document.currentScript;
           }
           if (req.url && req.url.startsWith((viteConfig.base + fileName).replace(/^\/?/, '/'))) {
             req.url = devEntryPath;
+            req.headers['sec-fetch-dest'] = 'script';
           }
           next();
         });


### PR DESCRIPTION
Close #938

Ensures Vite dev serves remoteEntry.js as JavaScript during direct browser navigation.