### PR TITLE
chore: parallelize integration test matrix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 4
       matrix:
         bundler: ["vite@5", "vite@6", "vite@7", "vite@8"]
     steps:


### PR DESCRIPTION
## Summary

Allow the Vite integration-test matrix to run all supported bundler jobs concurrently.

## Problem

The workflow currently tests four bundler targets (`vite@5`, `vite@6`, `vite@7`, and `vite@8`) through a matrix, but `max-parallel: 1` serializes those jobs. Each matrix entry runs on its own GitHub-hosted runner and performs its own checkout, dependency installation, package build, and test run, so the matrix does not need to wait for the previous bundler to finish.

## Change

- Change `jobs.integration-test.strategy.max-parallel` from `1` to `4`.
- Keep `fail-fast: false` so a failure in one bundler target does not cancel validation for the others.
- Leave the matrix entries and all test steps unchanged.

## Question about the existing setting

Do we know why `max-parallel: 1` was originally configured? Git history shows that it was introduced in commit `2ec3837` when the bundler matrix was expanded for Vite 8/Rolldown support, but the commit does not document whether this was required because of runner capacity, resource limits, or a test-isolation issue. 
Please confirm whether there is a reason the matrix must remain serialized.