### PR TITLE
fix: preserve linked shared source exclusions

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -2327,6 +2327,70 @@ describe('vite:module-federation-early-init', () => {
       path.join(REACT_EXAMPLE_ROOT, '..', 'shared-lib', 'src', 'index.tsx')
     );
     expect(config.optimizeDeps.entries).toContain('custom-entry.ts');
+  });
+
+  it('preserves optimizeDeps exclusion for linked shared source', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-linked-shared-'));
+    try {
+      const hostDir = path.join(root, 'packages', 'host');
+      const sharedDir = path.join(root, 'packages', 'shared');
+      const sharedSource = path.join(sharedDir, 'src', 'index.ts');
+      mkdirSync(path.join(hostDir, 'node_modules', '@fixture'), { recursive: true });
+      mkdirSync(path.dirname(sharedSource), { recursive: true });
+      writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+      writeFileSync(
+        path.join(sharedDir, 'package.json'),
+        JSON.stringify({
+          name: '@fixture/shared',
+          version: '1.0.0',
+          exports: {
+            '.': {
+              development: './src/index.ts',
+              browser: './dist/index.js',
+              import: './dist/index.js',
+            },
+          },
+        })
+      );
+      writeFileSync(sharedSource, 'export const marker = 1;\n');
+      symlinkSync(sharedDir, path.join(hostDir, 'node_modules', '@fixture', 'shared'), 'junction');
+
+      const plugin = (
+        federation({
+          name: 'host',
+          shared: {
+            '@fixture/shared': {
+              singleton: true,
+              version: '1.0.0',
+              import: sharedSource,
+            },
+          },
+        }) as Plugin[]
+      ).find((entry) => entry.name === 'vite:module-federation-early-init');
+      if (!plugin) throw new Error('vite:module-federation-early-init plugin not found');
+
+      const config: any = {
+        root: hostDir,
+        optimizeDeps: { include: [], exclude: ['@fixture/shared'] },
+      };
+      runConfig(plugin, {} as ConfigPluginContext, config, {
+        command: 'serve',
+        mode: 'test',
+      });
+      const normalizeHook = getNormalizeOptimizeDepsPlugin().configResolved;
+      if (typeof normalizeHook !== 'function') {
+        throw new Error('normalizeOptimizeDeps configResolved hook not found');
+      }
+      normalizeHook.call({} as MinimalPluginContextWithoutEnvironment, config);
+
+      expect({
+        included: config.optimizeDeps.include.includes('@fixture/shared'),
+        excluded: config.optimizeDeps.exclude.includes('@fixture/shared'),
+        sourceEntry: config.optimizeDeps.entries?.includes(sharedSource) ?? false,
+      }).toEqual({ included: false, excluded: true, sourceEntry: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('does not create optimizer entries for missing exposes', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,6 +409,16 @@ function includeLinkedSharedEntries(
 
   for (const [packageName, share] of Object.entries(shared ?? {})) {
     if (share?.shareConfig?.import === false) continue;
+    const configuredImport = share?.shareConfig?.import;
+    if (typeof configuredImport === 'string') {
+      const entry = path.isAbsolute(configuredImport)
+        ? configuredImport
+        : path.resolve(projectRoot, configuredImport);
+      if (existsSync(entry) && !entry.replaceAll('\\', '/').includes('/node_modules/')) {
+        additions.add(entry);
+        continue;
+      }
+    }
     const installed = getInstalledPackageJson(packageName, { cwd: projectRoot });
     if (!installed || installed.dir.replaceAll('\\', '/').includes('/node_modules/')) continue;
     const entry = getInstalledPackageEntry(packageName, { cwd: projectRoot });
@@ -784,7 +794,7 @@ export default __mfShared.default ?? __mfShared;`,
             const shouldBypassOptimizeDep = isLitShare(key) || !canResolveSharedSubpath(key, root);
             if (optimizeDeps.include.includes(key)) {
               optimizeDeps.exclude = optimizeDeps.exclude.filter((dep) => dep !== key);
-            } else if (shouldBypassOptimizeDep) {
+            } else if (shouldBypassOptimizeDep || optimizeDeps.exclude.includes(key)) {
               optimizeDeps.exclude.push(key);
             } else {
               optimizeDeps.include.push(key);


### PR DESCRIPTION
Close #1128

Keeps explicit optimizer exclusions and scans linked source entries without eagerly prebundling workspace packages.