### PR TITLE
fix: prefetch remote entries before init

### DIFF
--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -81,6 +81,30 @@ describe('host build', () => {
     expect(bootstrapCode).toContain('await initHost();');
   });
 
+  it('prefetches module remote entries before host init for version-first', async () => {
+    const output = await buildFixture({
+      fixture: 'loaded-first-static-host',
+      mfOptions: { ...HOST_BASE_MF_OPTIONS, hostInitInjectLocation: 'html' },
+    });
+    const bootstrapAsset = output.output.find(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+
+    expect(bootstrapAsset).toBeDefined();
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+    const prefetchIndex = bootstrapCode.indexOf('"http://localhost:3001/remoteEntry.js"');
+
+    // The remote entry download must start before initHost() so it overlaps
+    // the shared preloads instead of queueing behind them.
+    expect(prefetchIndex).toBeGreaterThanOrEqual(0);
+    expect(bootstrapCode).toContain(
+      'import(/* @vite-ignore */ __mfRemoteEntryPrefetchUrl).catch(() => {});'
+    );
+    expect(prefetchIndex).toBeLessThan(bootstrapCode.indexOf('await initHost()'));
+    expect(bootstrapCode).toContain('__mfPreloadRemote(');
+    expect(bootstrapCode).not.toMatch(/^await /m);
+  });
+
   it('transforms remote module imports into federation loadRemote() calls', async () => {
     const output = await buildFixture({
       fixture: 'basic-host',

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -1160,6 +1160,71 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('Promise.all(__mfRemotePreloads)');
   });
 
+  it('prefetches module-type remote entries before host init for version-first', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-entry-prefetch-'));
+    const federationOptions = {
+      internalName: 'host',
+      name: 'host',
+      shareStrategy: 'version-first',
+      shared: {},
+      remotes: {
+        remote: {
+          entry: 'http://localhost:5001/remoteEntry.js',
+          entryGlobalName: 'remote',
+          name: 'remote',
+          type: 'module',
+          shareScope: 'default',
+        },
+        legacy: {
+          entry: 'http://localhost:5002/remoteEntry.js',
+          entryGlobalName: 'legacy',
+          name: 'legacy',
+          type: 'var',
+          shareScope: 'default',
+        },
+      },
+    } as any;
+    addUsedRemote('remote', 'remote/Route', federationOptions);
+    addUsedRemote('remote', 'remote/Button', federationOptions);
+    addUsedRemote('legacy', 'legacy/Widget', federationOptions);
+
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'entry',
+      federationOptions,
+    });
+    const buildPlugin = plugins[1];
+    runConfigResolved(buildPlugin, {
+      root: tempDir,
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: { input: '/src/main.ts' } },
+    } as unknown as ResolvedConfig);
+
+    const result = (await runTransform(buildPlugin, 'export const app = true;', '/src/main.ts')) as
+      | { code: string }
+      | undefined;
+    const code = result?.code ?? '';
+
+    // Deduped across remote modules; script-loaded (var) remotes are excluded.
+    expect(code).toContain(
+      'const __mfRemoteEntryPrefetchUrls = ["http://localhost:5001/remoteEntry.js"];'
+    );
+    expect(code).not.toContain('http://localhost:5002/remoteEntry.js');
+    // A prefetch failure must stay silent; loadRemote reports real errors later.
+    expect(code).toContain(
+      'import(/* @vite-ignore */ __mfRemoteEntryPrefetchUrl).catch(() => {});'
+    );
+    // The prefetch must start before host init so entry downloads overlap
+    // shared preloads instead of queueing behind them.
+    const prefetchIndex = code.indexOf('__mfRemoteEntryPrefetchUrls');
+    expect(prefetchIndex).toBeGreaterThanOrEqual(0);
+    expect(prefetchIndex).toBeLessThan(code.indexOf('(async () => {'));
+    expect(prefetchIndex).toBeLessThan(code.indexOf('await initHost();'));
+    expect(code).not.toMatch(/^await /m);
+  });
+
   it('skips remote preload in the host bootstrap when shareStrategy is loaded-first', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mf-add-entry-loaded-first-'));
     fs.writeFileSync(
@@ -1211,6 +1276,7 @@ describe('pluginAddEntry', () => {
     expect(result?.code).not.toContain('__mfPreloadRemote');
     expect(result?.code).not.toContain('loadRemote');
     expect(result?.code).not.toContain('__mfRemotePreloads');
+    expect(result?.code).not.toContain('__mfRemoteEntryPrefetchUrls');
     expect(result?.code).toContain('await initHost();');
     expect(result?.code).toContain('})().then(() => import("/src/main.ts?mf-entry-bootstrap"));');
   });

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -350,6 +350,38 @@ const __mfCurrentScript = document.currentScript;
           .join(',')
       : '';
 
+    // The remote entry fetch is independent of host init, but loadRemote() only
+    // runs after `await initHost()` finishes its shared preloads, so remote
+    // entries otherwise queue behind every shared chunk (staircase waterfall).
+    // Warm the module-type entry URLs up front: the browser dedupes the
+    // later loadRemote() import of the same URL against the in-flight request.
+    const remoteEntryPrefetchUrls = shouldPreloadRemotes
+      ? Array.from(
+          new Set(
+            remoteSources.flatMap((remote) => {
+              const registration = getRemoteRegistration(
+                remote,
+                normalizedOptions.remotes,
+                federationOptions
+              );
+              return registration &&
+                (registration.type === 'module' || registration.type === 'esm') &&
+                /^(?:https?:)?\/\//.test(registration.entry)
+                ? [registration.entry]
+                : [];
+            })
+          )
+        )
+      : [];
+    const remoteEntryPrefetchBlock =
+      remoteEntryPrefetchUrls.length > 0
+        ? `const __mfRemoteEntryPrefetchUrls = ${JSON.stringify(remoteEntryPrefetchUrls)};
+for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
+  import(/* @vite-ignore */ __mfRemoteEntryPrefetchUrl).catch(() => {});
+}
+`
+        : '';
+
     const sharedPreloadSources =
       _command === 'serve' &&
       waitsForInit &&
@@ -456,6 +488,7 @@ const __mfCurrentScript = document.currentScript;
       getRuntimeModuleCacheBootstrapCode(),
       importHelper,
       entryImportDeclaration,
+      remoteEntryPrefetchBlock,
       importCode,
     ].join('\n');
   }


### PR DESCRIPTION
Close #1112

Start module-type remote entry downloads in parallel with host init shared preloads, removing a serial network round (staircase waterfall).