### PR TITLE
fix: preload remote-only dev singleton wrappers before entry import

### DIFF
--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -330,6 +330,51 @@ describe(`singleton React dev fallback (Vite ${viteVersion})`, () => {
     expect(pageErrors).toEqual([]);
   }, 60_000);
 
+  it('boots on first load when a remote-only singleton imports jsx-dev-runtime (#1104)', async () => {
+    const exposedEntry = path.join(fixtureRoot, 'src/Issue1104App.js');
+    await Promise.all([
+      writeFile(
+        path.join(fixtureRoot, 'src/main.js'),
+        `import { jsxDEV } from 'react/jsx-dev-runtime';
+
+const element = jsxDEV('div', { children: 'ready' }, undefined, false, undefined, undefined);
+window.__issue1104Result = element.type === 'div' ? 'ready' : 'invalid';
+document.body.textContent = window.__issue1104Result;
+`
+      ),
+      writeFile(exposedEntry, 'export default function Issue1104App() { return null; }\n'),
+    ]);
+
+    const host = await createDevServer(
+      'issue-1104-host',
+      {
+        name: 'issue1104Host',
+        exposes: { './App': exposedEntry },
+        dts: false,
+        shared: {
+          react: { singleton: true },
+        },
+      },
+      fixtureRoot
+    );
+    const browser = await chromium.launch({ channel: 'chrome', headless: true });
+    cleanupTasks.push(() => browser.close());
+    const page = await browser.newPage();
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+
+    await page.goto(host.origin, { waitUntil: 'domcontentloaded' });
+    try {
+      await page.waitForFunction(() => window.__issue1104Result === 'ready', undefined, {
+        timeout: 15_000,
+      });
+    } catch (error) {
+      throw new Error(JSON.stringify({ cause: String(error), pageErrors }, null, 2));
+    }
+
+    expect(pageErrors).toEqual([]);
+  }, 60_000);
+
   it('serves an optimized ESM React provider', async () => {
     const { origin } = await createDevServer('issue-913-provider', {
       name: 'issue913Provider',
@@ -534,6 +579,7 @@ window.__issue978Result = {
 declare global {
   interface Window {
     __issue1056Result?: string;
+    __issue1104Result?: string;
     __issue913HostReact?: unknown;
     __issue913RemoteReact?: unknown;
     __issue978Result?: {

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -17,10 +17,16 @@ import { toViteEncodedId, VITE_ID_PREFIX } from '../../utils/VirtualModule';
 
 const mockHasPackageDependency = vi.hoisted(() => vi.fn((_pkg: string) => true));
 
-vi.mock('../../utils/packageUtils', () => ({
-  hasPackageDependency: mockHasPackageDependency,
-  packageNameEncode: (name: string) => name,
-}));
+vi.mock('../../utils/packageUtils', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/packageUtils')>(
+    '../../utils/packageUtils'
+  );
+  return {
+    ...actual,
+    hasPackageDependency: mockHasPackageDependency,
+    packageNameEncode: (name: string) => name,
+  };
+});
 
 const mockMfOptions = vi.hoisted(() => ({
   shareStrategy: 'version-first' as 'version-first' | 'loaded-first',
@@ -49,6 +55,7 @@ import {
   markDynamicRemote,
   markStaticRemote,
 } from '../../virtualModules/virtualRemotes';
+import { addUsedShares } from '../../virtualModules/virtualRemoteEntry';
 import addEntry from '../pluginAddEntry';
 
 type AddEntryPlugin = ReturnType<typeof addEntry>[number];
@@ -444,6 +451,78 @@ describe('pluginAddEntry', () => {
     );
     expect(bootstrap.indexOf('__mfModuleCache.pendingShareLoads')).toBeLessThan(
       bootstrap.indexOf('.then(() => import(')
+    );
+  });
+
+  it('preloads remote-only dev shared wrappers before importing the entry', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-shared-preload-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'index.html'),
+      '<script type="module" src="/src/main.tsx"></script>'
+    );
+    const federationOptions = {
+      name: 'remote',
+      internalName: 'remote',
+      shareStrategy: 'version-first' as const,
+      exposes: { './App': './src/App.jsx' },
+      remotes: {},
+      shared: {
+        react: { shareConfig: { import: true, singleton: true, treeShaking: undefined } },
+        'react/jsx-dev-runtime': {
+          shareConfig: { import: true, singleton: true, treeShaking: undefined },
+        },
+        'non-singleton-share': {
+          shareConfig: { import: true, singleton: false, treeShaking: undefined },
+        },
+      },
+    } as any;
+    addUsedShares('react', federationOptions);
+    addUsedShares('react/jsx-dev-runtime', federationOptions);
+    addUsedShares('non-singleton-share', federationOptions);
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+      federationOptions,
+    });
+    const servePlugin = plugins[0];
+    const buildPlugin = plugins[1];
+
+    runConfig(
+      servePlugin,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    runConfig(
+      buildPlugin,
+      {} as ConfigPluginContext,
+      { build: { rollupOptions: {} } },
+      { command: 'serve', mode: 'development' }
+    );
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'serve',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(
+      buildPlugin,
+      'export const browserEntry = true;',
+      '/src/main.tsx'
+    )) as { code: string };
+    const code = result.code;
+
+    expect(code).toContain('const __mfSharedPreloadUrls =');
+    expect(code).toContain('import(/* @vite-ignore */ src)');
+    expect(code).not.toContain('non-singleton-share');
+    expect(code.indexOf('const __mfSharedPreloadUrls =')).toBeLessThan(
+      code.indexOf('const __mfReactServerModuleCache')
+    );
+    expect(code.indexOf('const __mfReactServerModuleCache')).toBeLessThan(
+      code.indexOf('.then(() => import(')
     );
   });
 

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -29,6 +29,11 @@ import {
   getUsedRemotesMap,
   isDynamicOnlyRemote,
 } from '../virtualModules/virtualRemotes';
+import { getUsedShares } from '../virtualModules/virtualRemoteEntry';
+import {
+  getLoadShareModulePath,
+  getProjectResolvedImportPath,
+} from '../virtualModules/virtualShared_preBuild';
 import {
   getModuleCacheGlobalKey,
   getRuntimeModuleCacheBootstrapCode,
@@ -344,6 +349,42 @@ const __mfCurrentScript = document.currentScript;
           })
           .join(',')
       : '';
+
+    const sharedPreloadSources =
+      _command === 'serve' &&
+      waitsForInit &&
+      Object.keys(normalizedOptions.exposes || {}).length > 0 &&
+      Object.keys(normalizedOptions.remotes || {}).length === 0 &&
+      federationOptions
+        ? Array.from(getUsedShares(federationOptions))
+            .filter((pkg) => !pkg.endsWith('/'))
+            .filter((pkg) => {
+              const shareItem =
+                federationOptions.shared[pkg] ||
+                Object.entries(federationOptions.shared).find(
+                  ([key]) => key.endsWith('/') && pkg.startsWith(key)
+                )?.[1];
+              const isExplicitShare = Object.prototype.hasOwnProperty.call(
+                federationOptions.shared,
+                pkg
+              );
+              return (
+                shareItem?.shareConfig?.singleton === true &&
+                shareItem?.shareConfig?.import !== false &&
+                !shareItem?.shareConfig?.treeShaking &&
+                (isExplicitShare ||
+                  typeof shareItem?.shareConfig?.import === 'string' ||
+                  Boolean(getProjectResolvedImportPath(pkg)))
+              );
+            })
+            .map((pkg) => toViteEncodedId(getLoadShareModulePath(pkg, false, federationOptions)))
+        : [];
+    const sharedPreloadBlock =
+      sharedPreloadSources.length > 0
+        ? `
+  const __mfSharedPreloadUrls = ${JSON.stringify(sharedPreloadSources)};
+  await Promise.all(__mfSharedPreloadUrls.map((src) => import(/* @vite-ignore */ src)));`
+        : '';
     const remoteCachePrefix = getRuntimeRemoteCachePrefix(federationOptions);
     const preloadRegistrationParameter = isLoadedFirstClientBuild ? ', registration' : '';
     const preloadRegistrationBlock = isLoadedFirstClientBuild
@@ -407,7 +448,7 @@ const __mfCurrentScript = document.currentScript;
   const __mfHostInit = await ${importExpression(initSrc)};
   await __mfHostInit.__tla;
   const { initHost } = __mfHostInit;
-  ${preloadBlock}${pendingShareLoadsAwait}
+  ${preloadBlock}${sharedPreloadBlock}${pendingShareLoadsAwait}
 })().then(() => ${entryImportExpression});
 `;
 


### PR DESCRIPTION
Fixes #1104 

## Summary

Fixes a cold-start failure in remote-only development builds where a shared singleton wrapper is evaluated after the application entry, leaving `react/jsx-dev-runtime`'s `_jsxDEV` undefined on the first page load.

## Root cause

- #1087 removed the static local fallback import from remote-only dev singleton wrappers to prevent the duplicate singleton evaluation described in #1085.
- When the wrapper is first evaluated while the application entry is loading, its shared exports are assigned asynchronously.
- The existing bootstrap awaited `pendingShareLoads`, but the wrapper had not been evaluated yet, so no pending promise had been registered.

## Changes

- Preload remote-only dev singleton wrappers from the `hostInit` bootstrap.
- Await the resulting `pendingShareLoads` before importing the application entry.
- Limit preloading to `singleton: true` shares, excluding `import: false`, tree-shaken shares, and unresolvable generated subpaths.