### PR TITLE
fix: handle shared named import prebundling

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1669,6 +1669,18 @@ describe('vite:module-federation-early-init', () => {
     });
     expect(result.contents).toContain(JSON.stringify(loadSharePath));
     expect(result.contents).not.toContain(JSON.stringify(encodedLoadSharePath));
+    for (const kind of ['import-statement', 'dynamic-import']) {
+      expect(
+        onResolveHandlers[1]({
+          path: 'pkg-foo/a',
+          importer: '/repo/node_modules/pkg-b/index.js',
+          kind,
+        })
+      ).toEqual({
+        path: expect.stringContaining(LOAD_SHARE_TAG),
+        external: true,
+      });
+    }
   });
 
   it('does not proxy shared deps when esbuild resolves optimizeDeps entry points', () => {
@@ -1872,7 +1884,10 @@ describe('vite:module-federation-early-init', () => {
         importer: '/repo/node_modules/.vite/deps/pkg.js',
         kind: 'import-statement',
       })
-    ).toEqual({ path: '@ui-lib/button', namespace: 'mf-shared' });
+    ).toEqual({
+      path: expect.stringContaining(LOAD_SHARE_TAG),
+      external: true,
+    });
   });
 
   it('redirects System.register commonjs-proxy consumers to loadShare chunks', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -726,6 +726,15 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   )
                     return;
                   addUsedShares(args.path, options);
+                  if (args.kind === 'import-statement' || args.kind === 'dynamic-import') {
+                    const shareItem = shared[key];
+                    const loadSharePath = getLoadShareModulePath(args.path, isRolldown, options);
+                    writeLoadShareModule(args.path, shareItem, _command, isRolldown, options);
+                    if (shareItem.shareConfig?.import !== false) {
+                      writePreBuildLibPath(args.path, shareItem, options);
+                    }
+                    return { path: loadSharePath, external: true };
+                  }
                   return { path: args.path, namespace: 'mf-shared' };
                 });
                 build.onLoad({ filter: /.*/, namespace: 'mf-shared' }, (args: any) => {


### PR DESCRIPTION
Close #1129

Resolve ESM shared imports directly during esbuild optimization, preserving named exports with dynamic imports.