### PR TITLE
fix: preserve host-owned singleton cache

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2691,7 +2691,7 @@ describe('virtualRemoteEntry', () => {
     );
   });
 
-  it('refreshes the host cache from the runtime-selected version-first share in builds', async () => {
+  it('refreshes external shares while preserving the host-owned cache in builds', async () => {
     const mod = await import('../virtualRemoteEntry');
 
     mod.getUsedShares().clear();
@@ -2700,7 +2700,9 @@ describe('virtualRemoteEntry', () => {
     const code = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
 
     expect(code).toContain('const __mfGetSharedCacheDescriptor =');
-    expect(code).toContain('await runtime.loadShare(pkg, {');
+    expect(code).toContain(
+      '__mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) === "host"'
+    );
     expect(code).not.toContain(
       '__mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined'
     );

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2087,14 +2087,12 @@ export function generateHostAutoInitCode(
               // a generic full-module key here.
               if (share.treeShaking) return;
               const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
-              ${
-                _command === 'serve'
-                  ? `if (
+              if (
                 __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined &&
-                __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined
-              ) return;`
-                  : ''
-              }
+                __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) ${
+                  _command === 'serve' ? '!== undefined' : `=== ${cacheOwner}`
+                }
+              ) return;
               await runtime.loadShare(pkg, {
                 customShareInfo: { shareConfig: share.shareConfig }
               }).then(async (factory) => {


### PR DESCRIPTION
 Preserves local Vite singleton identity while still refreshing runtime-selected Webpack/Rspack shares.