### PR TITLE
fix: honor hashed filenames across bundlers

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -233,6 +233,53 @@ describe('pluginAddEntry', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  it('applies hash-pattern remote filenames to Rolldown chunks', () => {
+    const plugins = addEntry({
+      entryName: 'remoteEntry',
+      entryPath: 'virtual:mf-remote-entry',
+      fileName: 'remote-entry-[hash].js',
+    });
+    const config = {
+      environments: {
+        federation: {
+          build: {
+            assetsDir: 'static',
+            rolldownOptions: { input: './index.ts' },
+          },
+        },
+      },
+    } as any;
+
+    runConfig(plugins[1], {} as ConfigPluginContext, config, {
+      command: 'build',
+      mode: 'production',
+    });
+
+    const output = config.environments.federation.build.rolldownOptions
+      .output as Rollup.OutputOptions;
+    const chunkFileNames = output.chunkFileNames as Function;
+    expect(chunkFileNames({ name: 'remoteEntry' })).toBe('remote-entry-[hash].js');
+    expect(chunkFileNames({ name: 'other' })).toBe('static/[name]-[hash].js');
+  });
+
+  it('preserves the implicit js extension for hash-pattern filenames', () => {
+    const plugins = addEntry({
+      entryName: 'remoteEntry',
+      entryPath: 'virtual:mf-remote-entry',
+      fileName: 'remoteEntry-[hash]',
+    });
+    const config = {} as UserConfig;
+
+    runConfig(plugins[1], {} as ConfigPluginContext, config, {
+      command: 'build',
+      mode: 'production',
+    });
+
+    const output = config.build!.rolldownOptions!.output as Rollup.OutputOptions;
+    const chunkFileNames = output.chunkFileNames as Function;
+    expect(chunkFileNames({ name: 'remoteEntry' })).toBe('remoteEntry-[hash].js');
+  });
+
   it('serves html proxy imports with the configured base', () => {
     const [servePlugin] = addEntry({
       entryName: 'hostInit',

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -236,24 +236,35 @@ export function getBuildInput(config: any) {
   return config.build?.rollupOptions?.input ?? config.build?.rolldownOptions?.input;
 }
 
-function patchHashEntryFileName(output: any, entryName: string, fileName: string) {
-  const originalEntryFileNames = output.entryFileNames;
-  output.entryFileNames = (chunkInfo: { name?: string }, ...args: unknown[]) => {
-    if (chunkInfo?.name === entryName) return fileName;
-    if (typeof originalEntryFileNames === 'function') {
-      return originalEntryFileNames(chunkInfo, ...args);
-    }
-    return originalEntryFileNames || 'assets/[name]-[hash].js';
-  };
+function patchHashEntryFileName(
+  output: any,
+  entryName: string,
+  fileName: string,
+  defaultFileNames: string
+) {
+  for (const option of ['entryFileNames', 'chunkFileNames']) {
+    const originalFileNames = output[option];
+    output[option] = (chunkInfo: { name?: string }, ...args: unknown[]) => {
+      if (chunkInfo?.name === entryName) return fileName;
+      if (typeof originalFileNames === 'function') {
+        return originalFileNames(chunkInfo, ...args);
+      }
+      return originalFileNames || defaultFileNames;
+    };
+  }
 }
 
 function patchHashEntryFileNames(config: any, entryName: string, fileName?: string) {
   if (!fileName?.includes?.('[hash')) return;
+  fileName = fileName.replace(/(\[hash(?::\d+)?\])$/, '$1.js');
   config.build ??= {};
   config.build.rollupOptions ??= {};
   config.build.rolldownOptions ??= {};
+  const assetsDir = config.build.assetsDir ?? 'assets';
+  const defaultFileNames = `${assetsDir ? `${assetsDir}/` : ''}[name]-[hash].js`;
 
-  const patchOutput = (output: any) => patchHashEntryFileName(output, entryName, fileName);
+  const patchOutput = (output: any) =>
+    patchHashEntryFileName(output, entryName, fileName, defaultFileNames);
   const patchBundlerOutput = (bundlerOptions: any) => {
     const output = bundlerOptions.output;
     if (Array.isArray(output)) {
@@ -265,6 +276,9 @@ function patchHashEntryFileNames(config: any, entryName: string, fileName?: stri
 
   patchBundlerOutput(config.build.rollupOptions);
   patchBundlerOutput(config.build.rolldownOptions);
+  Object.values(config.environments ?? {}).forEach((environment) =>
+    patchHashEntryFileNames(environment, entryName, fileName)
+  );
 }
 
 const addEntry = ({


### PR DESCRIPTION
Close #1122

Apply configured hash filenames to Rollup and Rolldown entries/chunks, including Environment API builds, while preserving asset directories.
 