### PR TITLE
fix: `loaded-first` static remote evaluation

### DIFF
--- a/integration/fixtures/basic-remote/exposed-module.js
+++ b/integration/fixtures/basic-remote/exposed-module.js
@@ -1,3 +1,5 @@
+export const REMOTE_NAME = 'remoteApp';
+
 export function greet(name) {
   return `Hello, ${name}!`;
 }

--- a/integration/fixtures/loaded-first-namespace-host/entry.js
+++ b/integration/fixtures/loaded-first-namespace-host/entry.js
@@ -1,0 +1,5 @@
+import * as remoteUtil from 'remote1/Module';
+
+export const name = remoteUtil.REMOTE_NAME;
+document.querySelector('#app').textContent = name;
+console.log('__mf_host_entry_evaluated__');

--- a/integration/fixtures/loaded-first-namespace-host/index.html
+++ b/integration/fixtures/loaded-first-namespace-host/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./entry.js"></script>
+  </body>
+</html>

--- a/integration/fixtures/loaded-first-static-host/entry.js
+++ b/integration/fixtures/loaded-first-static-host/entry.js
@@ -1,0 +1,5 @@
+import { REMOTE_NAME } from 'remote1/Module';
+
+export const name = REMOTE_NAME;
+document.querySelector('#app').textContent = name;
+console.log('__mf_host_entry_evaluated__');

--- a/integration/fixtures/loaded-first-static-host/index.html
+++ b/integration/fixtures/loaded-first-static-host/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./entry.js"></script>
+  </body>
+</html>

--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -18,6 +18,12 @@ const HOST_BASE_MF_OPTIONS = {
   dts: false,
 } satisfies Partial<ModuleFederationOptions>;
 
