### PR TITLE
fix: improve remote preflight and bindings

### DIFF
--- a/integration/fixtures/nested-remote-transitive/mixed-imports.js
+++ b/integration/fixtures/nested-remote-transitive/mixed-imports.js
@@ -1,0 +1,5 @@
+import { helper } from 'remoteA/shared/helpers';
+
+export const eager = helper;
+export const lazy = () => import('remoteB/heavy');
+export const alsoLazy = () => import('remoteA/shared/helpers');

--- a/integration/remote-dependency-pending.test.ts
+++ b/integration/remote-dependency-pending.test.ts
@@ -45,17 +45,19 @@ describe('remote dependency pending', () => {
 
     const allCode = getAllChunkCode(output);
 
-    expect(allCode).toMatch(/\b(?:const|var)\s+\{\s*View\s*\}\s*=\s*exportModule/);
+    expect(allCode).toMatch(/\b(?:let|var)\s+View\s*;/);
+    expect(allCode).toContain('if ("View" in exportModule)');
+    expect(allCode).toContain('__mf_remote_pending.then(() =>');
     expect(allCode).not.toContain('const pendingPrototype = {};');
     expect(allCode).toMatch(/__loadRemote__ckeditor5__mf_owner__\d+__loadRemote__/);
-    expect(allCode).toContain('const dependencyPending = importModule && importModule.__mf_remote_dependency_pending;');
+    expect(allCode).toContain(
+      'const dependencyPending = importModule && importModule.__mf_remote_dependency_pending;'
+    );
     expect(allCode).toContain('await dependencyPending;');
     expect(allCode).toMatch(
       /\b(?:const|var)\s+__mf_remote_dependency_pending\s*=\s*Promise\.all\(\[__mf_remote_pending\]\)/
     );
-    expect(allCode).not.toMatch(
-      /\b(?:const|var)\s+__mf_remote_dependency_pending\s*=\s*await\b/
-    );
+    expect(allCode).not.toMatch(/\b(?:const|var)\s+__mf_remote_dependency_pending\s*=\s*await\b/);
   });
 
   it('preloads nested remotes discovered through local transitive imports', async () => {
@@ -75,7 +77,8 @@ describe('remote dependency pending', () => {
     expect(allCode).toMatch(
       /await Promise\.all\(\[.*remoteA_mf_1_shared_mf_1_helpers__mf_owner__\d+__loadRemote__.*__mf_remote_pending/
     );
-    expect(allCode).toMatch(/\b(?:const|var)\s+\{\s*helper(?:\s*:\s*helper)?\s*\}\s*=/);
+    expect(allCode).toMatch(/\b(?:let|var)\s+helper\s*;/);
+    expect(allCode).toContain('if ("helper" in exportModule)');
     expect(allCode).toContain('Promise.all([__mf_remote_pending]);');
   });
 });

--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -106,6 +106,43 @@ describe('pluginProxyRemoteEntry', () => {
     expect(exposeResolveCalls).toBe(2);
   });
 
+  it('preflights static remote imports but leaves dynamic remote imports lazy', async () => {
+    const expose = resolve('integration/fixtures/nested-remote-transitive/mixed-imports.js');
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions({
+        exposes: { './widget': { import: expose } as any },
+        remotes: {
+          remoteA: {
+            name: 'remoteA',
+            entry: 'http://localhost:3001/remoteEntry.js',
+            type: 'module',
+          },
+          remoteB: {
+            name: 'remoteB',
+            entry: 'http://localhost:3002/remoteEntry.js',
+            type: 'module',
+          },
+        },
+      }),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+    const context = {
+      resolve: async (source: string) => (source === expose ? { id: expose } : undefined),
+    } as any;
+
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    const generated = await callHook(plugin.load, context, 'virtual:mf-exposes');
+
+    expect(generated).toContain('__loadRemote__remoteA_mf_1_shared_mf_1_helpers');
+    expect(generated).not.toContain('__loadRemote__remoteB_mf_1_heavy');
+  });
+
   it('uses an inlined data-URL origin for dev host init in SSR/module-runner contexts, protocol relative fallback origin otherwise', async () => {
     normalizeModuleFederationOptions({ name: 'test' });
     const plugin = pluginProxyRemoteEntry({

--- a/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
+++ b/src/plugins/__tests__/pluginRemoteNamedExports.test.ts
@@ -104,7 +104,10 @@ describe('pluginRemoteNamedExports', () => {
         'export const __mf_remote_dependency_pending = Promise.all([__mf_ns_0_pending]);'
       );
       expect(result).not.toContain('await ');
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('let foo;');
+      expect(result).toContain('if ("foo" in __mf_ns_0)');
+      expect(result).toContain('__mf_ns_0_pending.then(() =>');
+      expect(result).not.toContain('const { foo: foo } = __mf_ns_0;');
       expect(result).not.toContain('import { foo }');
     });
 
@@ -113,27 +116,27 @@ describe('pluginRemoteNamedExports', () => {
         ['import { View } from "remoteApp/utils";', 'class Foo extends View {}'].join('\n')
       );
 
-      expect(result).toContain('const { View: View } = __mf_ns_0;');
+      expect(result).toContain('let View;');
       expect(result).not.toContain('await ');
     });
 
     it('rewrites multiple named imports', async () => {
       const result = await transform('import { foo, bar, baz } from "remoteApp/utils";');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const { foo: foo, bar: bar, baz: baz } = __mf_ns_0;');
+      expect(result).toContain('let foo;\nlet bar;\nlet baz;');
     });
 
     it('rewrites aliased import', async () => {
       const result = await transform('import { foo as myFoo } from "remoteApp/utils";');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const { foo: myFoo } = __mf_ns_0;');
+      expect(result).toContain('let myFoo;');
     });
 
     it('rewrites default + named imports', async () => {
       const result = await transform('import Default, { foo } from "remoteApp/utils";');
       expect(result).toContain('default as Default');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('let foo;');
     });
 
     it('skips default-only import', async () => {
@@ -153,7 +156,7 @@ describe('pluginRemoteNamedExports', () => {
     it('handles bare remote name (no subpath)', async () => {
       const result = await transform('import { foo } from "remoteApp";');
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('let foo;');
     });
 
     it('skips bare remote-name rewrites inside node_modules files', async () => {
@@ -170,7 +173,7 @@ describe('pluginRemoteNamedExports', () => {
         '/repo/node_modules/some-package/index.js'
       );
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('let foo;');
     });
 
     it('handles multiple remotes in one file', async () => {
@@ -179,8 +182,8 @@ describe('pluginRemoteNamedExports', () => {
         'import { bar } from "otherRemote/helpers";',
       ].join('\n');
       const result = await transform(code);
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
-      expect(result).toContain('const { bar: bar } = __mf_ns_1;');
+      expect(result).toContain('let foo;');
+      expect(result).toContain('let bar;');
     });
 
     it('rewrites multiple remote imports to direct named bindings', async () => {
@@ -189,8 +192,8 @@ describe('pluginRemoteNamedExports', () => {
         'import { useShellStore } from "otherRemote/shellStore";',
       ].join('\n');
       const result = await transform(code);
-      expect(result).toContain('const { useAuth: useAuth } = __mf_ns_0;');
-      expect(result).toContain('const { useShellStore: useShellStore } = __mf_ns_1;');
+      expect(result).toContain('let useAuth;');
+      expect(result).toContain('let useShellStore;');
     });
   });
 
@@ -271,6 +274,8 @@ describe('pluginRemoteNamedExports', () => {
       );
       expect(result).not.toContain('await ');
       expect(result).toContain('__mf_re_');
+      expect(result).toContain('if ("foo" in __mf_ns_0)');
+      expect(result).not.toContain('let __mf_re_1 = __mf_ns_0["foo"]');
       expect(result).toContain('as foo');
     });
 
@@ -300,7 +305,7 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toContain('__moduleExports');
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('let foo;');
     });
 
     it('rewrites namespace import via fallback', async () => {
@@ -325,7 +330,7 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toContain('default as Default');
-      expect(result).toContain('const { foo: foo } = __mf_ns_0;');
+      expect(result).toContain('let foo;');
     });
 
     it('wraps dynamic import via fallback', async () => {
@@ -407,7 +412,7 @@ describe('pluginRemoteNamedExports', () => {
         '/src/app.tsx',
         true
       );
-      expect(result).toContain('const { foo: myFoo } = __mf_ns_0;');
+      expect(result).toContain('let myFoo;');
     });
 
     it('keeps runtime specifiers and skips inline type specifiers via fallback', async () => {
@@ -423,7 +428,7 @@ describe('pluginRemoteNamedExports', () => {
         true
       );
       expect(result).toContain('default as Default');
-      expect(result).toContain('const { foo: myFoo, bar: bar } = __mf_ns_0;');
+      expect(result).toContain('let myFoo;\nlet bar;');
       expect(result).not.toContain('type Foo');
     });
 

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -74,17 +74,22 @@ export default function ({
     );
   }
 
-  function collectImportSources(code: string): string[] {
-    const sources = new Set<string>();
+  function collectImportSources(code: string): Array<{ source: string; dynamic: boolean }> {
+    const sources = new Map<string, boolean>();
     const importRe =
       /(?:^|[;\n\r])\s*import\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']|import\(\s*["']([^"']+)["']\s*\)/g;
 
     for (const match of code.matchAll(importRe)) {
       const source = match[1] || match[2];
-      if (source) sources.add(source);
+      if (source) {
+        const dynamic = !match[1];
+        sources.set(source, (sources.get(source) ?? true) && dynamic);
+      }
     }
 
-    return Array.from(sources).sort();
+    return Array.from(sources, ([source, dynamic]) => ({ source, dynamic })).sort((a, b) =>
+      a.source.localeCompare(b.source)
+    );
   }
 
   function shouldScanResolvedImport(id: string): boolean {
@@ -109,9 +114,9 @@ export default function ({
     }
 
     const dependencies = new Set<string>();
-    for (const source of collectImportSources(code)) {
+    for (const { source, dynamic } of collectImportSources(code)) {
       if (isRemoteImport(source)) {
-        dependencies.add(source);
+        if (!dynamic) dependencies.add(source);
         continue;
       }
 

--- a/src/plugins/pluginRemoteNamedExports.ts
+++ b/src/plugins/pluginRemoteNamedExports.ts
@@ -9,7 +9,8 @@
  *
  * This plugin rewrites consumer code:
  *   import { foo } from "remote/xxx"
- *     → import { __moduleExports as __mf_ns_0 } from "remote/xxx"; const { foo } = __mf_ns_0;
+ *     → import { __moduleExports as ns, __mf_remote_pending as pending } from "remote/xxx";
+ *       let foo; if ("foo" in ns) foo = ns.foo; pending.then(() => { foo = ns.foo });
  *
  *   import("remote/xxx")
  *     → import("remote/xxx").then(…)  // spreads __moduleExports into namespace
@@ -216,8 +217,17 @@ function applyRewrites(
 
           let rewrite = `import { ${importParts.join(', ')} } from ${src};`;
           if (imp.named.length > 0) {
-            const destructParts = imp.named.map((s) => `${s.imported}: ${s.local}`);
-            rewrite += `\nconst { ${destructParts.join(', ')} } = ${nsId};`;
+            const declarations = imp.named.map((s) => `let ${s.local};`).join('\n');
+            const initializers = imp.named
+              .map(
+                (s) =>
+                  `if (${JSON.stringify(s.imported)} in ${nsId}) {\n${s.local} = ${nsId}[${JSON.stringify(s.imported)}];\n}`
+              )
+              .join('\n');
+            const assignments = imp.named
+              .map((s) => `${s.local} = ${nsId}[${JSON.stringify(s.imported)}];`)
+              .join('\n');
+            rewrite += `\n${declarations}\n${initializers}\n${pendingId}.then(() => {\n${assignments}\n});`;
           }
 
           ms.overwrite(imp.start, imp.end, rewrite);
@@ -238,8 +248,12 @@ function applyRewrites(
         });
 
         const importLine = `import { __moduleExports as ${nsId}, __mf_remote_pending as ${pendingId} } from ${src};`;
-        const varLines = vars
-          .map((v) => `let ${v.tmp} = ${nsId}[${JSON.stringify(v.local)}];`)
+        const varLines = vars.map((v) => `let ${v.tmp};`).join('\n');
+        const initializers = vars
+          .map(
+            (v) =>
+              `if (${JSON.stringify(v.local)} in ${nsId}) {\n${v.tmp} = ${nsId}[${JSON.stringify(v.local)}];\n}`
+          )
           .join('\n');
         const assignLines = vars
           .map((v) => `${v.tmp} = ${nsId}[${JSON.stringify(v.local)}];`)
@@ -247,7 +261,11 @@ function applyRewrites(
         const syncLine = `${pendingId}.then(() => {\n${assignLines}\n});`;
         const exportLine = `export { ${vars.map((v) => `${v.tmp} as ${v.exported}`).join(', ')} };`;
 
-        ms.overwrite(imp.start, imp.end, `${importLine}\n${varLines}\n${syncLine}\n${exportLine}`);
+        ms.overwrite(
+          imp.start,
+          imp.end,
+          `${importLine}\n${varLines}\n${initializers}\n${syncLine}\n${exportLine}`
+        );
         changed = true;
         break;
       }


### PR DESCRIPTION
Close #1126

Keeps dynamic remotes lazy and safely resolves named bindings after remote readiness.