### PR TITLE
fix: treat `$`-prefixed minified names as real identifiers

### DIFF
--- a/integration/proxy-alias-deconflict.test.ts
+++ b/integration/proxy-alias-deconflict.test.ts
@@ -1,7 +1,59 @@
 import { describe, expect, it } from 'vitest';
-import { resolveProxyAlias } from '../src/utils/bundleHelpers';
+import { isIdentifierReferenced, resolveProxyAlias } from '../src/utils/bundleHelpers';
+
+describe('isIdentifierReferenced', () => {
+  it.each(['$8', '$', '$1', '$$0'])('finds `%s` at the start of an identifier', (name) => {
+    expect(isIdentifierReferenced(name, `var n=j3,e=${name},r=PS;`)).toBe(true);
+  });
+
+  it.each(['An', 'd6', 'N4', 'require$$0', 'commonjsGlobal$1'])(
+    'still finds the ordinary name `%s`',
+    (name) => {
+      expect(isIdentifierReferenced(name, `const o=${name}.createElement("div");`)).toBe(true);
+    }
+  );
+
+  it('does not match a longer identifier that merely contains the name', () => {
+    expect(isIdentifierReferenced('$8', 'const x=$80;')).toBe(false);
+    expect(isIdentifierReferenced('$', 'const x=$foo;')).toBe(false);
+    expect(isIdentifierReferenced('r', 'const x=react;')).toBe(false);
+  });
+
+  it('does not match when the name is only a suffix of another identifier', () => {
+    expect(isIdentifierReferenced('$8', 'const x=a$8;')).toBe(false);
+    expect(isIdentifierReferenced('o', 'const x=foo;')).toBe(false);
+  });
+
+  it('reports an absent name as unreferenced', () => {
+    expect(isIdentifierReferenced('$8', 'console.log(other);')).toBe(false);
+  });
+});
 
 describe('resolveProxyAlias', () => {
+  // The `\b` check reported a minified `$8` binding unused, so the import was
+  // rebound to the proxy's export name and its references were left dangling —
+  // a clean build that threw `ReferenceError: $8 is not defined` in the browser.
+  it.each(['$8', '$', '$1'])(
+    'keeps the `%s` alias when it is referenced in the code body',
+    (local) => {
+      const fullImport = `import{r as ${local},c as Zg}from"./proxy-react.mjs_commonjs-proxy-abc.js";`;
+      const code = `${fullImport}var n=j3,e=${local},r=PS;t.exports=r(${local},tI);`;
+
+      const result = resolveProxyAlias({ imported: 'r', local }, 'l', code, fullImport);
+
+      expect(result.local).toBe(local);
+    }
+  );
+
+  it('still restores proxyLocal when a `$`-prefixed alias is genuinely unused', () => {
+    const fullImport = `import{r as $8}from"./proxy-abc.js"`;
+    const code = `${fullImport};console.log(somethingElse);`;
+
+    const result = resolveProxyAlias({ imported: 'r', local: '$8' }, 'l', code, fullImport);
+
+    expect(result.local).toBe('l');
+  });
+
   it('keeps b.local when it is referenced in the code body', () => {
     const fullImport = `import{r as commonjsGlobal$1}from"./proxy-abc.js"`;
     const code = `${fullImport};console.log(commonjsGlobal$1);`;

--- a/src/utils/__tests__/controlChunkSanitizer.test.ts
+++ b/src/utils/__tests__/controlChunkSanitizer.test.ts
@@ -77,6 +77,28 @@ describe('controlChunkSanitizer', () => {
     expect(result).not.toContain('preload-helper-CWZBUsdZ.js');
   });
 
+  it('keeps a `$`-prefixed `_` import whose binding is referenced as a value', () => {
+    const code =
+      'import{_ as __vitePreload}from"./assets/preload-helper-CWZBUsdZ.js";' +
+      'import{_ as $8}from"./assets/_virtual_mf-localSharedImportMap-CiudmNFF.js";' +
+      'async function getLocalSharedImportMap(){return $8}';
+
+    const result = stripEmptyPreloadCalls(code);
+
+    expect(result).toContain(
+      'import{_ as $8}from"./assets/_virtual_mf-localSharedImportMap-CiudmNFF.js";'
+    );
+    expect(result).not.toContain('preload-helper-CWZBUsdZ.js');
+  });
+
+  it('still drops a `$`-prefixed `_` import that is genuinely unused', () => {
+    const code =
+      'import{_ as $8}from"./assets/preload-helper-CWZBUsdZ.js";' +
+      'async function noop(){return 1}';
+
+    expect(stripEmptyPreloadCalls(code)).not.toContain('preload-helper-CWZBUsdZ.js');
+  });
+
   it('detects federation control chunks', () => {
     expect(isFederationControlChunk('remoteEntry.js', 'remoteEntry.js')).toBe(true);
     expect(isFederationControlChunk('assets/hostInit-abc.js', 'remoteEntry.js')).toBe(true);

--- a/src/utils/bundleHelpers.ts
+++ b/src/utils/bundleHelpers.ts
@@ -20,6 +20,18 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Whether `code` references `name` as a whole identifier.
+ *
+ * Not `\b`: a word boundary needs a `\w` on one side, and `$` is not one, so
+ * `\b$8\b` matches nothing at all. Minifiers assign `$`-prefixed names to any
+ * chunk with more than ~54 module-scope bindings, and a missed match here reads
+ * as "unused", which orphans a still-referenced import.
+ */
+export function isIdentifierReferenced(name: string, code: string): boolean {
+  return new RegExp(`(?<![$\\w])${escapeRegExp(name)}(?![$\\w])`).test(code);
+}
+
 function getProxyBaseName(fileName: string): string {
   return fileName
     .replace(/^.*\//, '')
@@ -27,8 +39,16 @@ function getProxyBaseName(fileName: string): string {
     .replace(/-[A-Za-z0-9_-]+$/, '');
 }
 
+/**
+ * Matches `function <name>(`. Escaped because an unescaped leading `$` is a
+ * regex end-anchor, so the pattern would silently match nothing.
+ */
+function functionDeclarationRegExp(name: string): RegExp {
+  return new RegExp(`function\\s+${escapeRegExp(name)}\\s*\\(`);
+}
+
 function extractFunctionDeclaration(code: string, functionName: string): string | undefined {
-  const funcRe = new RegExp(`function\\s+${functionName}\\s*\\([^)]*\\)\\s*\\{`);
+  const funcRe = new RegExp(`function\\s+${escapeRegExp(functionName)}\\s*\\([^)]*\\)\\s*\\{`);
   const funcStart = code.search(funcRe);
   if (funcStart < 0) return;
 
@@ -55,8 +75,7 @@ export function resolveProxyAlias(
   claimedLocals: Set<string> = new Set()
 ): { imported: string; local: string } {
   const codeWithoutImport = code.replace(fullImport, '');
-  const escapedLocal = binding.local.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const localUsedInCode = new RegExp(`\\b${escapedLocal}\\b`).test(codeWithoutImport);
+  const localUsedInCode = isIdentifierReferenced(binding.local, codeWithoutImport);
   const claimedImportLocals = new Set<string>();
   const importRe = /import\s*\{([^}]+)\}\s*from\s*["'][^"']+["']\s*;?/g;
   let match: RegExpExecArray | null;
@@ -132,7 +151,7 @@ export function collectSystemProxyInfos(
       // e.g. getAugmentedNamespace(React4). Prefer the wrapped namespace binding
       // over the helper when both come from the same loadShare chunk.
       for (const [local, exportName] of Object.entries(loadShareBindings).reverse()) {
-        if (new RegExp(`\\b${local}\\b`).test(expression)) {
+        if (isIdentifierReferenced(local, expression)) {
           exportMap[exported] = { type: 'reexport', exportName };
           break;
         }
@@ -198,8 +217,8 @@ export function rewriteEsmProxyConsumers(
         inlineable.push({
           local: b.local,
           funcBody: funcBody.replace(
-            new RegExp(`function\\s+${proxyLocal}\\s*\\(`),
-            `function ${b.local}(`
+            functionDeclarationRegExp(proxyLocal),
+            () => `function ${b.local}(`
           ),
         });
         claimedLocals.add(b.local);
@@ -278,7 +297,7 @@ export function rewriteSystemProxyConsumers(
 
         if (mapped.type === 'helper') {
           helpersToInline.push(
-            mapped.code.replace(new RegExp(`function\\s+${imported}\\s*\\(`), `function ${local}(`)
+            mapped.code.replace(functionDeclarationRegExp(imported), () => `function ${local}(`)
           );
           return '';
         }

--- a/src/utils/controlChunkSanitizer.ts
+++ b/src/utils/controlChunkSanitizer.ts
@@ -1,3 +1,5 @@
+import { isIdentifierReferenced } from './bundleHelpers';
+
 const FEDERATION_CONTROL_CHUNK_HINTS = [
   'hostInit',
   'virtualExposes',
@@ -5,7 +7,10 @@ const FEDERATION_CONTROL_CHUNK_HINTS = [
 ] as const;
 
 export function stripEmptyPreloadCalls(code: string): string {
-  const helperImportRegex = /import\s*\{\s*_\s*as\s*(\w+)\s*\}\s*from\s*["'][^"']+["']\s*;?/g;
+  // Not `\w+`: that skips the `$`-prefixed aliases minifiers produce, leaving
+  // those imports unprocessed.
+  const helperImportRegex =
+    /import\s*\{\s*_\s*as\s*([A-Za-z_$][\w$]*)\s*\}\s*from\s*["'][^"']+["']\s*;?/g;
   const helperAliases: string[] = [];
   let helperImportMatch: RegExpExecArray | null;
   while ((helperImportMatch = helperImportRegex.exec(code)) !== null) {
@@ -60,8 +65,7 @@ export function stripEmptyPreloadCalls(code: string): string {
     // such a binding is usually referenced as a plain value (e.g. `return x;`) rather
     // than called. Dropping that import leaves an undeclared free identifier behind,
     // which throws at runtime while the build still exits successfully.
-    const helperReferenceRegex = new RegExp(`\\b${local}\\b`);
-    return helperReferenceRegex.test(nextCode.replace(statement, '')) ? statement : '';
+    return isIdentifierReferenced(local, nextCode.replace(statement, '')) ? statement : '';
   });
 
   return nextCode;


### PR DESCRIPTION
`\b` cannot test whether an identifier is referenced. A word boundary sits between a `\w` and a non-`\w` character, and `$` is not a word character, so `\b` never matches at the start of a name beginning with `$` — `\b$8\b` matches nothing at all, in any input.

Minifiers produce those names routinely. esbuild and Oxc both draw single-character names from a 54-character alphabet whose last two entries are `_` and `$`, so any chunk with more than about 54 module-scope bindings has `$`-prefixed names, and a bundled application chunk has dozens of them.

Verified against esbuild 0.27.4, counting distinct module-scope bindings in a chunk:

| bindings | names starting with `$` |
| --- | --- |
| 60 | `$` |
| 500 | `$ $t $e $l $v $1 $2 $3 $4` |
| 3500 | 64 of them, including `$8` |

The regex behaviour on its own:

```js
new RegExp(`\\b$8\\b`).test('var e=$8,r=PS;')   // false — should be true
new RegExp(`\\b\\$8\\b`).test('var e=$8,r=PS;') // false — escaping alone does not help
```

Affects 1.13.0 through 1.20.7; the line is byte-identical across all of them. Vite 8 / Rolldown is
equally affected: the CJS proxy rewrite has no `isRolldown` guard, and Oxc's mangler uses the same
alphabet.

When such a check reports "unused", a still-referenced import gets rebound or deleted and its references are orphaned. The chunk builds and minifies cleanly and throws `ReferenceError: <name> is not defined` as soon as a browser evaluates it. For a remote that surfaces as the whole expose failing to load.

## What changed

Adds `isIdentifierReferenced(name, code)` — escape, then lookarounds instead of `\b` — and uses it for all three usage checks:

| Site | Effect of the bug |
| --- | --- |
| `resolveProxyAlias` (`bundleHelpers`) | Import rebound, references orphaned. Observed in production. |
| Re-export mapping in `collectSystemProxyInfos` (`bundleHelpers`) | Export mis-mapped |
| Helper import elision in `stripEmptyPreloadCalls` (`controlChunkSanitizer`) | Import statement deleted |

The latter two also interpolated the name **unescaped**, where a leading `$` is a regex end-anchor rather than a literal — a second, independent reason the same names went unmatched.

`stripEmptyPreloadCalls` additionally captured its alias with `\w+`, which skipped `$`-prefixed imports instead of processing them. That made site 3 latent rather than live. The capture and the check are widened together, because widening either alone is worse than neither: widening only the capture makes the bug reachable, and fixing only the check leaves the import unprocessed.

Also escapes the remaining raw identifier interpolations in `function <name>(` patterns, and switches those `String.replace` calls to callbacks so a `$` in the replacement is not read as a substitution pattern — the same hazard #461 fixed elsewhere.

No behaviour change for names that do not involve `$`.

## Verification

**Tests fail without the fix.** 8 in `integration/proxy-alias-deconflict.test.ts` and 1 in `src/utils/__tests__/controlChunkSanitizer.test.ts`. I confirmed this by reverting the fix inside the new helper and re-running, so the tests are pinned to the behaviour rather than merely passing alongside it.

The existing `resolveProxyAlias` tests from #461 cover `$` only in non-leading positions (`require$$0`, `commonjsGlobal$1`), which all pass under `\b`. That is why a leading `$` slipped through, so the new cases target that position specifically, plus the "genuinely unused" direction so the fix cannot be trivially satisfied by always returning `true`.

**Full suite green:** `pnpm typecheck`, `pnpm test` (49 files, 1061 passed / 1 skipped), `pnpm test:integration` (15 files, 78 passed, including real Vite builds), `pnpm fmt.check`.

**Verified end-to-end against the real failing build,** not only fixtures. Rebuilding the exact application tree that broke, with the fix reversed and then applied:

```
# fix reversed
build/assets/vendor-BQm3xKp1.js
  $8 — referenced 2x, first at 17:133828, bound nowhere in this chunk
bundle check: 1 chunk references an identifier that is never bound.

# fix applied
bundle check: 45 chunks clean
```

The two artifacts differ by one byte, in the import the plugin rewrites:

```js
// fix reversed — plugin decided $8 was unused
import{r as l,c as Zg}from"./..._commonjs-proxy-hash.js";
// fix applied — binding preserved
import{r as $8,c as Zg}from"./..._commonjs-proxy-hash.js";
```

react-dom's binding in the same chunk was `tI` and was handled correctly either way, which is the whole difference between the two.

Scope note: site 1 is verified end-to-end on that build; sites 2 and 3 and the escaping changes are covered by unit tests with verified negative controls.

Refs #460, #461, #591, #1014.
