### PR TITLE
feat: preserve user chunking config alongside federation chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,20 +351,29 @@ federation({
 `provideExternalRuntime` injects a local runtime plugin that publishes `runtime-core` on `globalThis._FEDERATION_RUNTIME_CORE`. `externalRuntime` rewrites imports of `@module-federation/runtime-core` to read that global. Using `provideExternalRuntime` together with `exposes` throws — only pure consumers may provide the runtime.
 The `externalRuntime` rewrite applies to the browser remote graph; SSR remote entries continue to resolve `@module-federation/runtime-core` from Node so they do not depend on the browser global.
 
-## ⚠️ `codeSplitting` settings are controlled by the plugin
+## ⚠️ `codeSplitting` is managed by the plugin
 
-Do not set either `build.rollupOptions.output.codeSplitting` or
-`build.rolldownOptions.output.codeSplitting` to `false` with this plugin — it will be **automatically ignored**.
+Do not set `build.rollupOptions.output.codeSplitting` or
+`build.rolldownOptions.output.codeSplitting` to `false` — it will be **ignored** (with a warning).
+Module Federation requires chunk splitting so `loadShare` and `runtimeInitStatus` stay isolated for correct bootstrap order.
 
-`codeSplitting.groups` is also ignored because grouping shared-runtime chunks can break MF init order.
-Module Federation needs `loadShare` and `runtimeInitStatus` isolated into separate chunks for correct bootstrap behavior.
+### `codeSplitting.groups` (Vite 8+ / Rolldown)
 
-## ⚠️ `manualChunks` is not supported
+User groups are now **preserved**. The plugin installs its own federation groups at the highest priority and appends your groups below them, so your groups can only claim modules the federation groups didn't.
 
-Do not use `build.rollupOptions.output.manualChunks` or
-`build.rolldownOptions.output.manualChunks` with this plugin — it will be **automatically ignored**.
-The plugin manages the runtime chunk graph itself, and forcing custom chunk grouping can break Module Federation bootstrap order.
-The plugin injects the splits it needs so `runtimeInitStatus` and `loadShare` stay isolated.
+- No warning is emitted just for keeping your groups.
+- If one of your groups sets a `priority` high enough to outrank the federation groups, it is **clamped** below them and the plugin warns once. This guarantees a user group can never capture a `runtimeInit`/`loadShare` wrapper or the preload helper.
+
+## ⚠️ `manualChunks` behavior depends on your Vite version
+
+| Setting | Vite 5–7 (Rollup) | Vite 8+ (Rolldown) |
+| --- | --- | --- |
+| `manualChunks` (function) | **Composed as a fallback** — federation modules are claimed first, everything else falls through to your function | **Ignored** (warns) — move grouping to `codeSplitting.groups` |
+| `manualChunks` (object) | **Ignored** (warns) — use the function form to compose | **Ignored** (warns) — move grouping to `codeSplitting.groups` |
+
+On Vite 5–7, Rollup rejects `codeSplitting` as an unknown option, so the plugin isolates `runtimeInitStatus`, `loadShare`, and the preload helper via `manualChunks`. A user-provided **function** is called for any module the plugin doesn't claim; the **object** form can't be composed safely and is ignored.
+
+On Vite 8+, chunking is managed through `codeSplitting.groups` (see above), so `manualChunks` is removed — express your grouping as `codeSplitting.groups` instead, where user groups are preserved below the federation groups.
 
 ### So far so good 🎉
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Module Federation requires chunk splitting so `loadShare` and `runtimeInitStatus
 User groups are now **preserved**. The plugin installs its own federation groups at the highest priority and appends your groups below them, so your groups can only claim modules the federation groups didn't.
 
 - No warning is emitted just for keeping your groups.
-- If one of your groups sets a `priority` high enough to outrank the federation groups, it is **clamped** below them and the plugin warns once. This guarantees a user group can never capture a `runtimeInit`/`loadShare` wrapper or the preload helper.
+- If one of your existing groups sets a `priority` high enough to outrank the federation groups, it is **clamped** below them and the plugin warns once. This prevents those groups from capturing a `runtimeInit`/`loadShare` wrapper or the preload helper.
 
 ## ⚠️ `manualChunks` behavior depends on your Vite version
 
@@ -371,7 +371,7 @@ User groups are now **preserved**. The plugin installs its own federation groups
 | `manualChunks` (function) | **Composed as a fallback** — federation modules are claimed first, everything else falls through to your function | **Ignored** (warns) — move grouping to `codeSplitting.groups` |
 | `manualChunks` (object) | **Ignored** (warns) — use the function form to compose | **Ignored** (warns) — move grouping to `codeSplitting.groups` |
 
-On Vite 5–7, Rollup rejects `codeSplitting` as an unknown option, so the plugin isolates `runtimeInitStatus`, `loadShare`, and the preload helper via `manualChunks`. A user-provided **function** is called for any module the plugin doesn't claim; the **object** form can't be composed safely and is ignored.
+On Vite 5–7, Rollup doesn't support `codeSplitting`, so the plugin isolates `runtimeInitStatus`, `loadShare`, and the preload helper via `manualChunks`. A user-provided **function** is called for any module the plugin doesn't claim; the **object** form isn't composed by the plugin and is ignored.
 
 On Vite 8+, chunking is managed through `codeSplitting.groups` (see above), so `manualChunks` is removed — express your grouping as `codeSplitting.groups` instead, where user groups are preserved below the federation groups.
 

--- a/e2e/vite-vite/tests/host-preview.spec.ts
+++ b/e2e/vite-vite/tests/host-preview.spec.ts
@@ -96,6 +96,32 @@ test.describe('vite-vite host preview', () => {
     expect(consoleLogs).toHaveLength(1);
   });
 
+  test('keeps a user codeSplitting.groups chunk alongside federation chunks', async ({
+    page,
+  }) => {
+    // The host runs Vite 8 (Rolldown). Its user `codeSplitting.groups` entry
+    // isolates PrimaryFederationMarker into a stable-named chunk. The plugin's
+    // federation groups keep the highest priority, so this only proves user
+    // groups survive alongside them.
+    const scriptUrls: string[] = [];
+    page.on('response', (response) => {
+      if (response.request().resourceType() === 'script') {
+        scriptUrls.push(response.url());
+      }
+    });
+
+    await page.goto('/');
+    // Federation still starts: the remote-backed marker renders.
+    await expect(page.getByTestId('primary-federation-marker')).toHaveText(
+      'primary federation instance'
+    );
+
+    // The user chunk is emitted and loaded on startup.
+    await expect
+      .poll(() => scriptUrls.some((url) => /user-host-chunk/.test(url)))
+      .toBe(true);
+  });
+
   test('isolates identical remote ids across two federation configs', async ({ page }) => {
     await page.goto('/');
 

--- a/e2e/vite-vite/tests/remote-preview.spec.ts
+++ b/e2e/vite-vite/tests/remote-preview.spec.ts
@@ -7,6 +7,27 @@ test.describe('vite-vite remote preview', () => {
     await expect(heading).toBeVisible();
   });
 
+  test('keeps a user manualChunks chunk alongside federation chunks', async ({ page }) => {
+    // The remote runs Vite 7 (Rollup). Its user `manualChunks` function emits
+    // deployInfo as a stable-named chunk, composed behind the federation chunks
+    // the plugin claims first.
+    const scriptUrls: string[] = [];
+    page.on('response', (response) => {
+      if (response.request().resourceType() === 'script') {
+        scriptUrls.push(response.url());
+      }
+    });
+
+    await page.goto('/');
+    // Federation still starts: the app renders, including the isolated module.
+    await expect(page.getByTestId('remote-deploy-info')).toHaveText('remote-deploy-info');
+
+    // The user chunk is emitted and loaded with the app.
+    await expect
+      .poll(() => scriptUrls.some((url) => /user-remote-chunk/.test(url)))
+      .toBe(true);
+  });
+
   test('renders shared-lib component', async ({ page }) => {
     await page.goto('/');
     const counter = page.getByTestId('shared-counter-[shared-lib] Remote');

--- a/examples/vite-vite/vite-host/vite.config.js
+++ b/examples/vite-vite/vite-host/vite.config.js
@@ -109,5 +109,16 @@ export default defineConfig({
   ],
   build: {
     target: 'chrome89',
+    // This host runs on Vite 8 (Rolldown) so it exercises the
+    // `codeSplitting.groups` composition path. The plugin installs its
+    // federation groups at the highest priority and keeps this user group below
+    // them — it emits PrimaryFederationMarker as its own stable-named chunk.
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [{ name: 'user-host-chunk', test: /PrimaryFederationMarker/ }],
+        },
+      },
+    },
   },
 });

--- a/examples/vite-vite/vite-remote/package.json
+++ b/examples/vite-vite/vite-remote/package.json
@@ -29,7 +29,7 @@
     "@swc/core": "1.7.14",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "@vitejs/plugin-react": "6.0.2",
-    "vite": "8.2.0"
+    "@vitejs/plugin-react": "5.1.2",
+    "vite": "7.3.6"
   }
 }

--- a/examples/vite-vite/vite-remote/src/App.jsx
+++ b/examples/vite-vite/vite-remote/src/App.jsx
@@ -1,6 +1,7 @@
 import './App.css';
 import reactLogo from './assets/react.svg';
 import { Input } from 'antd';
+import { deployInfo } from './deployInfo';
 // import viteLogo from './assets/vite.svg';
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
                 </p>
                 <p>The remote statically imports only the Ant Design Input component.</p>
                 <Input placeholder="Remote Input" />
+                <p data-testid="remote-deploy-info">{deployInfo}</p>
             </div>
         </div>
     );

--- a/examples/vite-vite/vite-remote/src/deployInfo.js
+++ b/examples/vite-vite/vite-remote/src/deployInfo.js
@@ -1,0 +1,4 @@
+// A small standalone module isolated into its own chunk via `manualChunks` so it
+// can be rewritten at deploy time without touching the rest of the remote bundle.
+// See the `build.rollupOptions.output.manualChunks` entry in vite.config.js.
+export const deployInfo = 'remote-deploy-info';

--- a/examples/vite-vite/vite-remote/vite.config.js
+++ b/examples/vite-vite/vite-remote/vite.config.js
@@ -109,11 +109,18 @@ export default defineConfig({
   ].filter(Boolean),
   build: {
     target: 'chrome89',
-    rolldownOptions: {
+    // This remote runs on Vite 7 (Rollup) so it exercises the `manualChunks`
+    // composition path. The plugin claims federation modules first, then this
+    // function runs for everything else — here it emits deployInfo as its own
+    // stable-named chunk alongside the federation chunks.
+    rollupOptions: {
       output: {
         chunkFileNames: 'static/js/[name]-[hash].js',
         entryFileNames: 'static/js/[name]-[hash].js',
         assetFileNames: 'static/[ext]/[name]-[hash].[ext]',
+        manualChunks(id) {
+          if (id.includes('deployInfo')) return 'user-remote-chunk';
+        },
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,11 +314,11 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
-        specifier: 6.0.2
-        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@8.0.0)(rolldown@1.2.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3))
+        specifier: 5.1.2
+        version: 5.1.2(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.33.0)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3))
       vite:
-        specifier: 8.2.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)
+        specifier: 7.3.6
+        version: 7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.33.0)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3)
 
   examples/vite-webpack-rspack/dynamic-remote:
     dependencies:
@@ -13072,8 +13072,8 @@ snapshots:
   vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.33.0)(sass-embedded@1.77.8)(terser@5.31.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.25
       rollup: 4.62.3
       tinyglobby: 0.2.17

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -977,6 +977,49 @@ describe('module-federation-esm-shims', () => {
     expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps a user group whose name collides with the preload-helper group', () => {
+    const plugin = getEsmShimsPlugin();
+    // A user group that shares the federation preload-helper group's name. It must
+    // be matched by object identity, not name, so it isn't silently dropped.
+    const userGroup = {
+      name: 'vite-preload-helper',
+      test: /custom-preload-marker/,
+      priority: 50,
+    };
+    const config: any = {
+      build: {
+        rolldownOptions: {
+          output: { codeSplitting: { groups: [userGroup] } },
+        },
+      },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+
+    const groups = config.build.rolldownOptions.output.codeSplitting.groups;
+    // The name collision no longer drops the user group.
+    const survivor = groups.find((g: any) => g.test?.source === 'custom-preload-marker');
+    expect(survivor).toEqual(userGroup);
+    // The plugin still installs its own preload-helper group; both same-named
+    // groups coexist because identity — not name — distinguishes them.
+    const federationHelper = groups.find(
+      (g: any) => g.name === 'vite-preload-helper' && g.test?.test('\0vite/preload-helper.js')
+    );
+    expect(federationHelper).toBeDefined();
+    expect(federationHelper).not.toBe(survivor);
+    expect(federationHelper.priority).toBeGreaterThan(survivor.priority);
+    expect(groups.filter((g: any) => g.name === 'vite-preload-helper')).toHaveLength(2);
+    // Keeping the user group is not a conflict — no warning.
+    expect(mfWarn).not.toHaveBeenCalled();
+
+    // Re-running config() drops the previous federation group (by identity) rather
+    // than mistaking it for a user group, so counts stay stable.
+    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+    const rerun = config.build.rolldownOptions.output.codeSplitting.groups;
+    expect(rerun.filter((g: any) => g.test?.source === 'custom-preload-marker')).toHaveLength(1);
+    expect(rerun.filter((g: any) => g.name === 'vite-preload-helper')).toHaveLength(2);
+  });
+
   it('composes user manualChunks behind federation chunks, keeps federation chunks isolated', () => {
     const plugin = getEsmShimsPlugin();
     const runtimeInitId = virtualRuntimeInitStatus.getImportId();

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -900,19 +900,63 @@ describe('module-federation-esm-shims', () => {
     expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
-  it('replaces user codeSplitting groups with federation groups and warns once', () => {
+  it('keeps user codeSplitting groups below the federation groups', () => {
     const plugin = getEsmShimsPlugin();
     const runtimeInitId = virtualRuntimeInitStatus.getImportId();
+    const userGroup = {
+      test: /resource-bindings/,
+      name: 'resource-bindings',
+      priority: 50,
+    };
+    const config: any = {
+      build: {
+        rolldownOptions: {
+          output: {
+            codeSplitting: {
+              groups: [userGroup],
+            },
+          },
+        },
+      },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+
+    const groups = config.build.rolldownOptions.output.codeSplitting.groups;
+    // User's group survives with its original priority.
+    const survivor = groups.find((g: any) => g.name === 'resource-bindings');
+    expect(survivor).toEqual(userGroup);
+    const helper = preloadHelperGroup(config.build.rolldownOptions.output);
+    expect(helper).toBeDefined();
+    // Matches Rolldown's injected helper id, not arbitrary user files.
+    expect(helper.test.test('\0vite/preload-helper.js')).toBe(true);
+    expect(helper.test.test('/src/preload-helper.ts')).toBe(false);
+    const federationGroup = groups.find((g: any) => typeof g?.name === 'function');
+    expect(federationGroup.name(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
+    // Federation groups outrank the user group so it can never capture
+    // runtimeInit/loadShare/preload modules.
+    expect(federationGroup.priority).toBeGreaterThan(survivor.priority);
+    expect(helper.priority).toBeGreaterThan(survivor.priority);
+    // Keeping user groups is not a conflict — no warning.
+    expect(mfWarn).not.toHaveBeenCalled();
+
+    // Running config() again neither duplicates groups nor drops the user group.
+    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+    const groupsAfterRerun = config.build.rolldownOptions.output.codeSplitting.groups;
+    expect(groupsAfterRerun).toHaveLength(3);
+    expect(groupsAfterRerun.filter((g: any) => g.name === 'resource-bindings')).toHaveLength(1);
+  });
+
+  it('clamps user group priority below the federation groups and warns once', () => {
+    const plugin = getEsmShimsPlugin();
     const config: any = {
       build: {
         rolldownOptions: {
           output: {
             codeSplitting: {
               groups: [
-                {
-                  test: /node_modules\/(react|react-dom)(\/|$)/,
-                  name: 'react',
-                },
+                { test: /vendor/, name: 'greedy', priority: Number.MAX_SAFE_INTEGER },
+                { test: /other/, name: 'also-greedy', priority: Number.MAX_SAFE_INTEGER },
               ],
             },
           },
@@ -923,24 +967,22 @@ describe('module-federation-esm-shims', () => {
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
     const groups = config.build.rolldownOptions.output.codeSplitting.groups;
-    // User's 'react' group is dropped; federation groups take over.
-    expect(groups.find((g: any) => g.name === 'react')).toBeUndefined();
+    const federationGroup = groups.find((g: any) => typeof g?.name === 'function');
     const helper = preloadHelperGroup(config.build.rolldownOptions.output);
-    expect(helper).toBeDefined();
-    // Matches Rolldown's injected helper id, not arbitrary user files.
-    expect(helper.test.test('\0vite/preload-helper.js')).toBe(true);
-    expect(helper.test.test('/src/preload-helper.ts')).toBe(false);
-    expect(federationNameFn(config.build.rolldownOptions.output)(`/virtual/${runtimeInitId}`)).toBe(
-      'runtimeInit'
-    );
+    for (const name of ['greedy', 'also-greedy']) {
+      const clamped = groups.find((g: any) => g.name === name);
+      expect(clamped.priority).toBeLessThan(federationGroup.priority);
+      expect(clamped.priority).toBeLessThan(helper.priority);
+    }
     expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores user manualChunks and warns, keeps federation chunks isolated', () => {
+  it('composes user manualChunks behind federation chunks, keeps federation chunks isolated', () => {
     const plugin = getEsmShimsPlugin();
     const runtimeInitId = virtualRuntimeInitStatus.getImportId();
+    const userManualChunks = vi.fn((_id: string) => 'existing-fn-chunk');
     const functionOutput: any = {
-      manualChunks: vi.fn((_id: string) => 'existing-fn-chunk'),
+      manualChunks: userManualChunks,
     };
     const objectOutput: any = {
       manualChunks: {
@@ -956,8 +998,8 @@ describe('module-federation-esm-shims', () => {
 
     runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
 
-    // Rollup output (Vite 5–7): user's manualChunks is replaced by the plugin's,
-    // and no codeSplitting is set.
+    // Rollup output (Vite 5–7): federation modules are claimed first and never
+    // reach the user's function.
     expect(functionOutput.codeSplitting).toBeUndefined();
     expect(typeof functionOutput.manualChunks).toBe('function');
     expect(functionOutput.manualChunks(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
@@ -965,9 +1007,10 @@ describe('module-federation-esm-shims', () => {
       `react${LOAD_SHARE_TAG}chunk.js`
     );
     expect(functionOutput.manualChunks('\0vite/preload-helper.js')).toBe('vite-preload-helper');
-    // Non-federation modules are left to automatic chunking (and it is not the
-    // user's original function, which would have returned 'existing-fn-chunk').
-    expect(functionOutput.manualChunks('/src/custom.ts')).toBeUndefined();
+    expect(userManualChunks).not.toHaveBeenCalled();
+    // Non-federation modules fall through to the user's function.
+    expect(functionOutput.manualChunks('/src/custom.ts')).toBe('existing-fn-chunk');
+    expect(userManualChunks).toHaveBeenCalledWith('/src/custom.ts');
 
     // Rolldown output (Vite 8+): user's manualChunks is removed in favor of the
     // federation codeSplitting groups, with the preload helper isolated.
@@ -977,11 +1020,31 @@ describe('module-federation-esm-shims', () => {
     expect(nameFn('/src/custom.ts')).toBeNull();
     expect(preloadHelperGroup(objectOutput)).toBeDefined();
 
-    // Warning was emitted (once for both outputs)
-    expect(mfWarn).toHaveBeenCalled();
+    // Only the removed Rolldown manualChunks warns; the composed function does not.
+    expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
-  it('installs federation groups and removes manualChunks for rolldown output arrays', () => {
+  it('ignores the object form of manualChunks on the rollup path and warns', () => {
+    const plugin = getEsmShimsPlugin();
+    const runtimeInitId = virtualRuntimeInitStatus.getImportId();
+    const output: any = {
+      manualChunks: { vendor: ['react'] },
+    };
+    const config: any = {
+      build: {
+        rollupOptions: { output },
+      },
+    };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+
+    expect(typeof output.manualChunks).toBe('function');
+    expect(output.manualChunks(`/virtual/${runtimeInitId}`)).toBe('runtimeInit');
+    expect(output.manualChunks('/node_modules/react/index.js')).toBeUndefined();
+    expect(mfWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it('installs federation groups, keeps user groups, and removes manualChunks for rolldown output arrays', () => {
     const plugin = getEsmShimsPlugin();
     const runtimeInitId = virtualRuntimeInitStatus.getImportId();
     const config: any = {
@@ -1012,9 +1075,11 @@ describe('module-federation-esm-shims', () => {
 
     const out0 = config.build.rolldownOptions.output[0];
     const out1 = config.build.rolldownOptions.output[1];
-    // User's 'react' group is dropped; preload helper isolated on out0.
-    expect(out0.codeSplitting.groups.find((g: any) => g.name === 'react')).toBeUndefined();
+    // User's 'react' group survives on out0, below the federation groups.
+    const reactGroup = out0.codeSplitting.groups.find((g: any) => g.name === 'react');
+    expect(reactGroup).toBeDefined();
     expect(preloadHelperGroup(out0)).toBeDefined();
+    expect(preloadHelperGroup(out0).priority).toBeGreaterThan(reactGroup.priority ?? 0);
     // User's manualChunks removed; federation groups installed on out1.
     expect(out1.manualChunks).toBeUndefined();
     const nameFn = federationNameFn(out1);
@@ -1023,7 +1088,8 @@ describe('module-federation-esm-shims', () => {
       `react${LOAD_SHARE_TAG}chunk.js`
     );
     expect(nameFn('/src/other/index.ts')).toBeNull();
-    expect(mfWarn).toHaveBeenCalledTimes(2);
+    // Only the removed manualChunks on out1 warns.
+    expect(mfWarn).toHaveBeenCalledTimes(1);
   });
 
   it('does not warn when config() is executed twice for patched output', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,13 @@ type CodeSplittingGroup = {
   priority?: number;
 };
 
+// Federation groups must always outrank user-provided codeSplitting groups so a
+// user group can never capture a runtimeInit/loadShare wrapper or the preload
+// helper (Rolldown assigns each module to the highest-priority matching group).
+// User group priorities are clamped below this value.
+const MF_GROUP_PRIORITY = 1_000_000;
+const USER_GROUP_MAX_PRIORITY = MF_GROUP_PRIORITY - 1;
+
 type ViteWatchOptions = NonNullable<NonNullable<UserConfig['server']>['watch']>;
 type ViteWatchConfig = ViteWatchOptions | boolean | null | undefined;
 
@@ -1414,49 +1421,46 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         }
 
         let warnedAboutCodeSplitting = false;
-        let warnedAboutCodeSplittingGroups = false;
         const ensureCodeSplitting = (output: MutableBundlerOutput) => {
-          if (output?.codeSplitting === false) {
-            delete output.codeSplitting;
-            if (warnedAboutCodeSplitting) return;
-            warnedAboutCodeSplitting = true;
-            mfWarn(
-              'Ignoring `output.codeSplitting = false` because module federation requires chunk splitting.'
-            );
-            return;
-          }
-
-          if (!output?.codeSplitting || typeof output.codeSplitting !== 'object') return;
-          if (!('groups' in output.codeSplitting)) return;
-
-          // Don't strip the groups we set ourselves in applyManualChunks — they
-          // isolate the loadShare/runtimeInit wrappers and the preload helper.
-          const groups = output.codeSplitting.groups;
-          if (
-            Array.isArray(groups) &&
-            groups.some(
-              (group) =>
-                typeof (group as Partial<CodeSplittingGroup>)?.name === 'function' &&
-                patchedManualChunks.has((group as { name: Function }).name)
-            )
-          ) {
-            return;
-          }
-
-          delete output.codeSplitting.groups;
-          if (Object.keys(output.codeSplitting).length === 0) {
-            delete output.codeSplitting;
-          }
-          if (warnedAboutCodeSplittingGroups) return;
-          warnedAboutCodeSplittingGroups = true;
+          if (output?.codeSplitting !== false) return;
+          delete output.codeSplitting;
+          if (warnedAboutCodeSplitting) return;
+          warnedAboutCodeSplitting = true;
           mfWarn(
-            'Ignoring `output.codeSplitting.groups` because it conflicts with module federation. ' +
-              'Grouping shared dependency init wrappers with their dependent modules can break runtime init order ' +
-              'and cause standalone remotes to fail before mount.'
+            'Ignoring `output.codeSplitting = false` because module federation requires chunk splitting.'
           );
         };
 
+        // Groups installed by applyManualChunks: the dynamic name() group (tracked
+        // in patchedManualChunks) and the preload-helper test group.
+        const isFederationGroup = (group: unknown): boolean => {
+          const candidate = group as Partial<CodeSplittingGroup> | undefined;
+          return (
+            (typeof candidate?.name === 'function' && patchedManualChunks.has(candidate.name)) ||
+            candidate?.name === PRELOAD_HELPER_CHUNK
+          );
+        };
+
+        let warnedAboutGroupPriority = false;
+        // Keep user groups, but clamp their priority below the federation groups so
+        // they can only claim modules the federation groups didn't.
+        const clampUserGroup = (group: unknown): unknown => {
+          const candidate = group as Partial<CodeSplittingGroup>;
+          if (typeof candidate?.priority !== 'number') return group;
+          if (candidate.priority <= USER_GROUP_MAX_PRIORITY) return group;
+          if (!warnedAboutGroupPriority) {
+            warnedAboutGroupPriority = true;
+            mfWarn(
+              `Clamping \`output.codeSplitting.groups\` priority to ${USER_GROUP_MAX_PRIORITY} — ` +
+                'module federation groups must keep the highest priority so shared dependency init ' +
+                'wrappers stay isolated in their own chunks.'
+            );
+          }
+          return { ...candidate, priority: USER_GROUP_MAX_PRIORITY };
+        };
+
         let warnedAboutManualChunks = false;
