### PR TITLE
fix: parallelize independent shared preloads

### DIFF
--- a/src/utils/__tests__/serializeRuntimeOptions.test.ts
+++ b/src/utils/__tests__/serializeRuntimeOptions.test.ts
@@ -1,4 +1,37 @@
-import { serializeRuntimeOptions } from '../serializeRuntimeOptions';
+import { serializeRuntimeOptions, toSafeJsLiteral } from '../serializeRuntimeOptions';
+
+describe('toSafeJsLiteral', () => {
+  it('matches JSON.stringify for ordinary values', () => {
+    expect(toSafeJsLiteral('react')).toBe(String.raw`"react"`);
+    expect(toSafeJsLiteral(42)).toBe('42');
+    expect(toSafeJsLiteral(['a', 'b/c'])).toBe(String.raw`["a","b/c"]`);
+    expect(toSafeJsLiteral({ name: 'host' })).toBe(String.raw`{"name":"host"}`);
+  });
+
+  it('embeds undefined as the bare keyword, matching template-literal interpolation of JSON.stringify(undefined)', () => {
+    expect(toSafeJsLiteral(undefined)).toBe('undefined');
+  });
+
+  it(String.raw`escapes a literal "<" so a string value cannot form "</script>"`, () => {
+    const escaped = toSafeJsLiteral('</script>');
+    expect(escaped).not.toContain('<');
+    expect(JSON.parse(escaped)).toBe('</script>');
+  });
+
+  it('escapes U+2028/U+2029 so the result stays a single valid string literal', () => {
+    const value = 'line\u2028sep\u2029break';
+    const escaped = toSafeJsLiteral(value);
+    expect(escaped).not.toContain('\u2028');
+    expect(escaped).not.toContain('\u2029');
+    expect(new Function(`return ${escaped};`)()).toBe(value);
+  });
+
+  it('produces a value that evaluates back to the original when embedded in generated code', () => {
+    const original = { pkg: '</script>', note: 'a\u2028b' };
+    const roundTripped = new Function(`return ${toSafeJsLiteral(original)};`)();
+    expect(roundTripped).toEqual(original);
+  });
+});
 
 describe('generateRuntimePluginOption - safe JS literal', () => {
   it('should serialize complex megaObject', () => {

--- a/src/utils/serializeRuntimeOptions.ts
+++ b/src/utils/serializeRuntimeOptions.ts
@@ -1,3 +1,25 @@
+// JSON.stringify alone does not escape a literal `<`, and can return `undefined`
+// (not the string "undefined") for values like `undefined` itself. Values embedded
+// via JSON.stringify into generated JS can break out of a `<script>` tag if that
+// code is later inlined into HTML (via a literal `</script>`), or terminate a
+// string literal early via a raw U+2028/U+2029 line separator. Use this wherever a
+// value is interpolated into code we generate, instead of JSON.stringify directly.
+const UNSAFE_JS_CHAR_MAP: Record<string, string> = {
+  '<': '\\u003C',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
+const UNSAFE_JS_CHAR_PATTERN = /[<\u2028\u2029]/g;
+
+export function toSafeJsLiteral(value: unknown): string {
+  const json = JSON.stringify(value);
+  // JSON.stringify(undefined) (and of functions/symbols) returns undefined rather
+  // than a string. Interpolating that into a template literal previously produced
+  // the bare `undefined` keyword in the generated code; preserve that behavior.
+  if (json === undefined) return 'undefined';
+  return json.replace(UNSAFE_JS_CHAR_PATTERN, (char) => UNSAFE_JS_CHAR_MAP[char]);
+}
+
 /**
  * Serializes a JavaScript object into a string of source code that can be evaluated.
  * This function is used to create runtime plugin options without relying solely on JSON.stringify,
@@ -22,23 +44,23 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
 
     const type = typeof val;
 
-    if (type === 'string') return JSON.stringify(val);
+    if (type === 'string') return toSafeJsLiteral(val);
     if (type === 'number' || type === 'boolean') return String(val);
     if (type === 'undefined') return 'undefined';
 
     // Handle Symbol
     if (type === 'symbol') {
       const desc = val.description ?? '';
-      return `Symbol(${JSON.stringify(desc)})`;
+      return `Symbol(${toSafeJsLiteral(desc)})`;
     }
 
     // Handle Function (returns the function's source code)
     if (type === 'function') return val.toString();
 
     // 2. Handle special built-in objects
-    if (val instanceof Date) return `new Date(${JSON.stringify(val.toISOString())})`;
+    if (val instanceof Date) return `new Date(${toSafeJsLiteral(val.toISOString())})`;
     if (val instanceof RegExp) {
-      return `new RegExp(${JSON.stringify(val.source)}, ${JSON.stringify(val.flags)})`;
+      return `new RegExp(${toSafeJsLiteral(val.source)}, ${toSafeJsLiteral(val.flags)})`;
     }
 
     // 3. Handle objects while detecting cycles in the active recursion path.
@@ -68,7 +90,7 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
         const properties: string[] = [];
         for (const key in val) {
           if (Object.prototype.hasOwnProperty.call(val, key)) {
-            properties.push(`${JSON.stringify(key)}: ${valueToCode(val[key])}`);
+            properties.push(`${toSafeJsLiteral(key)}: ${valueToCode(val[key])}`);
           }
         }
         return `{${properties.join(', ')}}`;
@@ -78,8 +100,8 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
     }
 
     // 4. Fallback case (e.g., BigInt)
-    // Coerce to string and then JSON.stringify that string for safety
-    return JSON.stringify(String(val));
+    // Coerce to string and then serialize that string for safety
+    return toSafeJsLiteral(String(val));
   }
 
   // Start serialization for the top-level object
@@ -88,7 +110,7 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
   // Iterate over the properties of the root 'options' object
   for (const key in options) {
     if (Object.prototype.hasOwnProperty.call(options, key)) {
-      topLevelProps.push(`${JSON.stringify(key)}: ${valueToCode(options[key])}`);
+      topLevelProps.push(`${toSafeJsLiteral(key)}: ${valueToCode(options[key])}`);
     }
   }
 

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -884,7 +884,9 @@ describe('virtualRemoteEntry', () => {
     const hostInit = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'serve');
 
     expect(localMap.indexOf('"react":')).toBeLessThan(localMap.indexOf('"@repro/react-consumer":'));
-    expect(hostInit).toContain('const __mfHostInitShareOrder = ["react","@repro/react-consumer"]');
+    expect(hostInit).toContain(
+      'const __mfHostInitShareBatches = [["react"],["@repro/react-consumer"]]'
+    );
   });
 
   it('orders React package roots before their subpath shares', async () => {
@@ -909,19 +911,22 @@ describe('virtualRemoteEntry', () => {
     mod.addUsedShares('react-dom');
 
     const hostInit = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'serve');
-    const orderMarker = 'const __mfHostInitShareOrder = ';
-    const orderStart = hostInit.indexOf(orderMarker);
-    const orderLineEnd = hostInit.indexOf('\n', orderStart);
-    const orderSource =
-      orderStart === -1 || orderLineEnd === -1
+    const batchesMarker = 'const __mfHostInitShareBatches = ';
+    const batchesStart = hostInit.indexOf(batchesMarker);
+    const batchesLineEnd = hostInit.indexOf('\n', batchesStart);
+    const batchesSource =
+      batchesStart === -1 || batchesLineEnd === -1
         ? '[]'
-        : hostInit.slice(orderStart + orderMarker.length, orderLineEnd).trim();
-    const order = JSON.parse(
-      orderSource.endsWith(';') ? orderSource.slice(0, -1) : orderSource
-    ) as string[];
+        : hostInit.slice(batchesStart + batchesMarker.length, batchesLineEnd).trim();
+    const batches = JSON.parse(
+      batchesSource.endsWith(';') ? batchesSource.slice(0, -1) : batchesSource
+    ) as string[][];
+    const order = batches.flat();
 
     expect(order.indexOf('react')).toBeLessThan(order.indexOf('react/jsx-runtime'));
     expect(order.indexOf('react-dom')).toBeLessThan(order.indexOf('react-dom/client'));
+    // react and react-dom have no dependency relationship, so they batch together.
+    expect(batches[0]).toEqual(expect.arrayContaining(['react', 'react-dom']));
   });
 
   it('uses auto-detected workspace import path in localSharedImportMap', async () => {
@@ -1464,7 +1469,7 @@ describe('virtualRemoteEntry', () => {
 
     const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
 
-    expect(code).toContain('const __mfHostInitShareOrder');
+    expect(code).toContain('const __mfHostInitShareBatches');
     expect(code).toContain('"lit/decorators.js"');
   });
 
@@ -1516,7 +1521,86 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain(
       'const {usedShared} = await import("virtual:mf-localSharedImportMap:__mfe_internal__host")'
     );
-    expect(code).toContain('for (const pkg of __mfHostInitShareOrder)');
+    expect(code).toContain('for (const __mfHostInitShareBatch of __mfHostInitShareBatches)');
+  });
+
+  it('preloads independent shared packages in parallel during host auto init', async () => {
+    const share = (name: string) => ({
+      name,
+      from: '',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: { singleton: true, requiredVersion: '^1.0.0', strictVersion: false },
+    });
+    normalizedSharedMock.mockReturnValue({
+      'pkg-a': share('pkg-a'),
+      'pkg-b': share('pkg-b'),
+    });
+    const mod = await import('../virtualRemoteEntry');
+
+    mod.getUsedShares().clear();
+    mod.addUsedShares('pkg-a');
+    mod.addUsedShares('pkg-b');
+
+    const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
+
+    const batchesMarker = 'const __mfHostInitShareBatches = ';
+    const batchesStart = code.indexOf(batchesMarker);
+    expect(batchesStart).not.toBe(-1);
+    const loopEnd = code.indexOf('return runtime;', batchesStart);
+    const loopCode = code.slice(batchesStart, loopEnd);
+
+    // pkg-a and pkg-b have no dependency relationship, so they must sit in
+    // the same batch and load concurrently instead of one after another.
+    expect(loopCode).toContain('await Promise.all(');
+
+    const order: string[] = [];
+    const resolvers: Record<string, (factory: () => unknown) => void> = {};
+    const runtime = {
+      loadShare: (pkg: string) => {
+        order.push(`start:${pkg}`);
+        return new Promise((resolve) => {
+          resolvers[pkg] = resolve;
+        }).then((factory) => {
+          order.push(`end:${pkg}`);
+          return factory;
+        });
+      },
+    };
+
+    const run = new Function(
+      'usedShared',
+      'runtime',
+      '__mfModuleCache',
+      '__mfGetSharedCacheDescriptor',
+      '__mfReadSharedCache',
+      '__mfReadSharedCacheOwner',
+      '__mfWriteSharedCache',
+      '__mfNormalizeRuntimeShare',
+      `return (async () => { ${loopCode} })();`
+    );
+
+    const donePromise = run(
+      { 'pkg-a': share('pkg-a'), 'pkg-b': share('pkg-b') },
+      runtime,
+      { share: {} },
+      (pkg: string) => ({ canonical: pkg }),
+      () => undefined,
+      () => undefined,
+      () => {},
+      (m: unknown) => m
+    );
+
+    // Let both loadShare calls start before resolving either.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['start:pkg-a', 'start:pkg-b']);
+
+    resolvers['pkg-a'](() => ({}));
+    resolvers['pkg-b'](() => ({}));
+    await donePromise;
+
+    expect(order).toEqual(['start:pkg-a', 'start:pkg-b', 'end:pkg-a', 'end:pkg-b']);
   });
 
   it('seeds package subpath shares and shared dependencies before their consumers', async () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -13,7 +13,7 @@ import {
   packageNameEncode,
   sharedCacheHelperCode,
 } from '../utils/packageUtils';
-import { serializeRuntimeOptions } from '../utils/serializeRuntimeOptions';
+import { serializeRuntimeOptions, toSafeJsLiteral } from '../utils/serializeRuntimeOptions';
 import { SSR_ONLY_RUNTIME_PLUGINS } from '../utils/ssrCapabilities';
 import VirtualModule, { MF_OWNER_INFIX } from '../utils/VirtualModule';
 import { getVirtualExposesId } from './virtualExposes';
@@ -159,7 +159,7 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
     .map((pkg, index) => {
       const shareItem = getNormalizeShareItem(pkg, resolvedOptions);
       if (!shareItem?.shareConfig.eager || shareItem.shareConfig.import === false) return '';
-      return `import * as __mfEagerShare_${index} from ${JSON.stringify(
+      return `import * as __mfEagerShare_${index} from ${toSafeJsLiteral(
         getLocalSharedPackagePath(pkg, shareItem, options)
       )};`;
     })
@@ -174,14 +174,14 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
         .map((pkg, index) => {
           const shareItem = getNormalizeShareItem(pkg, resolvedOptions);
           return `
-        ${JSON.stringify(pkg)}: async () => {
+        ${toSafeJsLiteral(pkg)}: async () => {
           ${
             shareItem?.shareConfig.import === false
-              ? `throw new Error(\`[Module Federation] Shared module '\${${JSON.stringify(pkg)}}' must be provided by host\`);`
+              ? `throw new Error(\`[Module Federation] Shared module '\${${toSafeJsLiteral(pkg)}}' must be provided by host\`);`
               : shareItem?.shareConfig.eager
                 ? `let pkg = __mfEagerShare_${index};
             return pkg;`
-                : `let pkg = await import(${JSON.stringify(getLocalSharedPackagePath(pkg, shareItem, options))});
+                : `let pkg = await import(${toSafeJsLiteral(getLocalSharedPackagePath(pkg, shareItem, options))});
             return pkg;`
           }
         }
@@ -232,23 +232,23 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
               ? 0
               : 1;
           return `
-          ${JSON.stringify(key)}: {
-            name: ${JSON.stringify(key)},
-            version: ${JSON.stringify(shareItem.version)},
-            scope: [${JSON.stringify(shareItem.scope)}],
+          ${toSafeJsLiteral(key)}: {
+            name: ${toSafeJsLiteral(key)},
+            version: ${toSafeJsLiteral(shareItem.version)},
+            scope: [${toSafeJsLiteral(shareItem.scope)}],
             loaded: false,
             materialize: ${sharesToMaterialize.has(key)},
             eager: ${Boolean(shareItem.shareConfig.eager)},
-            from: ${JSON.stringify(resolvedOptions.name)},
+            from: ${toSafeJsLiteral(resolvedOptions.name)},
             canLiveRebind: ${canLiveRebind},
             async get () {
               if (${shareItem.shareConfig.import === false}) {
-                throw new Error(\`[Module Federation] Shared module '\${${JSON.stringify(key)}}' must be provided by host\`);
+                throw new Error(\`[Module Federation] Shared module '\${${toSafeJsLiteral(key)}}' must be provided by host\`);
               }
-              usedShared[${JSON.stringify(key)}].loaded = true
-              const {${JSON.stringify(key)}: pkgDynamicImport} = importMap
+              usedShared[${toSafeJsLiteral(key)}].loaded = true
+              const {${toSafeJsLiteral(key)}: pkgDynamicImport} = importMap
               const res = await pkgDynamicImport()
-              const exportModule = ${JSON.stringify(useDirectReactImport)} && ${JSON.stringify(key)} === "react"
+              const exportModule = ${toSafeJsLiteral(useDirectReactImport)} && ${toSafeJsLiteral(key)} === "react"
                 ? (res?.default ?? res)
                 : {...res}
               // All npm packages pre-built by vite will be converted to esm
@@ -264,7 +264,7 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
             },
             shareConfig: {
               singleton: ${shareItem.shareConfig.singleton},
-              requiredVersion: ${JSON.stringify(shareItem.shareConfig.requiredVersion)},
+              requiredVersion: ${toSafeJsLiteral(shareItem.shareConfig.requiredVersion)},
               strictVersion: ${shareItem.shareConfig.strictVersion},
               eager: ${Boolean(shareItem.shareConfig.eager)},
               ${shareItem.shareConfig.import === false ? 'import: false,' : ''}
@@ -272,14 +272,14 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
             ${
               treeShakingConfig
                 ? `treeShaking: {
-              mode: ${JSON.stringify(treeShakingConfig.mode)},
-              usedExports: ${JSON.stringify(treeShakingUsedExports)},
-              providedExports: ${JSON.stringify(treeShakingProviderExports)},
+              mode: ${toSafeJsLiteral(treeShakingConfig.mode)},
+              usedExports: ${toSafeJsLiteral(treeShakingUsedExports)},
+              providedExports: ${toSafeJsLiteral(treeShakingProviderExports)},
               status: ${treeShakingStatus},
               ${
                 treeShakingProviderImportId
                   ? `async get() {
-                const container = await import(${JSON.stringify(treeShakingProviderImportId)});
+                const container = await import(${toSafeJsLiteral(treeShakingProviderImportId)});
                 if (typeof container.init === "function") await container.init();
                 return container.get();
               },`
@@ -300,14 +300,14 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
           if (!remote) return null;
           return `
                 {
-                  alias: ${JSON.stringify(key)},
-                  entryGlobalName: ${JSON.stringify(remote.entryGlobalName)},
-                  name: ${JSON.stringify(
+                  alias: ${toSafeJsLiteral(key)},
+                  entryGlobalName: ${toSafeJsLiteral(remote.entryGlobalName)},
+                  name: ${toSafeJsLiteral(
                     options ? getRuntimeRemoteAlias(key, options) : remote.name
                   )},
-                  type: ${JSON.stringify(remote.type)},
-                  entry: ${JSON.stringify(remote.entry)},
-                  shareScope: ${JSON.stringify(remote.shareScope ?? 'default')},
+                  type: ${toSafeJsLiteral(remote.type)},
+                  entry: ${toSafeJsLiteral(remote.entry)},
+                  shareScope: ${toSafeJsLiteral(remote.shareScope ?? 'default')},
                 }
           `;
         })
@@ -503,8 +503,8 @@ function generateSharedCacheSeedItem(
 ) {
   const cacheDescriptor = getSharedCacheDescriptor(pkg, shareItem);
   const cacheOwner = options.name;
-  return `if (__mfReadSharedCache(__mfModuleCache.share, ${JSON.stringify(cacheDescriptor)}) === undefined) {
-        const mod = await import(${JSON.stringify(importPath)});
+  return `if (__mfReadSharedCache(__mfModuleCache.share, ${toSafeJsLiteral(cacheDescriptor)}) === undefined) {
+        const mod = await import(${toSafeJsLiteral(importPath)});
         ${normalizeRuntimeShareCode}
         const normalizedModule = __mfNormalizeRuntimeShare(mod);
         const exportModule = normalizedModule === mod ? {...mod} : normalizedModule;
@@ -512,7 +512,7 @@ function generateSharedCacheSeedItem(
           value: true,
           enumerable: false
         });
-        __mfWriteSharedCache(__mfModuleCache.share, ${JSON.stringify(cacheDescriptor)}, exportModule, ${JSON.stringify(cacheOwner)});
+        __mfWriteSharedCache(__mfModuleCache.share, ${toSafeJsLiteral(cacheDescriptor)}, exportModule, ${toSafeJsLiteral(cacheOwner)});
       }`;
 }
 
@@ -687,8 +687,8 @@ function generateRuntimeSharedCacheSeedCode(
   // package's own subpath shares before the package itself.
   const seedBatches = getShareBatches(options, false);
   return `
-    const __mfSeedOrder = ${JSON.stringify(seedBatches.flat())};
-    const __mfSeedBatches = ${JSON.stringify(seedBatches)};
+    const __mfSeedOrder = ${toSafeJsLiteral(seedBatches.flat())};
+    const __mfSeedBatches = ${toSafeJsLiteral(seedBatches)};
     const __mfSeedKeys = __mfSeedOrder.filter((pkg) => usedShared[pkg] && usedShared[pkg].materialize !== false);
     __mfModuleCache.providerInit ||= new Map();
     const __mfInitializeProviderOnce = (key, initialize) => {
@@ -788,7 +788,7 @@ function generateRuntimeSharedCacheSeedCode(
         initialShared[pkg],
         pkg,
         share,
-        ${JSON.stringify(shareStrategy)}
+        ${toSafeJsLiteral(shareStrategy)}
       ));
     };
     const __mfFirstRuntimeSeedBarrierIndex = __mfSeedKeys.findIndex(
@@ -1036,7 +1036,7 @@ export function generateRemoteEntry(
     (share) => !!share?.shareConfig.treeShaking
   );
   const hasMultipleShareScopes = Array.isArray(options.shareScope);
-  const materializedShareBatches = JSON.stringify(getShareBatches(options, false));
+  const materializedShareBatches = toSafeJsLiteral(getShareBatches(options, false));
   const runtimeImports = [
     'init as runtimeInit',
     'loadRemote',
@@ -1115,11 +1115,11 @@ export function generateRemoteEntry(
   }
   ${getRuntimeModuleCacheBootstrapCode(exportConditions)}
   const initTokens = {}
-  const shareScopeNames = Array.isArray(${JSON.stringify(options.shareScope)}) ? ${JSON.stringify(options.shareScope)} : [${JSON.stringify(options.shareScope)}]
-  const shareScopeName = ${JSON.stringify(
+  const shareScopeNames = Array.isArray(${toSafeJsLiteral(options.shareScope)}) ? ${toSafeJsLiteral(options.shareScope)} : [${toSafeJsLiteral(options.shareScope)}]
+  const shareScopeName = ${toSafeJsLiteral(
     hasMultipleShareScopes ? options.shareScope[0] : options.shareScope
   )}
-  const mfName = ${JSON.stringify(options.name)}
+  const mfName = ${toSafeJsLiteral(options.name)}
   const __mfMaterializedShareBatches = ${materializedShareBatches}
   let localSharedImportMapPromise
   let exposesMapPromise
@@ -1327,7 +1327,7 @@ export function generateRemoteEntry(
         .map((item) => {
           const specifier = getSsrOnlyPluginSpecifier(item[1])!;
           const opts = item[2];
-          return `import(${JSON.stringify(specifier)}).then(m => (m.default ?? m)(${opts}))`;
+          return `import(${toSafeJsLiteral(specifier)}).then(m => (m.default ?? m)(${opts}))`;
         })
         .join(', ')}])
       : [];
@@ -1430,7 +1430,7 @@ export function generateRemoteEntry(
       if (!versionMap || versionMap[version] !== currentProvider) return undefined;
       const pinnedProvider = Object.assign({}, provider, {
         version: provider.version ?? version,
-        scope: provider.scope ?? currentProvider?.scope ?? ${JSON.stringify(
+        scope: provider.scope ?? currentProvider?.scope ?? ${toSafeJsLiteral(
           hasMultipleShareScopes ? options.shareScope : [options.shareScope]
         )},
         strategy: 'loaded-first'
@@ -2060,8 +2060,8 @@ export function generateHostAutoInitCode(
 ) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const shouldPreloadShares = resolvedOptions.shareStrategy !== 'loaded-first';
-  const hostInitShareOrder = JSON.stringify(getOrderedUsedShares(options));
-  const cacheOwner = JSON.stringify(resolvedOptions.name);
+  const hostInitShareBatches = toSafeJsLiteral(getShareBatches(options, false));
+  const cacheOwner = toSafeJsLiteral(resolvedOptions.name);
   const preferLocalVinextReact =
     hasPackageDependency('vinext') &&
     (!exportConditions?.includes('browser') || exportConditions.includes('worker'));
@@ -2080,48 +2080,50 @@ export function generateHostAutoInitCode(
           ${
             shouldPreloadShares
               ? `
-          const __mfHostInitShareOrder = ${hostInitShareOrder};
-          for (const pkg of __mfHostInitShareOrder) {
-            const share = usedShared[pkg];
-            if (!share || share.materialize === false) continue;
-            // remoteEntry.init resolves tree-enabled shares into the
-            // coverage-aware cache. Never republish that selected partial under
-            // a generic full-module key here.
-            if (share.treeShaking) continue;
-            const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
-            if (
-              __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined &&
-              __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined
-            ) {
-              continue;
-            }
-            await runtime.loadShare(pkg, {
-              customShareInfo: { shareConfig: share.shareConfig }
-            }).then(async (factory) => {
-              const mod = typeof factory === "function" ? factory() : factory;
-              let resolved = __mfNormalizeRuntimeShare(await Promise.resolve(mod));
-              ${
-                preferLocalVinextReact
-                  ? `if (
-                (pkg === "react" || pkg === "react-dom") &&
-                typeof share.get === "function" &&
-                share.shareConfig?.import !== false
+          const __mfHostInitShareBatches = ${hostInitShareBatches};
+          for (const __mfHostInitShareBatch of __mfHostInitShareBatches) {
+            await Promise.all(__mfHostInitShareBatch.map(async (pkg) => {
+              const share = usedShared[pkg];
+              if (!share || share.materialize === false) return;
+              // remoteEntry.init resolves tree-enabled shares into the
+              // coverage-aware cache. Never republish that selected partial under
+              // a generic full-module key here.
+              if (share.treeShaking) return;
+              const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
+              if (
+                __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined &&
+                __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined
               ) {
-                try {
-                  const localFactory = await share.get();
-                  const localModule = typeof localFactory === "function" ? localFactory() : localFactory;
-                  resolved = __mfNormalizeRuntimeShare(await Promise.resolve(localModule));
-                } catch {}
-              }`
-                  : ''
+                return;
               }
-              __mfWriteSharedCache(
-                __mfModuleCache.share,
-                cacheDescriptor,
-                resolved,
-                ${cacheOwner}
-              );
-            });
+              await runtime.loadShare(pkg, {
+                customShareInfo: { shareConfig: share.shareConfig }
+              }).then(async (factory) => {
+                const mod = typeof factory === "function" ? factory() : factory;
+                let resolved = __mfNormalizeRuntimeShare(await Promise.resolve(mod));
+                ${
+                  preferLocalVinextReact
+                    ? `if (
+                  (pkg === "react" || pkg === "react-dom") &&
+                  typeof share.get === "function" &&
+                  share.shareConfig?.import !== false
+                ) {
+                  try {
+                    const localFactory = await share.get();
+                    const localModule = typeof localFactory === "function" ? localFactory() : localFactory;
+                    resolved = __mfNormalizeRuntimeShare(await Promise.resolve(localModule));
+                  } catch {}
+                }`
+                    : ''
+                }
+                __mfWriteSharedCache(
+                  __mfModuleCache.share,
+                  cacheDescriptor,
+                  resolved,
+                  ${cacheOwner}
+                );
+              });
+            }));
           }
           `
               : ''
@@ -2147,7 +2149,7 @@ export function writeHostAutoInit(
   if (exportConditions !== undefined) state.exportConditions = exportConditions;
   state.module.writeSync(
     generateHostAutoInitCode(
-      JSON.stringify(remoteEntryId),
+      toSafeJsLiteral(remoteEntryId),
       command,
       options,
       state.exportConditions

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -2,6 +2,7 @@ import VirtualModule, { MF_OWNER_INFIX } from '../utils/VirtualModule';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { SERVER_ENV_GUARD } from '../utils/ssrCapabilities';
 import { isReactServerConditions } from '../utils/sharedExportConditions';
+import { toSafeJsLiteral } from '../utils/serializeRuntimeOptions';
 
 export const virtualRuntimeInitStatus = new VirtualModule('runtimeInit');
 const runtimeInitModules = new WeakMap<NormalizedModuleFederationOptions, VirtualModule>();
@@ -87,7 +88,7 @@ function getSsrNoopResolveCode(
   if (!enableSsrInit) return '';
 
   const hostInitResolveCode = hostInitImportId
-    ? `import(${JSON.stringify(hostInitImportId)})
+    ? `import(${toSafeJsLiteral(hostInitImportId)})
       .then(function(mod) { return mod.hostInitPromise; })
       .then(function(runtime) {
         ${initResolveExpression}(runtime);
@@ -107,7 +108,7 @@ function getSsrNoopResolveCode(
   // dep optimization or client-bundle inclusion — they only run server-side.
   //
   // Falls back to noops if the runtime is unavailable.
-  const remotesJson = JSON.stringify(ssrRemotes);
+  const remotesJson = toSafeJsLiteral(ssrRemotes);
   return `if (${SERVER_ENV_GUARD}) {
     var _noop = { loadRemote: function() { return Promise.resolve(undefined); }, loadShare: function() { return Promise.resolve(undefined); } };
     ${hostInitResolveCode}.then(function(resolved) {
@@ -138,7 +139,7 @@ function getRuntimeInitStateBootstrapCode(options: {
   ssrRemotes?: Array<{ name: string; entry: string; type: string }>;
 }) {
   return `
-const ${options.globalKeyVar} = ${JSON.stringify(getRuntimeInitGlobalKey(options.ownerImportId))};
+const ${options.globalKeyVar} = ${toSafeJsLiteral(getRuntimeInitGlobalKey(options.ownerImportId))};
 let ${options.stateVar} = globalThis[${options.globalKeyVar}];
 if (!${options.stateVar}) {
   ${getDeferredInitPromiseCode()}
@@ -166,8 +167,8 @@ export function getRuntimeInitBootstrapCode(
   exportConditions?: readonly string[]
 ) {
   return `
-const globalKey = ${JSON.stringify(getRuntimeInitGlobalKey(ownerImportId))};
-const moduleCacheGlobalKey = ${JSON.stringify(getModuleCacheGlobalKey(exportConditions))};
+const globalKey = ${toSafeJsLiteral(getRuntimeInitGlobalKey(ownerImportId))};
+const moduleCacheGlobalKey = ${toSafeJsLiteral(getModuleCacheGlobalKey(exportConditions))};
 globalThis[moduleCacheGlobalKey] ||= { share: {}, remote: {} };
 globalThis[moduleCacheGlobalKey].share ||= {};
 globalThis[moduleCacheGlobalKey].remote ||= {};
@@ -197,7 +198,7 @@ globalThis[globalKey].moduleCache.remote ||= {};
 
 export function getRuntimeModuleCacheBootstrapCode(exportConditions?: readonly string[]) {
   return `
-const __mfCacheGlobalKey = ${JSON.stringify(getModuleCacheGlobalKey(exportConditions))};
+const __mfCacheGlobalKey = ${toSafeJsLiteral(getModuleCacheGlobalKey(exportConditions))};
 globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
 globalThis[__mfCacheGlobalKey].share ||= {};
 globalThis[__mfCacheGlobalKey].remote ||= {};


### PR DESCRIPTION
Close #1095

Batches independent shared-package preloads with Promise.all instead of loading one at a time, cutting waterfall while preserving dependency ordering.