### PR TITLE
fix: include expose static closures in federation manifests

### DIFF
--- a/integration/build.test.ts
+++ b/integration/build.test.ts
@@ -54,6 +54,16 @@ describe('build', () => {
 
       const parsed = JSON.parse(manifest!.source as string);
       expect(parsed).toHaveProperty('exposes');
+
+      const syncAssets = parsed.exposes[0].assets.js.sync;
+      const chunks = manifestOutput.output.filter((item) => item.type === 'chunk');
+      for (const virtualId of ['virtual:mf-localSharedImportMap:', 'virtual:mf-exposes:']) {
+        const bootstrapChunk = chunks.find((chunk) =>
+          chunk.moduleIds.some((id) => id.includes(virtualId))
+        );
+        expect(bootstrapChunk).toBeDefined();
+        expect(syncAssets).toContain(bootstrapChunk!.fileName);
+      }
     });
 
     it('generates mf-stats.json when manifest is enabled', async () => {

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -43,6 +43,8 @@ vi.mock('../../utils/treeShaking', () => ({
 }));
 
 vi.mock('../../virtualModules', () => ({
+  getLocalSharedImportMapPath: ({ internalName }: { internalName: string }) =>
+    `virtual:mf-localSharedImportMap:${internalName}__mf_owner__1`,
   getUsedRemotesMap,
   getUsedShares,
   getPreBuildLibImportId,
@@ -62,7 +64,11 @@ function createRenderedModule(): RenderedModule {
   };
 }
 
-function createChunk(fileName: string, moduleIds: string[], facadeModuleId: string | null = null) {
+function createChunk(
+  fileName: string,
+  moduleIds: string[],
+  facadeModuleId: string | null = null
+): OutputChunk {
   return {
     type: 'chunk',
     fileName,
@@ -185,6 +191,7 @@ async function runGenerateBundleWithManifest(
 ): Promise<Record<string, string>> {
   getNormalizeModuleFederationOptions.mockReturnValue({
     name: 'basicRemote',
+    internalName: 'basicRemote',
     filename: runtime.filename || 'remoteEntry.js',
     getPublicPath: undefined,
     varFilename: runtime.varFilename,
@@ -293,6 +300,103 @@ describe('pluginMFManifest', () => {
     expect(
       stats.buildOutput.find((chunk: { fileName: string }) => chunk.fileName === 'remoteEntry.js')
     ).toBeTruthy();
+  });
+
+  it('includes direct and wrapped container bootstrap closures in expose assets', async () => {
+    const remoteEntry = createChunk('remoteEntry.js', ['/src/remoteEntry.ts']);
+    remoteEntry.imports = ['assets/runtime.js'];
+    remoteEntry.dynamicImports = ['assets/shared-map.js'];
+
+    const runtime = createChunk('assets/runtime.js', ['/src/runtime.ts']);
+    runtime.dynamicImports = ['assets/exposes-map.js', 'assets/unrelated.js'];
+    const sharedMap = createChunk(
+      'assets/shared-map.js',
+      ['/src/generated-shared-map.ts'],
+      '\0virtual:mf-localSharedImportMap:basicRemote__mf_owner__1?commonjs-proxy'
+    );
+    sharedMap.imports = ['assets/shared-dependency.js'];
+    const exposesMap = createChunk('assets/exposes-map.js', [
+      '/@id/__x00__virtual:mf-exposes:basicRemote__remoteEntry_js?commonjs-proxy',
+    ]);
+    exposesMap.imports = ['assets/bootstrap-dependency.js'];
+    exposesMap.dynamicImports = ['assets/not-bootstrap.js'];
+
+    const bundle = {
+      'remoteEntry.js': remoteEntry,
+      'assets/runtime.js': runtime,
+      'assets/shared-map.js': sharedMap,
+      'assets/shared-dependency.js': createChunk('assets/shared-dependency.js', [
+        '/src/shared-dependency.ts',
+      ]),
+      'assets/exposes-map.js': exposesMap,
+      'assets/bootstrap-dependency.js': createChunk('assets/bootstrap-dependency.js', [
+        '/src/bootstrap-dependency.ts',
+      ]),
+      'assets/unrelated.js': createChunk(
+        'assets/unrelated.js',
+        ['/src/unrelated.ts'],
+        '\0virtual:mf-localSharedImportMap:basicRemote__mf_owner__2'
+      ),
+      'assets/not-bootstrap.js': createChunk('assets/not-bootstrap.js', ['/src/not-bootstrap.ts']),
+      'assets/exposed.js': createChunk('assets/exposed.js', ['/src/exposed.js']),
+    } satisfies OutputBundle;
+
+    const emitted = await runGenerateBundleWithManifest(true, {
+      exposePaths: { './exposed': { import: './src/exposed.js' } },
+      bundle,
+    });
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    const stats = JSON.parse(emitted['mf-stats.json']);
+    const expectedAssets = {
+      sync: [
+        'assets/runtime.js',
+        'assets/shared-map.js',
+        'assets/shared-dependency.js',
+        'assets/exposes-map.js',
+        'assets/bootstrap-dependency.js',
+        'assets/exposed.js',
+      ],
+      async: [],
+    };
+
+    expect(manifest.exposes[0].assets.js).toEqual(expectedAssets);
+    expect(stats.assetAnalysis['./src/exposed.js'].js).toEqual(expectedAssets);
+  });
+
+  it('expands expose sync and async static closures without crossing dynamic boundaries', async () => {
+    const exposed = createChunk('assets/exposed.js', ['/src/exposed.js']);
+    exposed.imports = ['assets/expose-dependency.js'];
+    exposed.dynamicImports = ['assets/lazy.js', 'assets/expose-dependency.js'];
+    const lazy = createChunk('assets/lazy.js', ['/src/lazy.ts']);
+    lazy.imports = ['assets/lazy-dependency.js'];
+    lazy.dynamicImports = ['assets/not-preloaded.js'];
+
+    const bundle = {
+      'remoteEntry.js': createChunk('remoteEntry.js', ['/src/remoteEntry.ts']),
+      'assets/exposed.js': exposed,
+      'assets/expose-dependency.js': createChunk('assets/expose-dependency.js', [
+        '/src/expose-dependency.ts',
+      ]),
+      'assets/lazy.js': lazy,
+      'assets/lazy-dependency.js': createChunk('assets/lazy-dependency.js', [
+        '/src/lazy-dependency.ts',
+      ]),
+      'assets/not-preloaded.js': createChunk('assets/not-preloaded.js', ['/src/not-preloaded.ts']),
+    } satisfies OutputBundle;
+
+    const emitted = await runGenerateBundleWithManifest(true, {
+      exposePaths: { './exposed': { import: './src/exposed.js' } },
+      bundle,
+    });
+    const manifest = JSON.parse(emitted['mf-manifest.json']);
+    const stats = JSON.parse(emitted['mf-stats.json']);
+    const expectedAssets = {
+      sync: ['assets/exposed.js', 'assets/expose-dependency.js'],
+      async: ['assets/lazy.js', 'assets/lazy-dependency.js'],
+    };
+
+    expect(manifest.exposes[0].assets.js).toEqual(expectedAssets);
+    expect(stats.assetAnalysis['./src/exposed.js'].js).toEqual(expectedAssets);
   });
 
   it('isolates manifest usage and shares across plugin instances', async () => {

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils/normalizeModuleFederationOptions';
 import { getTreeShakingExportUsage } from '../utils/treeShaking';
 import {
+  getLocalSharedImportMapPath,
   getUsedRemotesMap,
   getUsedShares,
   TREE_SHAKING_GRAPH_QUERY,
@@ -19,14 +20,19 @@ import {
   addCssAssetsToAllExports,
   buildFileToShareKeyMap,
   collectCssAssets,
+  collectStaticChunks,
   createEmptyAssetMap,
   deduplicateAssets,
+  type OutputBundleItem,
+  type OutputChunkWithViteMetadata,
   type PreloadMap,
   processModuleAssets,
 } from '../utils/cssModuleHelpers';
 import { resolvePublicPath } from '../utils/pathNormalization';
 import { normalizePathForImport } from '../utils/buildPaths';
 import { DEFAULT_PUBLIC_TYPES_FOLDER } from '../utils/dtsConstants';
+import { normalizeVirtualModuleId } from '../utils/VirtualModule';
+import { getVirtualExposesId } from '../virtualModules/virtualExposes';
 import { getSsrRemoteEntryFileName } from '../virtualModules/virtualRemoteEntrySSR';
 
 /**
@@ -95,6 +101,78 @@ function isTreeShakingProviderChunk(file: Record<string, any>) {
   return Object.keys(file.modules || {}).some(
     (id) => id.includes(TREE_SHAKING_PROVIDER_TAG) || id.includes(TREE_SHAKING_GRAPH_QUERY)
   );
+}
+
+function isContainerBootstrapChunk(
+  chunk: OutputChunkWithViteMetadata,
+  moduleIds: Set<string>
+): boolean {
+  return [chunk.facadeModuleId, ...(chunk.moduleIds ?? [])].some(
+    (id) => typeof id === 'string' && moduleIds.has(normalizeVirtualModuleId(id))
+  );
+}
+
+function expandExposeAssets(
+  filesMap: PreloadMap,
+  exposeModules: string[],
+  bundle: Record<string, OutputBundleItem>,
+  remoteEntryFileName: string | undefined,
+  options: NormalizedModuleFederationOptions
+): void {
+  if (exposeModules.length === 0) return;
+
+  const containerChunks = remoteEntryFileName
+    ? collectStaticChunks(bundle, [remoteEntryFileName])
+    : [];
+  const bootstrapAssets = containerChunks.slice(1).map((chunk) => chunk.fileName);
+  const seen = new Set(containerChunks.map((chunk) => chunk.fileName));
+
+  if (containerChunks.length > 0) {
+    const bootstrapModuleIds = new Set([
+      getLocalSharedImportMapPath(options),
+      getVirtualExposesId(options),
+    ]);
+
+    // Vite 8 can place the container implementation behind a static wrapper.
+    for (const containerChunk of containerChunks) {
+      for (const imported of containerChunk.dynamicImports ?? []) {
+        const importedChunk = bundle[imported];
+        if (
+          !importedChunk ||
+          importedChunk.type !== 'chunk' ||
+          !isContainerBootstrapChunk(importedChunk, bootstrapModuleIds)
+        ) {
+          continue;
+        }
+
+        // These dynamic chunks are init/get prerequisites, but their dynamic imports are not.
+        for (const chunk of collectStaticChunks(bundle, [imported])) {
+          if (seen.has(chunk.fileName)) continue;
+          seen.add(chunk.fileName);
+          bootstrapAssets.push(chunk.fileName);
+        }
+      }
+    }
+  }
+
+  for (const exposeModule of exposeModules) {
+    const assets = filesMap[exposeModule];
+    if (!assets) continue;
+
+    const sync = Array.from(
+      new Set([
+        ...bootstrapAssets,
+        ...collectStaticChunks(bundle, assets.js.sync).map((chunk) => chunk.fileName),
+      ])
+    );
+    const syncSet = new Set(sync);
+    const async = collectStaticChunks(bundle, assets.js.async)
+      .map((chunk) => chunk.fileName)
+      .filter((fileName) => !syncSet.has(fileName));
+
+    assets.js.sync = sync;
+    assets.js.async = async;
+  }
 }
 
 function getTreeShakingBuildInfo(options: ReturnType<typeof getNormalizeModuleFederationOptions>) {
@@ -352,6 +430,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
             },
             { root, stripKnownJsExtensions: true }
           );
+          expandExposeAssets(filesMap, exposesModules, bundle, foundRemoteEntryFile, mfOptions);
 
           // Process shared modules
           const fileToShareKey = await buildFileToShareKeyMap(

--- a/src/utils/cssModuleHelpers.ts
+++ b/src/utils/cssModuleHelpers.ts
@@ -131,6 +131,28 @@ type ChunkAssetAnalysis = {
   dynamicAssets: Array<{ fileName: string; type: AssetType }>;
 };
 
+export const collectStaticChunks = (
+  bundle: Record<string, OutputBundleItem>,
+  roots: string[]
+): OutputChunkWithViteMetadata[] => {
+  const chunks: OutputChunkWithViteMetadata[] = [];
+  const visited = new Set<string>();
+  const queue = [...roots];
+
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+    const fileName = queue[queueIndex];
+    if (visited.has(fileName)) continue;
+    visited.add(fileName);
+
+    const chunk = bundle[fileName];
+    if (!chunk || chunk.type !== 'chunk') continue;
+    chunks.push(chunk);
+    queue.push(...(chunk.imports ?? []));
+  }
+
+  return chunks;
+};
+
 /**
  * Analyzes assets associated with a chunk without mutating the output map.
  * The static-import traversal is cycle-safe and ignores missing bundle entries.
@@ -141,27 +163,13 @@ const analyzeChunkAssets = (
   chunk: OutputChunkWithViteMetadata
 ): ChunkAssetAnalysis => {
   const dynamicAssets: ChunkAssetAnalysis['dynamicAssets'] = [];
-  const visited = new Set<string>();
-  const queue: string[] = [fileName];
-
-  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
-    const currentFileName = queue[queueIndex];
-    if (visited.has(currentFileName)) continue;
-    visited.add(currentFileName);
-
-    const currentChunk = bundle[currentFileName];
-    if (!currentChunk || currentChunk.type !== 'chunk') continue;
-
+  for (const currentChunk of collectStaticChunks(bundle, [fileName])) {
     for (const dynamicImport of currentChunk.dynamicImports ?? []) {
       if (!bundle[dynamicImport]) continue;
       dynamicAssets.push({
         fileName: dynamicImport,
         type: isCSSFile(dynamicImport) ? 'css' : 'js',
       });
-    }
-
-    for (const staticImport of currentChunk.imports ?? []) {
-      queue.push(staticImport);
     }
   }
 


### PR DESCRIPTION
## Summary

Include the complete static JavaScript closure required to evaluate exposed modules in federation manifest assets.

The manifest previously recorded only the expose root chunk, omitting its static dependencies and the container bootstrap chunks required by `init`/`get`.

## Changes

- reuse the existing cycle-safe static chunk traversal
- add container bootstrap dependencies and expose static closures to `assets.js.sync`
- expand async roots through static imports without crossing nested dynamic boundaries, with `sync` taking precedence
- support Vite 5–7 direct containers and the Vite 8 static-wrapper topology using scoped virtual module IDs

Shared/CSS analysis, development, SSR, and `disableAssetsAnalyze` behavior remain unchanged.

## Verification

- `pnpm test`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm build`
- emitted bundle graphs verified with Vite 5.4.21, 6.4.3, 7.3.6, and 8.2.0