### PR TITLE
fix: detect minified Webpack shared providers

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2881,8 +2881,10 @@ describe('virtualRemoteEntry', () => {
     const webpackGet = new Function(
       'return function webpackGet() { return __webpack_require__("react"); };'
     )();
+    const minifiedWebpackGet = new Function('return ()=>i.e(796).then((()=>()=>i(796)))')();
 
     expect(isWebpackProvider({ get: webpackGet })).toBe(true);
+    expect(isWebpackProvider({ get: minifiedWebpackGet })).toBe(true);
     expect(isWebpackProvider({ get: () => Promise.resolve(() => ({})) })).toBe(false);
     expect(isWebpackProvider({})).toBe(false);
     expect(code).toContain('const isWebpackScope = !scopeRoot &&');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1261,7 +1261,12 @@ export function generateRemoteEntry(
     function isWebpackProvider(provider) {
       if (typeof provider?.get !== 'function') return false;
       const source = Function.prototype.toString.call(provider.get);
-      return source.includes('__webpack_require__');
+      // Production minification renames __webpack_require__, but preserves
+      // Webpack's lazy chunk-loading .e(...).then(...) shape.
+      return (
+        source.includes('__webpack_require__') ||
+        /\\.\\s*e\\s*\\([^)]*\\)\\s*\\.then\\s*\\(/.test(source)
+      );
     }
     const __mfUsesWebpackShareScope = Object.values(initialShared).some((versions) =>
       Object.values(versions || {}).some(isWebpackProvider)


### PR DESCRIPTION
## Summary

Fixes an issue where `isWebpackProvider` incorrectly classified minified Webpack shared providers as non-Webpack providers.

## Related Issue

Fixes #1097 

## Background

Webpack shared providers can expose a lazy `get()` function. In production builds, Webpack may minify the internal `__webpack_require__` identifier. For example:

```js
() => i.e(796).then(() => () => i(796));
```

The previous implementation only looked for the `__webpack_require__` string. As a result, this minified provider was not deferred by the Webpack-specific provider guards. The Vite consumer could then continue with an unresolved provider and observe an undefined shared library at runtime.

## Root Cause

`isWebpackProvider` inferred the provider type from an unminified function identifier:

```js
source.includes("__webpack_require__");
```

That identifier is not preserved by production minification, while Webpack's lazy chunk-loading shape remains recognizable as `.e(...).then(...)`.

## Changes

- Recognize the minified Webpack lazy chunk-loading pattern `.e(...).then(...)`.
- Add a regression test using the exact minified getter reported in the issue.

## Verification

The following checks pass:

- `pnpm test` — 49 test files, 1065 tests passed
- `pnpm test:integration` — 15 test files, 78 tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm fmt.check`
