### PR TITLE
chore: Get IPV4 by scanning network in DtsPlugin

### DIFF
--- a/src/plugins/__tests__/pluginDts.test.ts
+++ b/src/plugins/__tests__/pluginDts.test.ts
@@ -3,12 +3,20 @@ import os from 'os';
 import path from 'path';
 import { PassThrough } from 'stream';
 import type { IncomingMessage, ServerResponse } from 'http';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ResolvedConfig, MinimalPluginContextWithoutEnvironment, Rollup } from 'vite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ResolvedConfig,
+  MinimalPluginContextWithoutEnvironment,
+  ConfigPluginContext,
+  ConfigEnv,
+  UserConfig,
+  Rollup,
+} from 'vite';
 import { normalizeModuleFederationOptions } from '../../utils/normalizeModuleFederationOptions';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
 
 const hasPackageDependency = vi.hoisted(() => vi.fn(() => false));
+const networkInterfaces = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/packageUtils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../utils/packageUtils')>();
@@ -16,6 +24,12 @@ vi.mock('../../utils/packageUtils', async (importOriginal) => {
     ...actual,
     hasPackageDependency,
   };
+});
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  const mockedOs = { ...actual, networkInterfaces };
+  return { ...mockedOs, default: mockedOs };
 });
 
 import {
@@ -40,6 +54,11 @@ function runGenerateBundle(plugin: NonNullable<ReturnType<typeof pluginDts>[numb
     {} as Rollup.OutputBundle,
     false
   );
+}
+
+function runConfig(plugin: NonNullable<ReturnType<typeof pluginDts>[number]>, config: UserConfig) {
+  callHook(plugin.config, {} as ConfigPluginContext, config, {} as ConfigEnv);
+  return config;
 }
 
 function createMockResponse() {
@@ -172,5 +191,83 @@ describe('pluginDts build', () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('pluginDts dev FEDERATION_IPV4', () => {
+  const originalFederationIpv4 = process.env['FEDERATION_IPV4'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env['FEDERATION_IPV4'];
+  });
+
+  afterEach(() => {
+    if (originalFederationIpv4 === undefined) {
+      delete process.env['FEDERATION_IPV4'];
+    } else {
+      process.env['FEDERATION_IPV4'] = originalFederationIpv4;
+    }
+  });
+
+  function getDevPlugin() {
+    const normalized = normalizeModuleFederationOptions({
+      name: 'test-module',
+      shareStrategy: 'loaded-first',
+    });
+    const devPlugin = pluginDts(normalized).find(
+      (plugin) => plugin.name === 'module-federation-dts-dev'
+    );
+    if (!devPlugin) throw new Error('dev plugin missing');
+    return devPlugin;
+  }
+
+  it('uses the first non-loopback IPv4 address found on the network', () => {
+    networkInterfaces.mockReturnValue({
+      eth0: [
+        {
+          address: '192.168.1.42',
+          netmask: '255.255.255.0',
+          family: 'IPv4',
+          mac: '00:00:00:00:00:00',
+          internal: false,
+          cidr: '192.168.1.42/24',
+        },
+      ],
+    });
+
+    const config = runConfig(getDevPlugin(), {});
+
+    expect(config.define?.['FEDERATION_IPV4']).toBe(JSON.stringify('192.168.1.42'));
+  });
+
+  it('falls back to 127.0.0.1 when no IPv4 interface is found', () => {
+    networkInterfaces.mockReturnValue({});
+
+    const config = runConfig(getDevPlugin(), {});
+
+    expect(config.define?.['FEDERATION_IPV4']).toBe(JSON.stringify('127.0.0.1'));
+  });
+
+  it('keeps a user-provided define.FEDERATION_IPV4 untouched', () => {
+    networkInterfaces.mockReturnValue({
+      eth0: [
+        {
+          address: '192.168.1.42',
+          netmask: '255.255.255.0',
+          family: 'IPv4',
+          mac: '00:00:00:00:00:00',
+          internal: false,
+          cidr: '192.168.1.42/24',
+        },
+      ],
+    });
+
+    const config = runConfig(getDevPlugin(), {
+      define: { FEDERATION_IPV4: JSON.stringify('10.10.10.10') },
+    });
+
+    expect(config.define?.['FEDERATION_IPV4']).toBe(JSON.stringify('10.10.10.10'));
+    expect(networkInterfaces).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/pluginDts.ts
+++ b/src/plugins/pluginDts.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { normalizeOptions, type moduleFederationPlugin } from '@module-federation/sdk';
 import {
@@ -32,7 +33,39 @@ const DEFAULT_DEV_OPTIONS: Required<DevOptions> = {
 
 const DYNAMIC_HINTS_PLUGIN = '@module-federation/dts-plugin/dynamic-remote-type-hints-plugin';
 
-const getIPv4 = () => process.env['FEDERATION_IPV4'] || '127.0.0.1';
+const localIpv4 = '127.0.0.1';
+
+// This code comes from https://github.com/module-federation/core/blob/0d65b82ed5d434cf82c9c2c257daf51db297cb07/packages/dts-plugin/src/server/utils/getIPV4.ts
+const getIpv4Interfaces = (): os.NetworkInterfaceInfo[] => {
+  try {
+    const interfaces = os.networkInterfaces();
+    const ipv4Interfaces: os.NetworkInterfaceInfo[] = [];
+
+    Object.values(interfaces).forEach((detail) => {
+      detail?.forEach((detail) => {
+        // 'IPv4' is in Node <= 17, from 18 it's a number 4 or 6
+        const familyV4Value = typeof detail.family === 'string' ? 'IPv4' : 4;
+
+        if (detail.family === familyV4Value && detail.address !== localIpv4) {
+          ipv4Interfaces.push(detail);
+        }
+      });
+    });
+    return ipv4Interfaces;
+  } catch (_err) {
+    return [];
+  }
+};
+
+const getIPv4 = () => {
+  if (process.env['FEDERATION_IPV4']) {
+    return process.env['FEDERATION_IPV4'];
+  }
+
+  const ipv4Interfaces = getIpv4Interfaces();
+  const ipv4Interface = ipv4Interfaces[0] || { address: localIpv4 };
+  return ipv4Interface.address;
+};
 
 const DEV_TYPES_FOLDER = '.dev-server';
 

--- a/src/plugins/pluginDts.ts
+++ b/src/plugins/pluginDts.ts
@@ -35,7 +35,8 @@ const DYNAMIC_HINTS_PLUGIN = '@module-federation/dts-plugin/dynamic-remote-type-
 
 const localIpv4 = '127.0.0.1';
 
-// This code comes from https://github.com/module-federation/core/blob/0d65b82ed5d434cf82c9c2c257daf51db297cb07/packages/dts-plugin/src/server/utils/getIPV4.ts
+// Match the DTS dev worker's network address so dynamic remote type hints remain
+// reachable when development traffic uses a LAN or VPN interface.
 const getIpv4Interfaces = (): os.NetworkInterfaceInfo[] => {
   try {
     const interfaces = os.networkInterfaces();
@@ -43,7 +44,7 @@ const getIpv4Interfaces = (): os.NetworkInterfaceInfo[] => {
 
     Object.values(interfaces).forEach((detail) => {
       detail?.forEach((detail) => {
-        // 'IPv4' is in Node <= 17, from 18 it's a number 4 or 6
+        // Node versions may represent the address family as a string or number.
         const familyV4Value = typeof detail.family === 'string' ? 'IPv4' : 4;
 
         if (detail.family === familyV4Value && detail.address !== localIpv4) {


### PR DESCRIPTION
Hello,

This is the PR to close https://github.com/module-federation/vite/issues/1140

So I copied https://github.com/module-federation/core/blob/main/packages/dts-plugin/src/server/utils/getIPV4.ts#L26 and pasted it directly in the `pluginDts`.

It scans ip of the machine to take the first one available to work seamlessly with the [`DevServer`](https://github.com/module-federation/core/blob/main/packages/dts-plugin/src/server/DevServer.ts#L76)

Thanks

ps : I have tested with a local build and https://pkg.pr.new/@module-federation/vite@1141 in my project, it works :) 