### PR TITLE
fix: preserve named exports in CommonJS

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -805,6 +805,14 @@ describe('module-federation-esm-shims', () => {
     expect(result).toBeNull();
   });
 
+  it('returns the full shared module to CommonJS consumers', () => {
+    const plugin = getEsmShimsPlugin();
+    const target = `\0virtual:mf:host${LOAD_SHARE_TAG}cjs-package${LOAD_SHARE_TAG}.js`;
+    const result = callHook(plugin.load, {} as any, `\0${target}?commonjs-proxy`);
+
+    expect(result).toBe(`export { __moduleExports as default } from ${JSON.stringify(target)};`);
+  });
+
   it('filters federation control chunks from js dynamic modulepreload deps', () => {
     const plugin = getEsmShimsPlugin();
     const config: any = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1642,6 +1642,12 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
         }
       },
       load(id: string, loadOptions?: LoadHookOptions) {
+        const commonJsProxySuffix = '?commonjs-proxy';
+        if (id.includes(LOAD_SHARE_TAG) && id.endsWith(commonJsProxySuffix)) {
+          const target = id.slice(id.startsWith('\0') ? 1 : 0, -commonJsProxySuffix.length);
+          return `export { __moduleExports as default } from ${JSON.stringify(target)};`;
+        }
+
         const loadVirtualModule = (
           importFalseExportUsage?: ReturnType<typeof getSharedExportUsage>
         ) => {


### PR DESCRIPTION
Closes #1142

Ensure Rollup CommonJS proxies return the complete shared module when its default export is a function.