### PR TITLE
fix: improve React remote refresh registration

### DIFF
--- a/src/plugins/hmr/__tests__/react.test.ts
+++ b/src/plugins/hmr/__tests__/react.test.ts
@@ -59,6 +59,9 @@ describe('reactAdapter', () => {
     );
     expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
     expect(res.end).toHaveBeenCalledWith(expect.stringContaining('window.location.origin'));
+    expect(res.end).toHaveBeenCalledWith(
+      expect.stringContaining('export const getRefreshReg = __rt.getRefreshReg;')
+    );
   });
 
   it('serves the React refresh proxy under the configured base path', () => {

--- a/src/plugins/hmr/react.ts
+++ b/src/plugins/hmr/react.ts
@@ -47,6 +47,7 @@ const REACT_REFRESH_PROXY_MODULE = [
   `const __rt = await import(__target);`,
   `export const injectIntoGlobalHook = __rt.injectIntoGlobalHook;`,
   `export const register = __rt.register;`,
+  `export const getRefreshReg = __rt.getRefreshReg;`,
   `export const createSignatureFunctionForTransform = __rt.createSignatureFunctionForTransform;`,
   `export const registerExportsForReactRefresh = __rt.registerExportsForReactRefresh;`,
   `export const validateRefreshBoundaryAndEnqueueUpdate = __rt.validateRefreshBoundaryAndEnqueueUpdate;`,


### PR DESCRIPTION
Close #1125

Export getRefreshReg from the React refresh proxy and add regression coverage.