+        let warnedAboutObjectManualChunks = false;
         // `useCodeSplitting` selects the bundler-appropriate isolation mechanism:
         // Rolldown (Vite 8+) supports `codeSplitting` (and needs it to relocate the
         // injected preload helper), while Rollup (Vite 5–7) only understands
@@ -1466,15 +1470,6 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           const isPatchedByPlugin =
             typeof output.manualChunks === 'function' &&
             patchedManualChunks.has(output.manualChunks);
-          if (output.manualChunks && !isPatchedByPlugin && !warnedAboutManualChunks) {
-            warnedAboutManualChunks = true;
-            mfWarn(
-              'Ignoring `output.manualChunks` because it conflicts with module federation. ' +
-                'Module federation transforms shared dependency imports with async init wrappers, and grouping ' +
-                'these transformed modules into a single chunk creates circular async dependencies that cause ' +
-                'the application to silently hang.'
-            );
-          }
           const mfChunkName = function (id: string): string | null {
             // Keep runtimeInitStatus in its own chunk to break init deadlock
             if (id.includes(runtimeInitId) || id.includes('__mf_v__runtimeInit__mf_v__')) {
@@ -1492,10 +1487,31 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           if (!useCodeSplitting) {
             // Rollup (Vite 5–7): `codeSplitting` is rejected as an unknown output
             // option, so isolate runtimeInit, loadShare, and the preload helper with
-            // `manualChunks`.
-            const mfManualChunks = function (id: string) {
+            // `manualChunks`. A user-provided manualChunks function is composed in as
+            // a fallback: federation modules are claimed first, everything else falls
+            // through to the user's function.
+            if (isPatchedByPlugin) return;
+            const userManualChunks = output.manualChunks;
+            if (
+              userManualChunks &&
+              typeof userManualChunks !== 'function' &&
+              !warnedAboutObjectManualChunks
+            ) {
+              warnedAboutObjectManualChunks = true;
+              mfWarn(
+                'Ignoring the object form of `output.manualChunks` because module federation cannot ' +
+                  'safely compose with it. Use the function form instead: federation modules are claimed ' +
+                  'first and your function runs for everything else.'
+              );
+            }
+            const mfManualChunks = function (id: string, ...rest: unknown[]) {
               if (PRELOAD_HELPER_TEST.test(id)) return PRELOAD_HELPER_CHUNK;
-              return mfChunkName(id) ?? undefined;
+              const mfChunk = mfChunkName(id);
+              if (mfChunk) return mfChunk;
+              if (typeof userManualChunks === 'function') {
+                return userManualChunks(id, ...rest) ?? undefined;
+              }
+              return undefined;
             };
             patchedManualChunks.add(mfManualChunks);
             output.manualChunks = mfManualChunks;
@@ -1507,9 +1523,32 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           // a dynamic `name()` group reproduces the runtimeInit/loadShare isolation,
           // and a higher-priority `test` group pulls the preload helper into its own
           // chunk (the helper is only matched by `test`, never the `name()` fn).
-          const groups: CodeSplittingGroup[] = [
-            { name: PRELOAD_HELPER_CHUNK, test: PRELOAD_HELPER_TEST, priority: 100 },
-            { name: mfChunkName },
+          // User groups are kept, clamped below the federation priorities, so they
+          // can only claim modules the federation groups leave behind.
+          if (output.manualChunks && !isPatchedByPlugin && !warnedAboutManualChunks) {
+            warnedAboutManualChunks = true;
+            mfWarn(
+              'Ignoring `output.manualChunks` for the Rolldown build because module federation manages ' +
+                'chunking with `output.codeSplitting.groups`. Move your grouping there — user groups are ' +
+                'kept below the federation groups.'
+            );
+          }
+          const existingGroups = (
+            output.codeSplitting && typeof output.codeSplitting === 'object'
+              ? output.codeSplitting.groups
+              : undefined
+          ) as unknown[] | undefined;
+          const userGroups = Array.isArray(existingGroups)
+            ? existingGroups.filter((group) => !isFederationGroup(group)).map(clampUserGroup)
+            : [];
+          const groups = [
+            {
+              name: PRELOAD_HELPER_CHUNK,
+              test: PRELOAD_HELPER_TEST,
+              priority: MF_GROUP_PRIORITY + 1,
+            },
+            { name: mfChunkName, priority: MF_GROUP_PRIORITY },
+            ...userGroups,
           ];
           output.codeSplitting = { ...(output.codeSplitting || {}), groups };
           delete output.manualChunks;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,10 @@ import {
 } from './virtualModules/virtualShared_preBuild';
 
 const patchedManualChunks = new WeakSet<Function>();
+// Plugin-created codeSplitting groups, tracked by object identity so a user group
+// that happens to share a federation group's name (e.g. `vite-preload-helper`)
+// isn't mistaken for one of ours and dropped.
+const federationGroups = new WeakSet<object>();
 
 // Rolldown injects the `__vite_preload` helper as a special runtime module and,
 // left to automatic chunking, hoists it into whichever loadShare chunk first uses
@@ -1431,15 +1435,10 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           );
         };
 
-        // Groups installed by applyManualChunks: the dynamic name() group (tracked
-        // in patchedManualChunks) and the preload-helper test group.
-        const isFederationGroup = (group: unknown): boolean => {
-          const candidate = group as Partial<CodeSplittingGroup> | undefined;
-          return (
-            (typeof candidate?.name === 'function' && patchedManualChunks.has(candidate.name)) ||
-            candidate?.name === PRELOAD_HELPER_CHUNK
-          );
-        };
+        // Groups installed by applyManualChunks, matched by object identity (not
+        // name) so a user group named like a federation group isn't filtered out.
+        const isFederationGroup = (group: unknown): boolean =>
+          typeof group === 'object' && group !== null && federationGroups.has(group);
 
         let warnedAboutGroupPriority = false;
         // Keep user groups, but clamp their priority below the federation groups so
@@ -1541,15 +1540,15 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
           const userGroups = Array.isArray(existingGroups)
             ? existingGroups.filter((group) => !isFederationGroup(group)).map(clampUserGroup)
             : [];
-          const groups = [
-            {
-              name: PRELOAD_HELPER_CHUNK,
-              test: PRELOAD_HELPER_TEST,
-              priority: MF_GROUP_PRIORITY + 1,
-            },
-            { name: mfChunkName, priority: MF_GROUP_PRIORITY },
-            ...userGroups,
-          ];
+          const mfPreloadGroup = {
+            name: PRELOAD_HELPER_CHUNK,
+            test: PRELOAD_HELPER_TEST,
+            priority: MF_GROUP_PRIORITY + 1,
+          };
+          const mfNameGroup = { name: mfChunkName, priority: MF_GROUP_PRIORITY };
+          federationGroups.add(mfPreloadGroup);
+          federationGroups.add(mfNameGroup);
+          const groups = [mfPreloadGroup, mfNameGroup, ...userGroups];
           output.codeSplitting = { ...(output.codeSplitting || {}), groups };
           delete output.manualChunks;
         };


### PR DESCRIPTION
The plugin currently discards any user-provided chunking config: `output.codeSplitting.groups` (Rolldown) is deleted and `output.manualChunks` (Rollup) is replaced. This makes it impossible for a consumer to emit a module as its own chunk with a stable file name in a federation build — for example to rewrite one small file at deploy time.

The original reason for discarding user config still holds: federation's runtime-init and load-share wrappers must stay isolated in their own chunks, or a remote can deadlock on startup. This change keeps that guarantee while letting user config through:

- Rolldown: user `codeSplitting.groups` are kept, but federation groups are installed at a higher priority and user priorities are clamped below it. Rolldown assigns each module to the highest-priority matching group, so a user group can never capture a federation module — it only gets what federation leaves behind.
- Rollup: a user `manualChunks` function is composed in as a fallback behind the plugin's own, which claims federation modules first. The object form is still rejected, with a warning pointing at the function form.

Warnings now only fire when the plugin actually mutates user config (clamping a priority, dropping object-form `manualChunks`, removing `manualChunks` on a Rolldown output).