### PR TITLE
fix: exclude workspace sources from hydration fallback

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -573,6 +573,119 @@ describe('pluginAddEntry', () => {
     expect(other).toBeUndefined();
   });
 
+  it('does not consume hydration fallback for Vite /@fs workspace source IDs', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-fs-workspace-'));
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = await runTransform(
+      buildPlugin,
+      'export const useI18n = () => undefined;\ncreateRoot(document);',
+      '/@fs//workspace/packages/i18n/src/index.ts'
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not consume hydration fallback for an existing source outside the app root', async () => {
+    const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-app-root-'));
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-workspace-root-'));
+    const sourcePath = path.join(workspaceRoot, 'packages/i18n/src/index.ts');
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, '');
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+    });
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: appRoot,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = await runTransform(
+      buildPlugin,
+      'export const useI18n = () => undefined;\ncreateRoot(document);',
+      `${sourcePath}?v=123`
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('still wraps an app-root hydration entry and virtual hydration entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-hydration-entries-'));
+    const entryPath = path.join(tempDir, 'src/entry-client.tsx');
+    fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+    fs.writeFileSync(entryPath, '');
+
+    const createPlugin = () => {
+      const plugins = addEntry({
+        entryName: 'hostInit',
+        entryPath: '/virtual/hostInit.js',
+        inject: 'entry',
+      });
+      const buildPlugin = plugins[1];
+      runConfig(
+        buildPlugin,
+        {} as ConfigPluginContext,
+        { build: { rollupOptions: {} } },
+        { command: 'serve', mode: 'development' }
+      );
+      runConfigResolved(buildPlugin, {
+        root: tempDir,
+        base: '/',
+        command: 'serve',
+        build: { rollupOptions: {} },
+      } as unknown as ResolvedConfig);
+      return buildPlugin;
+    };
+
+    const entryResult = (await runTransform(
+      createPlugin(),
+      'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);',
+      entryPath
+    )) as { code: string } | undefined;
+    const virtualResult = (await runTransform(
+      createPlugin(),
+      'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);',
+      '\0app-client-entry.tsx'
+    )) as { code: string } | undefined;
+
+    expect(entryResult?.code).toContain('await initHost();');
+    expect(entryResult?.code).toContain(
+      `})().then(() => import(${JSON.stringify(`${entryPath}?mf-entry-bootstrap`)}));`
+    );
+    expect(virtualResult?.code).toContain('await initHost();');
+  });
+
   for (const command of ['serve', 'build'] as const) {
     it(`wraps only React Router v8's client entry during ${command}`, async () => {
       const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -437,6 +437,27 @@ const __mfCurrentScript = document.currentScript;
     );
   }
 
+  function isWorkspaceSourceId(id: string) {
+    const decoded = decodeViteId(id);
+    const normalized = normalizeModuleId(decoded);
+    if (normalized.startsWith('\0') || normalized.startsWith('virtual:')) return false;
+
+    const filePath = stripQueryAndHash(normalized);
+    if (filePath.startsWith('/@fs/')) return true;
+    if (!path.isAbsolute(filePath)) return false;
+
+    const root = normalizePathForImport(path.resolve(viteConfig.root));
+    const absolutePath = normalizePathForImport(path.resolve(filePath));
+    const relativePath = normalizePathForImport(path.relative(root, absolutePath));
+    const isOutsideRoot =
+      relativePath === '..' || relativePath.startsWith('../') || path.isAbsolute(relativePath);
+
+    // Vite transform IDs for workspace imports are absolute paths. Only classify
+    // existing files outside the app root so virtual/framework IDs remain eligible
+    // for the SSR hydration fallback.
+    return isOutsideRoot && fs.existsSync(absolutePath);
+  }
+
   function addEntryFile(file: string) {
     const normalized = normalizeModuleId(file);
     if (!entryFiles.includes(normalized)) entryFiles.push(normalized);
@@ -903,6 +924,7 @@ const __mfCurrentScript = document.currentScript;
           !clientInjected &&
           !isFederationInternalVirtualId(id) &&
           !id.includes('node_modules') &&
+          !isWorkspaceSourceId(id) &&
           (!code.includes('HydratedRouter') || isReactRouterEntry) &&
           (id.startsWith('\0') || /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) &&
           (/hydrateRoot|createRoot|ReactDOM\.render/.test(code) ||


### PR DESCRIPTION
## Summary

Fixes #1100

When `hostInitInjectLocation: 'entry'` is used without an explicit HTML or Rollup entry in dev, the hydration fallback identifies a module that calls `hydrateRoot`, `createRoot`, or Vue `mount()` and injects the host-init bootstrap into it.

The fallback previously excluded `node_modules` but not workspace source modules. Vite can represent those modules as `/@fs/` IDs or as absolute filesystem paths outside `viteConfig.root`. A workspace package entry containing `createRoot` could therefore be mistaken for the application entry and wrapped with `?mf-entry-bootstrap`, breaking its original exports.

## Changes

- Decode Vite IDs and remove query/hash suffixes before filesystem classification.
- Exclude `/@fs/` modules and existing filesystem modules outside `viteConfig.root` from the hydration fallback.
- Keep Module Federation virtual IDs and framework virtual entries eligible for the existing fallback.
- Preserve explicit `entryFiles`, `node_modules` filtering, and `forceClientInjected` behavior.
- Add regression coverage for workspace source IDs, external absolute source paths, app-root hydration entries, and virtual hydration entries.

## Validation

- `pnpm exec vitest run src/plugins/__tests__/pluginAddEntry.test.ts`
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run fmt.check`
- `pnpm build`


## Scope note

Existing non-`node_modules` filesystem entries outside the application root are no longer eligible for this implicit hydration fallback. Applications using such entries should use an explicit Rollup input or a virtual entry instead.