### PR TITLE
fix: manage bare remote side-effect imports

### DIFF
--- a/src/virtualModules/__tests__/virtualRemotes.test.ts
+++ b/src/virtualModules/__tests__/virtualRemotes.test.ts
@@ -298,6 +298,17 @@ describe('generateRemotes', () => {
     );
   });
 
+  it('runs a loaded-first remote imported for side effects', async () => {
+    mockOptions.shareStrategy = 'loaded-first';
+    const runtime = {
+      registerRemotes: vi.fn(),
+      loadRemote: vi.fn(() => Promise.resolve({})),
+    };
+
+    runGeneratedRemoteModule(generateRemotes('remote', 'serve', false, 'client'), runtime);
+    await vi.waitFor(() => expect(runtime.loadRemote).toHaveBeenCalledWith('remote'));
+  });
+
   it('resolves the real remote on the server for loaded-first dev', () => {
     mockOptions.shareStrategy = 'loaded-first';
     const code = generateRemotes('remote/Button', 'serve');

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -485,7 +485,8 @@ export function generateRemotes(
 
   const realRemoteInit = `__mfRemotePending = __mfStartRemoteLoad().then(__mfAssignRemoteModule);`;
   const deferredClientInit = `exportModule = __mfCreateDeferredRemoteProxy();`;
-  const eagerLoadClientRemote = shouldEagerLoadClientRemoteInDev(command, enableSsrInit);
+  const eagerLoadClientRemote =
+    id === remoteRegistration?.alias || shouldEagerLoadClientRemoteInDev(command, enableSsrInit);
   const eagerClientInit = eagerLoadClientRemote ? getEagerDeferredClientInit() : deferredClientInit;
   const loadedFirstClientInit = eagerLoadClientRemote
     ? getEagerDeferredClientInit()


### PR DESCRIPTION
Close #1127

Bare remotes now load on evaluation under loaded-first, ensuring side effects execute in development and production.