### PR TITLE
fix: share application-local modules by adopting the resolved file as…

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -6,6 +6,9 @@ import type {
   UserConfig,
 } from 'vite';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'node:path';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 import { normalizePathForImport } from '../../utils/buildPaths';
 
@@ -1738,5 +1741,88 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     expect(resolution).not.toBe('timeout');
     expect((resolution as { id: string }).id).toBe('/vite/deps/react.js');
+  });
+
+  it('adopts the resolved project file as import source for app-local shared keys', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    // Downstream helpers stat the adopted file, so use a real one.
+    const storeDir = mkdtempSync(path.join(tmpdir(), 'mf-app-store-'));
+    const storePath = path.join(storeDir, 'store.ts');
+    writeFileSync(storePath, 'export const state = {};\nexport default () => state;\n');
+    existsSyncMock.mockImplementation((filePath: string) => filePath === storePath);
+    readFileSyncMock.mockImplementation((filePath: string) =>
+      filePath === storePath ? 'export const state = {};\nexport default () => state;\n' : ''
+    );
+
+    const shared: NormalizedShared = {
+      'app/store': {
+        name: 'app/store',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '1.0.0', strictVersion: true },
+      },
+    };
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const resolve = async (id: string) => ({
+      id: id === 'app/store' ? storePath : `/resolved/${id}`,
+    });
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta(), resolve } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve } as any,
+      'app/store',
+      '/project/src/main.ts',
+      { isEntry: false }
+    );
+
+    expect((resolution as { id: string }).id).toBeDefined();
+    expect(shared['app/store'].shareConfig.import).toBe(storePath);
+    expect(writeLoadShareModuleMock).toHaveBeenCalledWith(
+      'app/store',
+      shared['app/store'],
+      'build',
+      expect.anything()
+    );
+  });
+
+  it('keeps installed packages untouched when adopting app-local shared keys', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg: string) =>
+      pkg === 'vue' ? '/project/node_modules/vue/index.mjs' : undefined
+    );
+
+    const shared = makeShared();
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const resolve = async (id: string) => ({ id: `/resolved/${id}` });
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta(), resolve } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+    await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve } as any,
+      'vue',
+      '/project/src/main.ts',
+      {
+        isEntry: false,
+      }
+    );
+
+    expect(shared.vue.shareConfig.import).toBeUndefined();
   });
 });

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1795,6 +1795,123 @@ describe('pluginProxySharedModule_preBuild', () => {
     );
   });
 
