### PR TITLE
fix: stabilize dev-singleton integration cleanup

### DIFF
--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -111,12 +111,17 @@ export default {
 });
 
 afterEach(async () => {
-  await Promise.all(
-    cleanupTasks
-      .splice(0)
-      .reverse()
-      .map((cleanup) => cleanup())
+  const cleanups = cleanupTasks.splice(0).reverse();
+  // The fixture cleanup is registered first and must run after all servers close.
+  const cleanupFixture = cleanups.pop();
+  const cleanupResults = await Promise.allSettled(cleanups.map((cleanup) => cleanup()));
+
+  await cleanupFixture?.();
+
+  const failedCleanup = cleanupResults.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
   );
+  if (failedCleanup) throw failedCleanup.reason;
 });
 
 async function createDevServer(


### PR DESCRIPTION
## Summary

Stabilize the `dev-singleton-react` integration test cleanup so full integration runs do not intermittently fail in Vitest's `afterEach` hook.

The test starts browser instances, Vite servers, CLI child processes, temporary cache directories, and a temporary fixture root. Cleanup previously started all tasks at the same time, including deleting the fixture root while Vite processes could still be shutting down. Under full-suite resource contention, this could leave cleanup hanging until the 10-second hook timeout.

## Root cause

- Cleanup tasks were collected in reverse registration order, but `Promise.all()` started them concurrently.
- The fixture-root removal therefore raced with Vite server and CLI process cleanup.
- The race was intermittent and was more likely during the full integration suite than when running `dev-singleton-react.test.ts` alone.
- The failure was reported at the `afterEach` hook rather than in the test assertion.

## Implementation

- Keep browser, Vite server, and CLI process cleanup concurrent.
- Remove the fixture-root cleanup from the concurrent group.
- Wait for all resource cleanup tasks to settle before deleting the fixture root.
- Re-throw the first resource cleanup error after fixture cleanup so failures remain visible.
- Keep the change limited to `integration/dev-singleton-react.test.ts`; no production code or public API changes are included.

## Compatibility

- No runtime behavior changes.
- No public API, type, or configuration changes.
- Cleanup remains parallel for independent resources, avoiding unnecessary sequential teardown time.
- Existing cleanup errors are still surfaced instead of being ignored.

## Flakiness observation

- CI intermittently failed in `integration/dev-singleton-react.test.ts` with `Hook timed out in 10000ms` from the `afterEach` cleanup hook.
- The failure was not deterministic when the test file ran alone, so the test was measured separately from the full integration suite.
- Before the fix, the target test passed 20/20 times in isolation, while the full integration suite passed 18/20 times and failed 2/20 times with the same cleanup timeout.
- After the fix, the full integration suite passed 20/20 consecutive runs with no cleanup timeout.

## Tests

The following checks passed after the change:

- `pnpm test:integration` — 20 consecutive full-suite runs passed; 0 cleanup timeouts
- `pnpm exec vitest run integration/dev-singleton-react.test.ts` — 4 tests passed
- `pnpm test` — 49 files, 1,074 passed, 1 skipped
- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm build`