+const LOADED_FIRST_STATIC_MF_OPTIONS = {
+  ...HOST_BASE_MF_OPTIONS,
+  shareStrategy: 'loaded-first',
+  hostInitInjectLocation: 'html',
+} satisfies Partial<ModuleFederationOptions>;
+
 const hostInitChunkRegex = /<script\s+type="module"\s+src="[^"]*hostInit[^"]*">/;
 const bootstrapScriptRegex = /<script\s+type="module"[^>]+src="[^"]*mf-entry-bootstrap[^"]*">/;
 
@@ -33,6 +39,48 @@ async function createWorkspaceFixture() {
 }
 
 describe('host build', () => {
+  it.each([
+    ['named', 'loaded-first-static-host'],
+    ['namespace', 'loaded-first-namespace-host'],
+  ])('preloads %s static remotes before a loaded-first host entry', async (_kind, fixture) => {
+    const output = await buildFixture({
+      fixture,
+      mfOptions: LOADED_FIRST_STATIC_MF_OPTIONS,
+    });
+
+    const bootstrapAsset = output.output.find(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+    expect(bootstrapAsset).toBeDefined();
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+    const preloadIndex = bootstrapCode.indexOf('__mfPreloadRemote("');
+    const entryImportIndex = bootstrapCode.indexOf('})().then(() =>');
+
+    expect(preloadIndex).toBeGreaterThanOrEqual(0);
+    expect(bootstrapCode).toContain('"remote1/Module"');
+    expect(bootstrapCode).toContain('await Promise.all(__mfRemotePreloads);');
+    expect(bootstrapCode).not.toContain('Promise.allSettled(__mfRemotePreloads)');
+    expect(bootstrapCode).toContain('runtime.registerRemotes([registration]);');
+    expect(preloadIndex).toBeLessThan(entryImportIndex);
+    expect(bootstrapCode).not.toMatch(/^await /m);
+  });
+
+  it('keeps dynamic-only remotes lazy with loaded-first', async () => {
+    const output = await buildFixture({
+      fixture: 'basic-host',
+      mfOptions: LOADED_FIRST_STATIC_MF_OPTIONS,
+    });
+    const bootstrapAsset = output.output.find(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+
+    expect(bootstrapAsset).toBeDefined();
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+    expect(bootstrapCode).not.toContain('__mfPreloadRemote');
+    expect(bootstrapCode).not.toContain('Promise.all(__mfRemotePreloads)');
+    expect(bootstrapCode).toContain('await initHost();');
+  });
+
   it('transforms remote module imports into federation loadRemote() calls', async () => {
     const output = await buildFixture({
       fixture: 'basic-host',

--- a/integration/loaded-first-static-browser.test.ts
+++ b/integration/loaded-first-static-browser.test.ts
@@ -83,7 +83,9 @@ async function createBrowser() {
 const remoteOptions = {
   name: 'remoteApp',
   filename: 'remoteEntry.js',
-  exposes: { './Module': './exposed-module.js' },
+  exposes: {
+    './Module': path.resolve(FIXTURES, 'basic-remote', 'exposed-module.js'),
+  },
   dts: false,
 } satisfies Parameters<typeof federation>[0];
 

--- a/integration/loaded-first-static-browser.test.ts
+++ b/integration/loaded-first-static-browser.test.ts
@@ -1,0 +1,239 @@
+import { chromium } from '@playwright/test';
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { federation } from '../src';
+import { FIXTURES } from './helpers/build';
+
+type StaticServer = {
+  origin: string;
+  close: () => Promise<void>;
+};
+
+async function serveDirectory(root: string): Promise<StaticServer> {
+  const server = createServer(async (request, response) => {
+    const pathname = decodeURIComponent(new URL(request.url ?? '/', 'http://localhost').pathname);
+    const relativePath = pathname === '/' ? 'index.html' : pathname.replace(/^\//, '');
+    const filePath = path.resolve(root, relativePath);
+
+    if (filePath !== root && !filePath.startsWith(`${root}${path.sep}`)) {
+      response.writeHead(403).end();
+      return;
+    }
+
+    try {
+      const content = await readFile(filePath);
+      const contentType = filePath.endsWith('.html')
+        ? 'text/html'
+        : filePath.endsWith('.js')
+          ? 'application/javascript'
+          : 'application/octet-stream';
+      response.writeHead(200, {
+        'access-control-allow-origin': '*',
+        'content-type': contentType,
+      });
+      response.end(content);
+    } catch {
+      response.writeHead(404).end();
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Static server did not bind');
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function buildFixtureTo(
+  fixture: string,
+  outDir: string,
+  mfOptions: Parameters<typeof federation>[0]
+): Promise<void> {
+  const result = await build({
+    root: path.resolve(FIXTURES, fixture),
+    logLevel: 'silent',
+    build: {
+      outDir,
+      emptyOutDir: true,
+      target: 'chrome91',
+    },
+    plugins: [federation(mfOptions)],
+  });
+
+  if (Array.isArray(result)) throw new Error('Expected a single Rollup output');
+}
+
+async function createBrowser() {
+  return chromium.launch({ channel: 'chrome', headless: true });
+}
+
+const remoteOptions = {
+  name: 'remoteApp',
+  filename: 'remoteEntry.js',
+  exposes: { './Module': './exposed-module.js' },
+  dts: false,
+} satisfies Parameters<typeof federation>[0];
+
+function hostOptions(remoteEntry: string) {
+  return {
+    name: 'hostApp',
+    filename: 'remoteEntry.js',
+    remotes: {
+      remote1: {
+        name: 'remote1',
+        entry: remoteEntry,
+        type: 'module',
+      },
+    },
+    shareStrategy: 'loaded-first',
+    hostInitInjectLocation: 'html',
+    dts: false,
+  } satisfies Parameters<typeof federation>[0];
+}
+
+describe('loaded-first static remote browser bootstrap', () => {
+  it.each([
+    ['named', 'loaded-first-static-host'],
+    ['namespace', 'loaded-first-namespace-host'],
+  ])(
+    'evaluates %s static imports after the remote is ready',
+    async (_kind, fixture) => {
+      const workspace = await mkdtemp(path.join(tmpdir(), 'mf-loaded-first-browser-'));
+      let remoteServer: StaticServer | undefined;
+      let hostServer: StaticServer | undefined;
+      let browser: Awaited<ReturnType<typeof createBrowser>> | undefined;
+
+      try {
+        const remoteOutDir = path.join(workspace, 'remote');
+        const hostOutDir = path.join(workspace, 'host');
+        await buildFixtureTo('basic-remote', remoteOutDir, remoteOptions);
+        remoteServer = await serveDirectory(remoteOutDir);
+        await buildFixtureTo(
+          fixture,
+          hostOutDir,
+          hostOptions(`${remoteServer.origin}/remoteEntry.js`)
+        );
+        hostServer = await serveDirectory(hostOutDir);
+
+        browser = await createBrowser();
+        const page = await browser.newPage();
+        const pageErrors: string[] = [];
+        const consoleErrors: string[] = [];
+        const requests: string[] = [];
+        const events: string[] = [];
+        await page.addInitScript(() => {
+          (window as typeof window & { __mfUnhandled?: string[] }).__mfUnhandled = [];
+          window.addEventListener('unhandledrejection', (event) => {
+            const target = window as typeof window & { __mfUnhandled: string[] };
+            target.__mfUnhandled.push(String(event.reason));
+          });
+        });
+        page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+        page.on('console', (message) => {
+          if (message.type() === 'error') consoleErrors.push(message.text());
+          if (message.text() === '__mf_host_entry_evaluated__') events.push('host-entry');
+        });
+        page.on('request', (request) => requests.push(request.url()));
+        page.on('response', (response) => {
+          if (response.url() === `${remoteServer!.origin}/remoteEntry.js`) {
+            events.push('remote-response');
+          }
+        });
+
+        await page.goto(hostServer.origin, { waitUntil: 'domcontentloaded' });
+        try {
+          await page.waitForFunction(
+            () => document.querySelector('#app')?.textContent === 'remoteApp',
+            undefined,
+            { timeout: 15_000 }
+          );
+        } catch (error) {
+          throw new Error(
+            JSON.stringify(
+              {
+                cause: String(error),
+                pageErrors,
+                consoleErrors,
+                requests,
+                events,
+                content: await page.content(),
+              },
+              null,
+              2
+            )
+          );
+        }
+        expect(await page.locator('#app').textContent()).toBe('remoteApp');
+
+        expect(events.indexOf('remote-response')).toBeGreaterThanOrEqual(0);
+        expect(events.indexOf('host-entry')).toBeGreaterThanOrEqual(0);
+        expect(events.indexOf('remote-response')).toBeLessThan(events.indexOf('host-entry'));
+        expect(pageErrors).toEqual([]);
+        await expect(page.evaluate(() => (window as any).__mfUnhandled)).resolves.toEqual([]);
+      } finally {
+        await browser?.close();
+        await hostServer?.close();
+        await remoteServer?.close();
+        await rm(workspace, { recursive: true, force: true });
+      }
+    },
+    60_000
+  );
+
+  it('does not evaluate the host entry when a static remote fails', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'mf-loaded-first-browser-failure-'));
+    let remoteServer: StaticServer | undefined;
+    let hostServer: StaticServer | undefined;
+    let browser: Awaited<ReturnType<typeof createBrowser>> | undefined;
+
+    try {
+      const remoteOutDir = path.join(workspace, 'remote');
+      const hostOutDir = path.join(workspace, 'host');
+      await buildFixtureTo('basic-remote', remoteOutDir, remoteOptions);
+      remoteServer = await serveDirectory(remoteOutDir);
+      const remoteEntry = `${remoteServer.origin}/remoteEntry.js`;
+      await remoteServer.close();
+      remoteServer = undefined;
+
+      await buildFixtureTo('loaded-first-static-host', hostOutDir, hostOptions(remoteEntry));
+      hostServer = await serveDirectory(hostOutDir);
+      browser = await createBrowser();
+      const page = await browser.newPage();
+      const pageErrors: string[] = [];
+      await page.addInitScript(() => {
+        (window as typeof window & { __mfUnhandled?: string[] }).__mfUnhandled = [];
+        window.addEventListener('unhandledrejection', (event) => {
+          const target = window as typeof window & { __mfUnhandled: string[] };
+          target.__mfUnhandled.push(String(event.reason));
+        });
+      });
+      page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+
+      await page.goto(hostServer.origin, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(500);
+
+      expect(await page.locator('#app').textContent()).toBe('');
+      const unhandled = await page.evaluate(() => (window as any).__mfUnhandled as string[]);
+      expect([...pageErrors, ...unhandled].join('\n')).toMatch(
+        /Failed to load script resources|RUNTIME-008/
+      );
+    } finally {
+      await browser?.close();
+      await hostServer?.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -80,7 +80,7 @@ import {
   getResolvedLocalSharedImportMapId,
   getUsedShares,
 } from '../virtualModules/virtualRemoteEntry';
-import { getUsedRemotesMap } from '../virtualModules/virtualRemotes';
+import { getStaticRemotes, getUsedRemotesMap } from '../virtualModules/virtualRemotes';
 import { virtualRuntimeInitStatus } from '../virtualModules/virtualRuntimeInitStatus';
 
 const REACT_EXAMPLE_ROOT = path.join(process.cwd(), 'examples/vite-vite/vite-host');
@@ -1230,6 +1230,62 @@ describe('vite:module-federation-early-init', () => {
 
       expect([...getUsedRemotesMap(owner._options).modules]).toContain('modules/authSlice');
       expect([...getUsedRemotesMap(owner._options).modules]).not.toContain('modules/lazy');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('scans only the configured client entry and ignores type-only or textual imports', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-entry-static-build-'));
+    const entry = path.join(root, 'src/entry.ts');
+    mkdirSync(path.dirname(entry), { recursive: true });
+    writeFileSync(
+      path.join(root, 'index.html'),
+      '<script type="module" src="/src/unused.ts"></script>'
+    );
+    writeFileSync(path.join(root, 'src/unused.ts'), 'import "remote/only-in-index-html";');
+    writeFileSync(
+      entry,
+      [
+        '// import "remote/comment";',
+        'const text = "import \'remote/string\'";',
+        'import type { RemoteType } from "remote/type";',
+        'import "remote/runtime";',
+        'const lazy = require("remote/commonjs");',
+      ].join('\n')
+    );
+
+    try {
+      const plugins = federation({
+        name: 'entry-static-build',
+        remotes: {
+          remote: {
+            name: 'remote',
+            type: 'module',
+            entry: '/modules/assets/remoteEntry.js',
+          },
+        },
+      }) as Plugin[];
+      const early = plugins.find((plugin) => plugin.name === 'vite:module-federation-early-init');
+      const owner = plugins.find((plugin) => plugin.name === 'module-federation-vite') as
+        | (Plugin & { _options: NormalizedModuleFederationOptions })
+        | undefined;
+      if (!early || !owner) throw new Error('module federation plugins not found');
+
+      runConfig(
+        early,
+        { meta: {} } as ConfigPluginContext,
+        {
+          root,
+          build: { rollupOptions: { input: entry } },
+        } as UserConfig,
+        {
+          command: 'build',
+          mode: 'production',
+        }
+      );
+
+      expect(getStaticRemotes(owner._options)).toEqual(new Set(['remote/runtime']));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'url';
 import type { ConfigEnv, EnvironmentOptions, Plugin, ResolvedConfig, UserConfig } from 'vite';
 import { version as viteVersion } from 'vite';
-import addEntry from './plugins/pluginAddEntry';
+import addEntry, { getBuildInput } from './plugins/pluginAddEntry';
 import { checkAliasConflicts } from './plugins/pluginCheckAliasConflicts';
 import pluginDevRemoteHmr, { shouldIgnoreFile } from './plugins/pluginDevRemoteHmr';
 import pluginExternalRuntimeCore from './plugins/pluginExternalRuntimeCore';
@@ -70,6 +70,7 @@ import {
   isAssetLikeImport,
   isViteOptimizableEntry,
 } from './utils/pathNormalization';
+import { findModuleImportDescriptors } from './utils/htmlEntryUtils';
 import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualModule';
 import {
   getHostAutoInitPath,
@@ -91,7 +92,7 @@ import {
   isOwnedHostAutoInitId,
   refreshHostAutoInit,
 } from './virtualModules/virtualRemoteEntry';
-import { addUsedRemote } from './virtualModules/virtualRemotes';
+import { addUsedRemote, markStaticRemote } from './virtualModules/virtualRemotes';
 import { getRuntimeInitStatusImportId } from './virtualModules/virtualRuntimeInitStatus';
 import {
   findCurrentLoadShareForStaleOwnerId,
@@ -443,10 +444,10 @@ function isFile(candidate: string): boolean {
 
 function registerEntryImports(
   options: NormalizedModuleFederationOptions,
-  projectRoot: string
+  projectRoot: string,
+  recordShared = true,
+  entryFiles: string[] = []
 ): void {
-  const staticImport = /\b(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s*)?(['"])([^'"]+)\1/g;
-  const dynamicImport = /\b(?:import|require)\s*\(\s*(['"])([^'"]+)\1/g;
   const sourceExtensions = ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.vue', '.svelte'];
   const root = path.resolve(projectRoot);
   const pending: Array<{ file: string; preloadRemotes: boolean }> = [];
@@ -479,12 +480,29 @@ function registerEntryImports(
     }
   };
 
-  const htmlEntry = path.join(root, 'index.html');
-  if (existsSync(htmlEntry)) {
-    const html = readFileSync(htmlEntry, 'utf8');
-    for (const match of html.matchAll(/<script\b[^>]*\bsrc=(['"])([^'"]+)\1[^>]*>/gi)) {
-      enqueue(match[2], htmlEntry, true);
+  const htmlEntries = entryFiles.filter((file) => file.endsWith('.html'));
+  const htmlEntryPaths = htmlEntries.length
+    ? htmlEntries
+    : entryFiles.length === 0
+      ? [path.join(root, 'index.html')]
+      : [];
+  for (const htmlEntry of htmlEntryPaths) {
+    if (existsSync(htmlEntry)) {
+      const html = readFileSync(htmlEntry, 'utf8');
+      for (const match of html.matchAll(
+        /<script\b(?=[^>]*\btype=["']module["'])(?=[^>]*\bsrc=(['"])([^'"]+)\1)[^>]*>/gi
+      )) {
+        enqueue(match[2], htmlEntry, true);
+      }
     }
+  }
+  for (const entry of entryFiles.filter((file) => !file.endsWith('.html'))) {
+    const relativeEntry = path.relative(root, entry);
+    enqueue(
+      relativeEntry.startsWith('.') ? relativeEntry : `./${relativeEntry}`,
+      path.join(root, 'index.html'),
+      true
+    );
   }
   for (const expose of Object.values(options.exposes ?? {})) {
     enqueue(expose.import);
@@ -495,25 +513,22 @@ function registerEntryImports(
     if (visited.get(file) || (visited.has(file) && !preloadRemotes)) continue;
     visited.set(file, preloadRemotes);
     const code = readFileSync(file, 'utf8');
-    for (const pattern of [staticImport, dynamicImport]) {
-      const isStatic = pattern === staticImport;
-      pattern.lastIndex = 0;
-      for (const match of code.matchAll(pattern)) {
-        const request = match[2];
-        const remoteKey =
-          preloadRemotes && isStatic && request
-            ? Object.keys(options.remotes).find(
-                (name) => request === name || request.startsWith(`${name}/`)
-              )
-            : undefined;
-        const sharedKey = request && findSharedKey(request, options.shared);
-        if (remoteKey) {
-          addUsedRemote(remoteKey, request, options);
-        } else if (sharedKey) {
-          addUsedShares(request, options);
-        } else if (request) {
-          enqueue(request, file, preloadRemotes && isStatic);
-        }
+    for (const { source: request, kind, typeOnly } of findModuleImportDescriptors(code)) {
+      const isStatic = kind === 'static' && !typeOnly;
+      const remoteKey =
+        preloadRemotes && isStatic && request
+          ? Object.keys(options.remotes).find(
+              (name) => request === name || request.startsWith(`${name}/`)
+            )
+          : undefined;
+      const sharedKey = !typeOnly && request && findSharedKey(request, options.shared);
+      if (remoteKey) {
+        addUsedRemote(remoteKey, request, options);
+        markStaticRemote(request, options);
+      } else if (sharedKey && recordShared) {
+        addUsedShares(request, options);
+      } else if (request && !typeOnly) {
+        enqueue(request, file, preloadRemotes && isStatic);
       }
     }
   }
@@ -534,6 +549,20 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
       if (_command === 'serve') ignoreFederationGeneratedFiles(config, options);
 
       const root = config.root || process.cwd();
+      const buildInput = getBuildInput(config);
+      const configuredEntryFiles =
+        typeof buildInput === 'string'
+          ? [buildInput]
+          : Array.isArray(buildInput)
+            ? buildInput
+            : buildInput && typeof buildInput === 'object'
+              ? Object.values(buildInput)
+              : [];
+      const resolvedConfiguredEntryFiles = configuredEntryFiles
+        .map((entry) => String(entry))
+        .filter((entry) => !/[?&]__react-router-build-client-route(?:[=&]|$)/.test(entry))
+        .map((entry) => entry.split(/[?#]/)[0])
+        .map((entry) => (path.isAbsolute(entry) ? entry : path.resolve(root, entry)));
       resetConcreteSharedImportSourceCache();
       setPackageDetectionCwd(root);
       const isVinext = hasPackageDependency('vinext');
@@ -565,10 +594,14 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
       }
 
       if (
-        _command === 'serve' &&
+        !config.build?.ssr &&
         (Object.keys(shared ?? {}).length > 0 || Object.keys(remotes ?? {}).length > 0)
       ) {
-        registerEntryImports(options, root);
+        // The static remote registry is also needed by the production host
+        // bootstrap. Keep share/optimize-deps discovery serve-only, but scan
+        // the same client entry graph during build so the bootstrap can wait
+        // for only the remotes imported synchronously by that graph.
+        registerEntryImports(options, root, _command === 'serve', resolvedConfiguredEntryFiles);
       }
 
       // Create shared module virtual files EARLY and register shares eagerly

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -19,6 +19,7 @@ const mockHasPackageDependency = vi.hoisted(() => vi.fn((_pkg: string) => true))
 
 vi.mock('../../utils/packageUtils', () => ({
   hasPackageDependency: mockHasPackageDependency,
+  packageNameEncode: (name: string) => name,
 }));
 
 const mockMfOptions = vi.hoisted(() => ({
@@ -42,7 +43,12 @@ vi.mock('../../utils/normalizeModuleFederationOptions', async () => {
 });
 
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
-import { addUsedRemote, getUsedRemotesMap } from '../../virtualModules/virtualRemotes';
+import {
+  addUsedRemote,
+  getUsedRemotesMap,
+  markDynamicRemote,
+  markStaticRemote,
+} from '../../virtualModules/virtualRemotes';
 import addEntry from '../pluginAddEntry';
 
 type AddEntryPlugin = ReturnType<typeof addEntry>[number];
@@ -1014,6 +1020,102 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('__mfRemotePreloads');
     expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain('})().then(() => import("/src/main.ts?mf-entry-bootstrap"));');
+  });
+
+  it('preloads static remotes before a loaded-first production host entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-loaded-first-build-'));
+    const federationOptions = {
+      internalName: 'host',
+      name: 'host',
+      shareStrategy: 'loaded-first',
+      shared: {},
+      remotes: {
+        employees: {
+          entry: 'http://localhost:4174/remoteEntry.js',
+          entryGlobalName: 'employees',
+          name: 'employees',
+          type: 'module',
+          shareScope: 'default',
+        },
+      },
+    } as any;
+    markStaticRemote('employees/staff', federationOptions);
+    markDynamicRemote('employees/lazy', federationOptions);
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+      federationOptions,
+    });
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'build', mode: 'production' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: { input: '/src/main.ts' } },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(buildPlugin, 'export const app = true;', '/src/main.ts')) as
+      | { code: string }
+      | undefined;
+
+    expect(result?.code).toContain('__mfPreloadRemote(');
+    expect(result?.code).toContain('employees/staff');
+    expect(result?.code).not.toContain('employees/lazy');
+    expect(result?.code).toContain('await Promise.all(__mfRemotePreloads);');
+    expect(result?.code).not.toContain('Promise.allSettled(__mfRemotePreloads)');
+    expect(result?.code).toContain('runtime.registerRemotes([registration]);');
+    expect(result?.code).toContain('throw error;');
+    expect(result?.code).toContain('})().then(() => import(');
+  });
+
+  it('does not preload a dynamic-only remote in a loaded-first production host entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-loaded-first-dynamic-'));
+    const federationOptions = {
+      internalName: 'host',
+      name: 'host',
+      shareStrategy: 'loaded-first',
+      shared: {},
+      remotes: {
+        employees: {
+          entry: 'http://localhost:4174/remoteEntry.js',
+          entryGlobalName: 'employees',
+          name: 'employees',
+          type: 'module',
+          shareScope: 'default',
+        },
+      },
+    } as any;
+    markDynamicRemote('employees/lazy', federationOptions);
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+      federationOptions,
+    });
+    const buildPlugin = plugins[1];
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: { input: '/src/main.ts' } },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(buildPlugin, 'export const app = true;', '/src/main.ts')) as
+      | { code: string }
+      | undefined;
+
+    expect(result?.code).not.toContain('__mfPreloadRemote');
+    expect(result?.code).toContain('await initHost();');
   });
 
   it('rewrites dev html entry scripts to external proxy modules instead of inline scripts', async () => {

--- a/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
+++ b/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../utils/packageUtils', () => ({
 }));
 
 import { pluginRemoteNamedExports } from '../pluginRemoteNamedExports';
+import { getStaticRemotes } from '../../virtualModules/virtualRemotes';
 
 const OPTIONS = {
   remotes: {
@@ -349,6 +350,28 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toBeUndefined();
+    });
+
+    it('does not record type-only or textual imports as static remotes', async () => {
+      const options = {
+        ...OPTIONS,
+        remotes: {
+          ...OPTIONS.remotes,
+        },
+      } as any;
+      await transform(
+        [
+          '// import { ignored } from "remoteApp/comment";',
+          'const text = "import { ignored } from \\"remoteApp/string\\"";',
+          'import type { Foo } from "remoteApp/type";',
+          'import { foo } from "remoteApp/runtime";',
+        ].join('\n'),
+        '/src/app.tsx',
+        false,
+        options
+      );
+
+      expect(getStaticRemotes(options)).toEqual(new Set(['remoteApp/runtime']));
     });
 
     it('skips default-only import via fallback', async () => {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -23,7 +23,9 @@ import {
 } from '../utils/VirtualModule';
 import {
   addUsedRemote,
+  getRemoteRegistration,
   getRuntimeRemoteId,
+  getStaticRemotes,
   getUsedRemotesMap,
   isDynamicOnlyRemote,
 } from '../virtualModules/virtualRemotes';
@@ -301,42 +303,60 @@ const __mfCurrentScript = document.currentScript;
       ? 'import(/* @vite-ignore */ __mfEntryUrl)'
       : importExpression(entrySrc);
 
-    // Eagerly preloading remotes mirrors the federation runtime's own
-    // `version-first` behaviour, where `ShareHandler.initializeSharing()` loads
-    // every remote entry during startup. With `loaded-first` the runtime defers
-    // remote loading until a module is actually requested, so the host must NOT
-    // preload — otherwise an offline remote would block host bootstrap even
-    // though the user explicitly opted into the on-demand strategy.
+    const normalizedOptions = federationOptions ?? getNormalizeModuleFederationOptions();
+    const isLoadedFirstClientBuild =
+      (_command === 'build' || viteConfig?.command === 'build') &&
+      waitsForInit &&
+      !viteConfig?.build?.ssr &&
+      normalizedOptions.shareStrategy === 'loaded-first';
+
+    // `version-first` eagerly loads every used remote, while `loaded-first`
+    // normally defers loading until an export is read. A static ESM import is
+    // different: its namespace must be ready before the importing entry is
+    // evaluated. Preload only those statically imported remotes in the client
+    // production host bootstrap so dynamic-only remotes remain on-demand.
     const shouldPreloadRemotes =
       !options?.skipRemotePreload &&
-      (federationOptions ?? getNormalizeModuleFederationOptions())?.shareStrategy !==
-        'loaded-first';
+      (normalizedOptions.shareStrategy !== 'loaded-first' || isLoadedFirstClientBuild);
+
+    const remoteSources = isLoadedFirstClientBuild
+      ? Array.from(getStaticRemotes(normalizedOptions))
+      : Object.entries(getUsedRemotesMap(federationOptions))
+          .flatMap(([, remotes]) => Array.from(remotes))
+          .filter(
+            (remote) => !federationOptions || !isDynamicOnlyRemote(remote, federationOptions)
+          );
 
     // Bare ids may represent a root (`.`) expose, so preload them too. Failures
-    // remain non-blocking through Promise.allSettled below.
+    // remain non-blocking for version-first through Promise.allSettled below.
     const remotePreloads = shouldPreloadRemotes
-      ? Object.entries(getUsedRemotesMap(federationOptions))
-          .flatMap(([, remotes]) => Array.from(remotes))
-          .filter((remote) => !federationOptions || !isDynamicOnlyRemote(remote, federationOptions))
+      ? remoteSources
           .sort()
-          .map(
-            (remote) =>
-              `__mfPreloadRemote(${JSON.stringify(
-                getRuntimeRemoteId(
-                  remote,
-                  (federationOptions ?? getNormalizeModuleFederationOptions()).remotes,
-                  federationOptions
-                )
-              )}, ${JSON.stringify(remote)})`
-          )
+          .map((remote) => {
+            const registration = isLoadedFirstClientBuild
+              ? getRemoteRegistration(remote, normalizedOptions.remotes, federationOptions)
+              : undefined;
+            return `__mfPreloadRemote(${JSON.stringify(
+              getRuntimeRemoteId(remote, normalizedOptions.remotes, federationOptions)
+            )}, ${JSON.stringify(remote)}${
+              registration ? `, ${JSON.stringify(registration)}` : ''
+            })`;
+          })
           .join(',')
       : '';
     const remoteCachePrefix = getRuntimeRemoteCachePrefix(federationOptions);
+    const preloadRegistrationParameter = isLoadedFirstClientBuild ? ', registration' : '';
+    const preloadRegistrationBlock = isLoadedFirstClientBuild
+      ? `if (registration && typeof runtime.registerRemotes === "function") {
+      runtime.registerRemotes([registration]);
+    }`
+      : '';
 
     const preloadBlock = remotePreloads
       ? `
   const runtime = await initHost();
-  const __mfPreloadRemote = (runtimeRemote, remote) => {
+  const __mfPreloadRemote = (runtimeRemote, remote${preloadRegistrationParameter}) => {
+    ${preloadRegistrationBlock}
     const remoteCacheKey = ${JSON.stringify(remoteCachePrefix)} + remote;
     const pendingKey = "__mf_pending__" + remoteCacheKey;
     if (!__mfModuleCache.remote[pendingKey]) {
@@ -354,7 +374,7 @@ const __mfCurrentScript = document.currentScript;
     return __mfModuleCache.remote[pendingKey];
   };
   const __mfRemotePreloads = [${remotePreloads}];
-  await Promise.allSettled(__mfRemotePreloads);`
+  await ${isLoadedFirstClientBuild ? 'Promise.all' : 'Promise.allSettled'}(__mfRemotePreloads);`
       : `await initHost();`;
 
     // The hostInit chunk's top-level await may be lowered to an emulated

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -112,7 +112,7 @@ function resolveDevHashEntryFileName(fileName: string) {
   return path.extname(baseName) ? normalized : `${normalized}.js`;
 }
 
-function getBuildInput(config: any) {
+export function getBuildInput(config: any) {
   return config.build?.rollupOptions?.input ?? config.build?.rolldownOptions?.input;
 }
 

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -21,6 +21,7 @@
 import type { Plugin } from 'vite';
 import { createCodePositionMap } from '../utils/codePositionMap';
 import { CodeRewriter, type SourceMapLike } from '../utils/codeRewriter';
+import { findModuleImportDescriptors } from '../utils/htmlEntryUtils';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import {
   LOAD_REMOTE_TAG,
@@ -82,22 +83,6 @@ interface WalkVisitor {
 
 function isAstNode(value: unknown): value is { type: string; [key: string]: unknown } {
   return !!value && typeof value === 'object' && typeof (value as any).type === 'string';
-}
-
-function findStaticRemoteSources(code: string, isRemoteImport: (source: string) => boolean) {
-  const codePositions = createCodePositionMap(code);
-  const sources = new Set<string>();
-  const patterns = [
-    /\b(?:import|export)\s+[^;]*?\bfrom\s*["']([^"']+)["']/g,
-    /\bimport\s*["']([^"']+)["']/g,
-  ];
-  for (const pattern of patterns) {
-    for (const match of code.matchAll(pattern)) {
-      const source = match[1];
-      if (codePositions[match.index!] && isRemoteImport(source)) sources.add(source);
-    }
-  }
-  return sources;
 }
 
 function walkAST(root: unknown, visitor: WalkVisitor): void {
@@ -554,8 +539,10 @@ export function pluginRemoteNamedExports(options: NormalizedModuleFederationOpti
       // Quick bail-out: does the source mention any remote name?
       if (!remoteNames.some((name) => code.includes(name))) return;
       const matchesRemoteImport = (source: string) => isRemoteImport(source, id);
-      for (const source of findStaticRemoteSources(code, matchesRemoteImport)) {
-        markStaticRemote(source, options);
+      for (const { kind, source, typeOnly } of findModuleImportDescriptors(code)) {
+        if (kind === 'static' && !typeOnly && matchesRemoteImport(source)) {
+          markStaticRemote(source, options);
+        }
       }
 
       let imports: ImportInfo[] | undefined;

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -30,6 +30,17 @@ describe('findModuleImportSources', () => {
       `)
     ).toEqual(['remote']);
   });
+
+  it('ignores type-only imports', () => {
+    expect(
+      findModuleImportSources(`
+        import type { RemoteType } from 'remote/type';
+        export type { ExportedType } from 'remote/export-type';
+        import { value } from 'remote/runtime';
+        const lazy = import('remote/lazy');
+      `)
+    ).toEqual(['remote/runtime', 'remote/lazy']);
+  });
 });
 
 describe('findModuleImportDescriptors', () => {

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  findModuleImportDescriptors,
   findModuleImportSources,
   injectEntryScript,
   rewriteEntryScripts,
@@ -28,6 +29,45 @@ describe('findModuleImportSources', () => {
         import { real } from 'remote';
       `)
     ).toEqual(['remote']);
+  });
+});
+
+describe('findModuleImportDescriptors', () => {
+  it('separates runtime imports from type-only imports', () => {
+    expect(
+      findModuleImportDescriptors(`
+        import type { RemoteType } from 'remote/type';
+        export type { ExportedType } from 'remote/export-type';
+        export { type NamedType } from 'remote/named-type';
+        import { value } from 'remote/value';
+        import 'remote/side-effect';
+        const lazy = import('remote/lazy');
+      `)
+    ).toEqual([
+      { kind: 'static', syntax: 'import', source: 'remote/type', typeOnly: true },
+      { kind: 'static', syntax: 'import', source: 'remote/export-type', typeOnly: true },
+      { kind: 'static', syntax: 'import', source: 'remote/named-type', typeOnly: true },
+      { kind: 'static', syntax: 'import', source: 'remote/value', typeOnly: false },
+      { kind: 'dynamic', syntax: 'import', source: 'remote/lazy', typeOnly: false },
+      { kind: 'static', syntax: 'import', source: 'remote/side-effect', typeOnly: false },
+    ]);
+  });
+
+  it('keeps CommonJS require calls as dynamic descriptors', () => {
+    expect(findModuleImportDescriptors(`const value = require('remote/commonjs');`)).toEqual([
+      { kind: 'dynamic', syntax: 'require', source: 'remote/commonjs', typeOnly: false },
+    ]);
+  });
+
+  it('ignores import-looking text in comments and strings', () => {
+    expect(
+      findModuleImportDescriptors(`
+        // import { fake } from 'remote/comment';
+        const text = "import('remote/string')";
+        const expression = /import 'remote-import'/;
+        import 'remote/real';
+      `)
+    ).toEqual([{ kind: 'static', syntax: 'import', source: 'remote/real', typeOnly: false }]);
   });
 });
 

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -66,7 +66,7 @@ export function findModuleImportSources(code: string): string[] {
   return Array.from(
     new Set(
       findModuleImportDescriptors(code)
-        .filter(({ syntax }) => syntax === 'import')
+        .filter(({ syntax, typeOnly }) => syntax === 'import' && !typeOnly)
         .map(({ source }) => source)
     )
   );

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -1,20 +1,75 @@
 import { createCodePositionMap } from './codePositionMap';
 
-export function findModuleImportSources(code: string): string[] {
-  const codePositions = createCodePositionMap(code);
-  const sources = new Set<string>();
-  const patterns = [
-    /\b(?:import|export)\s+[^;]*?\bfrom\s*["']([^"']+)["']/g,
-    /\bimport\s*\(\s*["']([^"']+)["']/g,
-    /\bimport\s*["']([^"']+)["']/g,
-  ];
+export interface ModuleImportDescriptor {
+  kind: 'static' | 'dynamic';
+  syntax: 'import' | 'require';
+  source: string;
+  typeOnly: boolean;
+}
 
-  for (const pattern of patterns) {
-    for (const match of code.matchAll(pattern)) {
-      if (codePositions[match.index!]) sources.add(match[1]);
-    }
+function isTypeOnlyClause(clause: string): boolean {
+  const normalized = clause.trim();
+  if (/^type\b/.test(normalized)) return true;
+
+  const namedSpecifiers = normalized.match(/^\{([\s\S]*)\}$/)?.[1];
+  if (!namedSpecifiers) return false;
+
+  const specifiers = namedSpecifiers
+    .split(',')
+    .map((specifier) => specifier.trim())
+    .filter(Boolean);
+  return specifiers.length > 0 && specifiers.every((specifier) => /^type\b/.test(specifier));
+}
+
+/**
+ * Finds module imports while ignoring comments, strings, and regular expressions.
+ * The descriptor keeps enough information for callers to distinguish runtime
+ * static imports from type-only imports without introducing a parser dependency.
+ */
+export function findModuleImportDescriptors(code: string): ModuleImportDescriptor[] {
+  const codePositions = createCodePositionMap(code);
+  const descriptors: ModuleImportDescriptor[] = [];
+  const staticFromPattern = /\b(?:import|export)\s+([\s\S]*?)\s+from\s*(["'])([^"']+)\2/g;
+  const dynamicPattern = /\bimport\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*)?(["'])([^"']+)\1\s*\)/g;
+  const requirePattern = /\brequire\s*\(\s*(["'])([^"']+)\1\s*\)/g;
+  const sideEffectPattern = /\bimport\s*(["'])([^"']+)\1/g;
+
+  for (const match of code.matchAll(staticFromPattern)) {
+    if (!codePositions[match.index!]) continue;
+    descriptors.push({
+      kind: 'static',
+      syntax: 'import',
+      source: match[3],
+      typeOnly: isTypeOnlyClause(match[1]),
+    });
   }
-  return Array.from(sources);
+
+  for (const match of code.matchAll(dynamicPattern)) {
+    if (!codePositions[match.index!]) continue;
+    descriptors.push({ kind: 'dynamic', syntax: 'import', source: match[2], typeOnly: false });
+  }
+
+  for (const match of code.matchAll(requirePattern)) {
+    if (!codePositions[match.index!]) continue;
+    descriptors.push({ kind: 'dynamic', syntax: 'require', source: match[2], typeOnly: false });
+  }
+
+  for (const match of code.matchAll(sideEffectPattern)) {
+    if (!codePositions[match.index!]) continue;
+    descriptors.push({ kind: 'static', syntax: 'import', source: match[2], typeOnly: false });
+  }
+
+  return descriptors;
+}
+
+export function findModuleImportSources(code: string): string[] {
+  return Array.from(
+    new Set(
+      findModuleImportDescriptors(code)
+        .filter(({ syntax }) => syntax === 'import')
+        .map(({ source }) => source)
+    )
+  );
 }
 
 export function sanitizeDevEntryPath(devEntryPath: string): string {

--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -5,6 +5,7 @@ import {
   addUsedRemote,
   generateRemotes,
   getRemoteVirtualModule,
+  getStaticRemotes,
   getUsedRemotesMap,
   isDynamicOnlyRemote,
   markDynamicRemote,
@@ -20,6 +21,20 @@ it('classifies an expose as dynamic-only until a static import is seen', () => {
 
   markStaticRemote('remote/Card', options);
   expect(isDynamicOnlyRemote('remote/Card', options)).toBe(false);
+});
+
+it('scopes static remote registry by federation options', () => {
+  const first = {} as never;
+  const second = {} as never;
+
+  markStaticRemote('remote/Static', first);
+  markDynamicRemote('remote/Both', first);
+  markStaticRemote('remote/Both', first);
+  markStaticRemote('remote/Other', second);
+
+  expect(getStaticRemotes(first)).toEqual(new Set(['remote/Static', 'remote/Both']));
+  expect(getStaticRemotes(second)).toEqual(new Set(['remote/Other']));
+  expect(getStaticRemotes(first)).not.toBe(getStaticRemotes(second));
 });
 
 const mockOptions = vi.hoisted(() => ({

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -98,6 +98,7 @@ const usedRemotesByOptions = new WeakMap<
 >();
 const dynamicRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
 const staticRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
+const EMPTY_STATIC_REMOTES: ReadonlySet<string> = new Set();
 
 function getScopedUsedRemotesMap(options: NormalizedModuleFederationOptions) {
   let scoped = usedRemotesByOptions.get(options);
@@ -148,6 +149,10 @@ export function markStaticRemote(remote: string, options: NormalizedModuleFedera
   remotes.add(remote);
 }
 
+export function getStaticRemotes(options: NormalizedModuleFederationOptions): ReadonlySet<string> {
+  return staticRemotesByOptions.get(options) ?? EMPTY_STATIC_REMOTES;
+}
+
 export function isDynamicOnlyRemote(remote: string, options: NormalizedModuleFederationOptions) {
   return (
     (dynamicRemotesByOptions.get(options)?.has(remote) ?? false) &&
@@ -159,6 +164,24 @@ function getRemoteAliasFromId(id: string, remotes: Record<string, RemoteObjectCo
   return Object.keys(remotes)
     .filter((name) => id === name || id.startsWith(name + '/'))
     .sort((a, b) => b.length - a.length)[0];
+}
+
+export function getRemoteRegistration(
+  id: string,
+  remotes: Record<string, RemoteObjectConfig>,
+  options?: NormalizedModuleFederationOptions
+) {
+  const alias = getRemoteAliasFromId(id, remotes);
+  if (!alias) return undefined;
+  const remote = remotes[alias];
+  return {
+    entryGlobalName: remote.entryGlobalName,
+    name: options ? getRuntimeRemoteAlias(alias, options) : remote.name,
+    alias,
+    type: remote.type,
+    entry: remote.entry,
+    shareScope: remote.shareScope ?? 'default',
+  };
 }
 
 export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
@@ -389,20 +412,11 @@ export function generateRemotes(
   const isLoadedFirst = resolvedOptions.shareStrategy === 'loaded-first';
   const initMode = resolveRemoteInitMode(resolvedOptions.shareStrategy, consumer);
   const deferRemoteLoad = shouldDeferRemoteLoad(initMode);
-  const remoteAlias = getRemoteAliasFromId(id, resolvedOptions.remotes);
-  const remote = remoteAlias ? resolvedOptions.remotes[remoteAlias] : undefined;
-  const runtimeRemoteAlias = remoteAlias ? getRuntimeRemoteAlias(remoteAlias, options) : undefined;
   const runtimeRemoteId = getRuntimeRemoteId(id, resolvedOptions.remotes, options);
+  const remoteRegistration = getRemoteRegistration(id, resolvedOptions.remotes, options);
   const registerRemoteCode =
-    isLoadedFirst && remote
-      ? `runtime.registerRemotes([${JSON.stringify({
-          entryGlobalName: remote.entryGlobalName,
-          name: options ? runtimeRemoteAlias : remote.name,
-          alias: remoteAlias,
-          type: remote.type,
-          entry: remote.entry,
-          shareScope: remote.shareScope ?? 'default',
-        })}]);`
+    isLoadedFirst && remoteRegistration
+      ? `runtime.registerRemotes([${JSON.stringify(remoteRegistration)}]);`
       : '';
   const hostAutoInitPath = getHostAutoInitPath(options);
   const ssrRemotes = Object.entries(resolvedOptions.remotes).map(([name, item]) => ({


### PR DESCRIPTION
## Summary

Fixes #1096 without introducing top-level await (TLA).

When a host uses a static remote import with `shareStrategy: 'loaded-first'`, the host entry must not be evaluated until that remote namespace is ready. The previous bootstrap deliberately skipped all remote preloads for `loaded-first`, which could cause named or namespace imports to observe an incomplete remote module and fail during application startup.

This change preloads only remotes that are statically imported by the client entry graph. Dynamic-only remotes remain on-demand.

## Root cause

- `pluginRemoteNamedExports` rewrites remote named and namespace imports while preserving a TLA-free module wrapper.
- The `loaded-first` host bootstrap previously skipped remote preloading entirely.
- As a result, the application entry could be evaluated before a statically imported remote namespace was available.
- The failure was commonly surfaced as a bare `Uncaught (in promise)` during production startup.

## Implementation

- Add a shared import descriptor scanner that distinguishes:
  - runtime static imports;
  - dynamic `import()` calls;
  - CommonJS `require()` calls;
  - type-only imports and exports.
- Track the actual static remote module IDs discovered from the configured client entry graph.
- For client production builds using `loaded-first`:
  - register each static remote with the runtime;
  - preload only those static remotes;
  - await them with `Promise.all()` before importing the application entry.
- Preserve the existing behavior for:
  - dynamic-only remotes;
  - `version-first` and its `Promise.allSettled()` error policy;
  - SSR and server consumer wrappers;
  - CommonJS handling;
  - `skipRemotePreload` paths;
  - remote wrapper dependency-pending exports.
- Keep generated wrappers and bootstrap code free of TLA.

## Error behavior

Static remote preload failures now reject the bootstrap with the original remote loading error. The application entry is not imported, so entry side effects do not run after a static remote failure.

Dynamic-only remote failures remain deferred until the remote is requested.

## Compatibility

- No public `ModuleFederationOptions` or runtime API changes.
- No new TLA or `await` at module top level.
- The change is limited to internal static-import tracking, host bootstrap sequencing, and regression coverage.

## Tests

Passed on the fix branch:

- `pnpm test` — 49 files, 1,073 passed, 1 skipped
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:integration` — 16 files, 84 passed
- `pnpm fmt.check`
- `git diff --check`

The browser regression coverage verifies:

- named static imports;
- namespace static imports;
- remote request ordering before host entry evaluation;
- absence of page errors and unhandled rejections on success;
- no host entry side effects after a static remote load failure;
- propagation of the original runtime loading error.

## Review guide

Recommended review order:

1. Entry import descriptors and static remote registry. (https://github.com/module-federation/vite/commit/5b8af3a7ecb15f0a779cfc54966bdd01633becaa) 
2. `loaded-first` bootstrap preload and runtime registration. (https://github.com/module-federation/vite/commit/5abdb67a6aea8a87420285b234a9bf5ad522d3fc)
3. Production/browser regression fixtures and failure-path assertions. (https://github.com/module-federation/vite/commit/194399633f0e76a7e309123a4a181041e264e8e6)