+  it('waits for app-local shared materialization across concurrent resolutions', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    const storeDir = mkdtempSync(path.join(tmpdir(), 'mf-app-store-'));
+    const storePath = path.join(storeDir, 'store.ts');
+    writeFileSync(storePath, 'export const state = {};\n');
+    existsSyncMock.mockImplementation((filePath: string) => filePath === storePath);
+    readFileSyncMock.mockImplementation((filePath: string) =>
+      filePath === storePath ? 'export const state = {};\n' : ''
+    );
+
+    const shared: NormalizedShared = {
+      'app/store': {
+        name: 'app/store',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '1.0.0', strictVersion: true },
+      },
+    };
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    let signalResolutionStarted!: () => void;
+    let releaseResolution!: () => void;
+    const resolutionStarted = new Promise<void>((resolve) => {
+      signalResolutionStarted = resolve;
+    });
+    const resolutionGate = new Promise<void>((resolve) => {
+      releaseResolution = resolve;
+    });
+    const resolve = async (id: string) => {
+      if (id === 'app/store') {
+        signalResolutionStarted();
+        await resolutionGate;
+        return { id: storePath };
+      }
+      return { id: `/resolved/${id}` };
+    };
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta(), resolve } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const firstResolution = callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve } as any,
+      'app/store',
+      '/project/src/first.ts',
+      { isEntry: false }
+    );
+    await resolutionStarted;
+    const secondResolution = callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve } as any,
+      'app/store',
+      '/project/src/second.ts',
+      { isEntry: false }
+    );
+    const secondState = await Promise.race([
+      Promise.resolve(secondResolution).then(() => 'resolved'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 10)),
+    ]);
+
+    releaseResolution();
+    await Promise.all([firstResolution, secondResolution]);
+
+    expect(secondState).toBe('pending');
+    expect(shared['app/store'].shareConfig.import).toBe(storePath);
+  });
+
+  it('preserves query parameters in resolved app-local shared imports', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    const storeDir = mkdtempSync(path.join(tmpdir(), 'mf-app-store-'));
+    const storePath = path.join(storeDir, 'store.ts');
+    const resolvedStoreId = `${storePath}?raw`;
+    writeFileSync(storePath, 'export const state = {};\n');
+    existsSyncMock.mockImplementation((filePath: string) => filePath === storePath);
+    readFileSyncMock.mockImplementation((filePath: string) =>
+      filePath === storePath ? 'export const state = {};\n' : ''
+    );
+
+    const shared: NormalizedShared = {
+      'app/store': {
+        name: 'app/store',
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: { singleton: true, requiredVersion: '1.0.0', strictVersion: true },
+      },
+    };
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const resolve = async (id: string) => ({
+      id: id === 'app/store' ? resolvedStoreId : `/resolved/${id}`,
+    });
+
+    callHook(
+      proxyPlugin.config,
+      { meta: createPluginMeta(), resolve } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+    await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve } as any,
+      'app/store',
+      '/project/src/main.ts',
+      { isEntry: false }
+    );
+
+    expect(shared['app/store'].shareConfig.import).toBe(resolvedStoreId);
+  });
+
   it('keeps installed packages untouched when adopting app-local shared keys', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
     getInstalledPackageEntryMock.mockImplementation((pkg: string) =>

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL } from 'url';
@@ -80,6 +81,43 @@ function tryResolveFromProjectRoot(source: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+type SharedResolveContext = {
+  resolve: (
+    source: string,
+    importer?: string,
+    options?: { skipSelf?: boolean }
+  ) => Promise<{ id: string; external?: boolean | 'absolute' | 'relative' } | null>;
+};
+
+/**
+ * A shared key that is not an installed package (an application module such as
+ * `app/store`, made resolvable by a user resolver plugin) has no package entry to
+ * inspect, so the generated loadShare module silently falls back to the local
+ * copy and every consumer ends up with its own instance. Resolve the key through
+ * Vite and adopt the resolved project file as the `import` source, which is
+ * exactly what `shared: { 'app/store': { import: './src/store' } }` configures.
+ */
+async function adoptResolvedLocalSharedImport(
+  ctx: SharedResolveContext,
+  source: string,
+  importer: string | undefined,
+  key: string,
+  shareItem: ShareItem
+): Promise<void> {
+  const { shareConfig } = shareItem;
+  if (typeof shareConfig.import === 'string' || shareConfig.import === false) return;
+  // Only bare keys: subpath and node_modules sources always belong to packages.
+  if (source !== key || isNodeModulePath(source)) return;
+  if (tryResolveFromProjectRoot(source)) return;
+  const resolved = await ctx.resolve(source, importer, { skipSelf: true });
+  if (!resolved || resolved.external) return;
+  const id = resolved.id.split('?')[0];
+  if (id.startsWith('\0') || !path.isAbsolute(id) || isNodeModulePath(id) || !existsSync(id)) {
+    return;
+  }
+  shareConfig.import = id;
 }
 
 function isBuildConfigImporter(importer: string | undefined): boolean {
@@ -570,6 +608,7 @@ export function proxySharedModule(options: {
         const loadSharePath = getLoadShareModulePath(shareSource, useRolldown, federationOptions);
         if (!materializedLoadShareSources.has(shareSource)) {
           materializedLoadShareSources.add(shareSource);
+          await adoptResolvedLocalSharedImport(this, source, importer, key, shared[key]);
           writeLoadShareModule(shareSource, shared[key], _command, useRolldown, federationOptions);
           if (shared[key].shareConfig.import !== false) {
             writePreBuildLibPath(shareSource, shared[key], federationOptions);


### PR DESCRIPTION
… import source

A shared key that is not an installed package (an application module such as 'app/store' resolved by a user resolver plugin) has no package entry to inspect for named exports, so the generated loadShare module silently fell back to the local copy and every consumer got its own instance of a singleton.

Resolve such keys through Vite in the loadShare resolveId hook and adopt the resolved project file as shareConfig.import, which is what shared: { 'app/store': { import: './src/store' } } configures explicitly.