### PR TITLE
fix: mirror remote snapshots under their real container name

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1011,6 +1011,67 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('initRes.initializeSharing(shareScopeName');
   });
 
+  it('mirrors resolved manifest snapshots under the real container name', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        remotes: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'loaded-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+
+    const pluginCode = code.slice(
+      code.indexOf('function __mfRealNameSnapshotPlugin()'),
+      code.indexOf('const runtimeResolveShareHook =')
+    );
+    const plugin = new Function(`${pluginCode}; return __mfRealNameSnapshotPlugin();`)() as {
+      afterLoadSnapshot: (args: { remoteSnapshot: Record<string, string> }) => unknown;
+    };
+
+    const manifestUrl = 'https://cdn.invalid/provider/mf-manifest.json';
+    const moduleInfo: Record<string, unknown> = {
+      [`__mfe_internal__host__mf_owner__1__alias:${manifestUrl}`]: {},
+      // The provider's own entry, which shadows a real-name lookup.
+      provider: { version: manifestUrl, remoteEntry: '' },
+    };
+    const federationGlobal = globalThis as { __FEDERATION__?: unknown };
+    const hadFederationGlobal = '__FEDERATION__' in federationGlobal;
+    const previous = federationGlobal.__FEDERATION__;
+    federationGlobal.__FEDERATION__ = { moduleInfo };
+
+    try {
+      const remoteSnapshot = {
+        globalName: 'provider',
+        version: manifestUrl,
+        remoteEntry: 'remoteEntry.js',
+      };
+      plugin.afterLoadSnapshot({ remoteSnapshot });
+      expect(moduleInfo[`provider:${manifestUrl}`]).toBe(remoteSnapshot);
+
+      plugin.afterLoadSnapshot({
+        remoteSnapshot: { globalName: 'other', version: manifestUrl, remoteEntry: '' },
+      });
+      expect(`other:${manifestUrl}` in moduleInfo).toBe(false);
+
+      plugin.afterLoadSnapshot({ remoteSnapshot: { ...remoteSnapshot } });
+      expect(moduleInfo[`provider:${manifestUrl}`]).toBe(remoteSnapshot);
+    } finally {
+      if (hadFederationGlobal) {
+        federationGlobal.__FEDERATION__ = previous;
+      } else {
+        delete federationGlobal.__FEDERATION__;
+      }
+    }
+  });
+
   it('inlines a dedicated build-only initResolve bootstrap into remoteEntry', async () => {
     const mod = await import('../virtualRemoteEntry');
 
@@ -1264,7 +1325,7 @@ describe('virtualRemoteEntry', () => {
       'if (share.treeShaking) continue;'
     );
     expect(code).toContain(
-      'plugins: [__mfSharePinLifecyclePlugin(), __mfTreeShakingSnapshotPlugin(),'
+      'plugins: [__mfSharePinLifecyclePlugin(), __mfRealNameSnapshotPlugin(), __mfTreeShakingSnapshotPlugin(),'
     );
   });
 

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1339,7 +1339,7 @@ export function generateRemoteEntry(
       name: mfName,
       remotes: ${options.shareStrategy === 'loaded-first' ? '[]' : 'usedRemotes'},
       shared: usedShared,
-      plugins: [__mfSharePinLifecyclePlugin(), ${hasTreeShakingShared ? '__mfTreeShakingSnapshotPlugin(),' : ''} ...__browserPlugins, ...__ssrPlugins],
+      plugins: [__mfSharePinLifecyclePlugin(), __mfRealNameSnapshotPlugin(), ${hasTreeShakingShared ? '__mfTreeShakingSnapshotPlugin(),' : ''} ...__browserPlugins, ...__ssrPlugins],
       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ''}
     });
     ${
@@ -1371,6 +1371,29 @@ export function generateRemoteEntry(
             return defaultResolver(...resolverArgs);
           };
           lifecycle.pinned.reveal();
+          return args;
+        }
+      };
+    }
+    function __mfRealNameSnapshotPlugin() {
+      return {
+        name: "vite-real-name-snapshot-plugin",
+        afterLoadSnapshot(args) {
+          // Remotes are registered under an owner-scoped runtime name, so the
+          // global snapshot only ever holds that name. Containers built by other
+          // bundlers ask for the same remote by its real container name, miss, and
+          // fall back to that container's own entry, whose remoteEntry is empty
+          // (RUNTIME-011). Mirroring the resolved snapshot under the real name
+          // keeps the primary lookup off that fallback.
+          const snapshot = args && args.remoteSnapshot;
+          const globalName = snapshot && snapshot.globalName;
+          const version = snapshot && snapshot.version;
+          if (!globalName || !version || !snapshot.remoteEntry) return args;
+          const moduleInfo = globalThis.__FEDERATION__ && globalThis.__FEDERATION__.moduleInfo;
+          const realNameKey = globalName + ":" + version;
+          if (moduleInfo && !moduleInfo[realNameKey]) {
+            moduleInfo[realNameKey] = snapshot;
+          }
           return args;
         }
       };


### PR DESCRIPTION
Fixes #1105.

## Problem

Remotes are registered with the runtime under an owner-scoped name — `getRuntimeRemoteAlias` (`src/virtualModules/virtualRuntimeInitStatus.ts:53-56`) — and global snapshot keys derive from the remote *name* (`runtime-core/dist/global.js:107-111` + `utils/tool.js:9-13`). So `__FEDERATION__.moduleInfo` ends up with

```
__mfe_internal__host__mf_owner__1__aliasProvider:https://…/provider/mf-manifest.json   remoteEntry: "remoteEntry.js"
```

and never an entry for `provider:https://…/provider/mf-manifest.json`.

A webpack/rspack container in the same page declares the same remote by its **real container name**. Its lookup misses that key, then `getTargetSnapshotInfoByModuleInfo` (`global.js:95-105`) strips the version and accepts the bare-name entry the provider wrote to describe itself, whose `remoteEntry` is `""` (`SnapshotHandler.loadRemoteSnapshotInfo`, `:59-70`). That snapshot is truthy, so `isManifestProvider` is false, the manifest fetch at `SnapshotHandler.js:109-116` is never reached, and `assignRemoteInfo` throws:

```
[ Federation Runtime ]: The remoteEntry URL is missing from the remote snapshot. #RUNTIME-011
args: {"remoteName":"provider"}
```

It is intermittent — resolving before the bare entry exists fetches the manifest and works — and it surfaces far from its cause: if the failing require sits in an exposed entry module at module-evaluation time, the runtime installs a throwing module factory (`webpack-bundler-runtime/dist/remotes.js:19-26`), swallows the rejection into the ensure-chunk chain (`:31-32`), webpack 5 never evicts the module cache, and **every export of that container reads as `undefined` for the rest of the page**. The only visible error is a `TypeError: Cannot read properties of undefined` in an unrelated export getter.

## Approach

The obvious fix — put the real container name in the runtime `name` and move the synthetic string to `alias` — is deliberately **not** what this PR does. #1001 ("preserve public aliases for loadRemote") moved the alias slot the other way on purpose, and `virtualRemotes.test.ts` ("does not reuse pending or loaded remotes across federation instances") pins the property that two owners pointing at *different entries for the same container name* stay separate. Registering the real name would make the second `registerRemote` a silent no-op (`RemoteHandler.registerRemote` skips a duplicate `name` unless `force`), so the second owner would silently load the first owner's entry.

So this PR leaves naming and registration untouched and repairs the lookup table instead: a generated runtime plugin mirrors every resolved manifest snapshot under `<globalName>:<version>` in `afterLoadSnapshot`. `globalName` is the real container name and `version` is the manifest URL (`sdk/generateSnapshotFromManifest.js:50,53`), so the mirrored key is exactly what another bundler's container asks for, and its primary lookup hits before the empty fallback is consulted.

Properties:

- **Additive.** Owner scoping, public aliases and `loadRemote` ids are unchanged; nothing that reads a remote name back is touched.
- **Multi-owner safe.** Different entries for the same container name produce different `version`s, hence different mirrored keys — no collision.
- **Self-limiting.** Only snapshots that carry `globalName`, `version` *and* a non-empty `remoteEntry` are mirrored; mirroring an entry-less snapshot would spread the very failure this fixes. An existing key is never clobbered.
- **Ordering-proof.** Once mirrored, the provider's own `loadRemoteSnapshotInfo` finds `provider:<url>` and no longer writes the bare stub at all, so the fallback is never reachable.

It follows the existing generated-plugin pattern (`__mfSharePinLifecyclePlugin`, `__mfTreeShakingSnapshotPlugin`) and is registered in the same `runtimeInit({ plugins: [...] })` list.

## Testing

- New unit test in `src/virtualModules/__tests__/virtualRemoteEntry.test.ts` extracts the generated `__mfRealNameSnapshotPlugin` and drives `afterLoadSnapshot` over three cases: mirrors a manifest snapshot under its real name, skips a snapshot with an empty `remoteEntry`, and keeps an existing real-name entry.
- `pnpm test` — 49 files, 1078 passed.
- `pnpm build && pnpm test:integration` — 16 files, 84 passed.
- `pnpm typecheck`, `pnpm fmt.check` clean.
- End to end against a minimal four-container repro (vite host + three rspack containers, plain functions, no framework): https://github.com/h11g/mf-vite-real-name-snapshot-repro

  Before — `provider:<manifestUrl>` absent, bare `provider` present with `remoteEntry: ""`:
  ```
  step 2  consumer/widget threw:
  RUNTIME-015 → Original: RUNTIME-011  The remoteEntry URL is missing from the remote snapshot.
  args: {"remoteName":"provider"}
  ```
  After, with this branch linked into the host:
  ```
  provider:http://localhost:3002/mf-manifest.json      remoteEntry: "remoteEntry.js"
  step 2  consumer/widget -> widget(provider(leaf))
  ```

I did not add an e2e spec: expressing the four-container graph means reshaping apps under `examples/vite-webpack-rspack/` that other specs share. Happy to add one there if you'd prefer it in-repo.

## Note on the secondary defect

`runtime-core`'s `getTargetSnapshotInfoByModuleInfo` accepting a snapshot whose `remoteEntry` is `""` (`global.js:99-104`) is the other half of this: a snapshot with no entry should arguably never satisfy a lookup whose purpose is to find one, and falling through to the manifest fetch would make this class of failure self-healing. That belongs in `module-federation/core`; happy to file it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)