### PR TITLE
fix: control missing import false warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ export default defineConfig({
 In this remote app configuration, we define a remoteEntry.js file that will expose the App component.
 The shared property ensures that both host and remote applications use the same vue library.
 
+### Host-only shared dependencies
+
+Use `import: false` when a dependency must be provided by the host and should not be bundled as a local fallback. If it is intentionally not installed locally, the named-export detection warning can be suppressed:
+
+```ts
+shared: {
+  "@pos-dashboard/host": {
+    singleton: true,
+    import: false,
+    suppressMissingImportWarning: true,
+  },
+},
+```
+
+`suppressMissingImportWarning` defaults to `false`. Enable it only when the host is guaranteed to provide the dependency and local named-export detection is unnecessary.
+
 ## The Host Application configuration
 
 file **host/vite.config.ts**

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -142,6 +142,7 @@ export interface ShareItem {
   shareConfig: SharedConfig &
     moduleFederationPlugin.SharedConfig & {
       treeShaking?: TreeShakingConfig;
+      suppressMissingImportWarning?: boolean;
     };
 }
 
@@ -204,6 +205,7 @@ function normalizeShareItem(
         eager?: boolean;
         requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion'];
         strictVersion?: boolean;
+        suppressMissingImportWarning?: boolean;
         treeShaking?: TreeShakingConfig;
       }
 ): ShareItem {
@@ -280,6 +282,7 @@ function normalizeShareItem(
               ? `^${version}`
               : '*',
       strictVersion: !!shareItem.strictVersion,
+      ...(shareItem.suppressMissingImportWarning ? { suppressMissingImportWarning: true } : {}),
       ...(treeShaking ? { treeShaking: { ...treeShaking } } : {}),
     },
   };
@@ -306,6 +309,8 @@ function normalizeShared(
             eager?: boolean;
             requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion'];
             strictVersion?: boolean;
+            /** Suppress the missing local dependency warning for `import: false` shares. */
+            suppressMissingImportWarning?: boolean;
             treeShaking?: TreeShakingConfig;
           }
       >
@@ -438,6 +443,8 @@ export type ModuleFederationOptions = {
             eager?: boolean;
             requiredVersion?: moduleFederationPlugin.SharedConfig['requiredVersion'];
             strictVersion?: boolean;
+            /** Suppress the missing local dependency warning for `import: false` shares. */
+            suppressMissingImportWarning?: boolean;
             treeShaking?: TreeShakingConfig;
             import?: moduleFederationPlugin.SharedConfig['import'];
           }

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2986,6 +2986,40 @@ describe('writeLoadShareModule', () => {
     expect(mfWarnSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('warns by default for a missing import: false dependency', () => {
+    const options = normalizeModuleFederationOptions({
+      name: 'default-warning',
+      shared: {
+        'host-only-dep': {
+          import: false,
+          singleton: true,
+        },
+      },
+    });
+
+    writeLoadShareModule('host-only-dep', options.shared['host-only-dep'], 'serve', false, options);
+
+    expect(options.shared['host-only-dep'].shareConfig.suppressMissingImportWarning).toBeFalsy();
+    expect(mfWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses missing import: false dependency warnings when configured', () => {
+    const options = normalizeModuleFederationOptions({
+      name: 'suppressed-warning',
+      shared: {
+        'host-only-dep': {
+          import: false,
+          singleton: true,
+          suppressMissingImportWarning: true,
+        },
+      },
+    });
+
+    writeLoadShareModule('host-only-dep', options.shared['host-only-dep'], 'serve', false, options);
+
+    expect(mfWarnSpy).not.toHaveBeenCalled();
+  });
+
   it('auto-detects workspace package entry when the shared dep is not directly resolvable', () => {
     const pkg = 'transitive-pkg';
     const mockShareItem: ShareItem = {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2965,6 +2965,27 @@ describe('writeLoadShareModule', () => {
     );
   });
 
+  it('warns once when rewriting a missing import: false dependency', () => {
+    const pkg = 'host-only-dep';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+    writeLoadShareModule(pkg, mockShareItem, 'serve', false);
+
+    expect(mfWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('auto-detects workspace package entry when the shared dep is not directly resolvable', () => {
     const pkg = 'transitive-pkg';
     const mockShareItem: ShareItem = {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1122,6 +1122,7 @@ interface SharedVirtualModuleState {
   treeShakingProviderCacheMap: Record<string, VirtualModule>;
   materializedTreeShakingProviders: Set<string>;
   loadShareCacheMap: Record<string, VirtualModule>;
+  warnedMissingImportFalse: Set<string>;
   ownerKey?: string;
 }
 
@@ -1131,6 +1132,7 @@ const legacySharedVirtualModuleState: SharedVirtualModuleState = {
   treeShakingProviderCacheMap: {},
   materializedTreeShakingProviders: new Set(),
   loadShareCacheMap: {},
+  warnedMissingImportFalse: new Set(),
 };
 const sharedVirtualModuleStates = new WeakMap<
   NormalizedModuleFederationOptions,
@@ -1155,6 +1157,7 @@ function getSharedVirtualModuleState(options?: NormalizedModuleFederationOptions
       treeShakingProviderCacheMap: {},
       materializedTreeShakingProviders: new Set(),
       loadShareCacheMap: {},
+      warnedMissingImportFalse: new Set(),
       ownerKey: `${options.internalName}${MF_OWNER_INFIX}${nextSharedVirtualModuleOwnerId++}`,
     };
     sharedVirtualModuleStates.set(options, state);
@@ -1907,7 +1910,9 @@ export function writeLoadShareModule(
         treeShakingConsumer
       );
     } else {
-      if (detectedNamedExports === undefined) {
+      const { warnedMissingImportFalse } = getSharedVirtualModuleState(resolvedOptions);
+      if (detectedNamedExports === undefined && !warnedMissingImportFalse.has(pkg)) {
+        warnedMissingImportFalse.add(pkg);
         mfWarn(
           `Shared dependency "${pkg}" has import: false but is not installed locally.\n` +
             `  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n` +

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1911,7 +1911,11 @@ export function writeLoadShareModule(
       );
     } else {
       const { warnedMissingImportFalse } = getSharedVirtualModuleState(resolvedOptions);
-      if (detectedNamedExports === undefined && !warnedMissingImportFalse.has(pkg)) {
+      if (
+        detectedNamedExports === undefined &&
+        !shareItem.shareConfig.suppressMissingImportWarning &&
+        !warnedMissingImportFalse.has(pkg)
+      ) {
         warnedMissingImportFalse.add(pkg);
         mfWarn(
           `Shared dependency "${pkg}" has import: false but is not installed locally.\n` +


### PR DESCRIPTION
Close #1118

 Deduplicates warnings and adds opt-in suppression for intentional host-only dependencies. Default remains false.
 