### PR TITLE
fix: skip consumer-only shared provider placeholders

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -4007,6 +4007,23 @@ describe('virtualRemoteEntry', () => {
     ).toBe(loadedReact18);
   });
 
+  it('ignores import:false placeholders when selecting an external provider', async () => {
+    const selectProvider = await getExternalSharedProviderSelector();
+    const localReact = {
+      from: 'host',
+      version: '18.3.1',
+      shareConfig: { singleton: true, requiredVersion: false as const },
+    };
+    const remotePlaceholder = {
+      from: 'remote',
+      shareConfig: { singleton: true, import: false, requiredVersion: false },
+    };
+
+    expect(
+      selectProvider({ '18.3.1': remotePlaceholder }, 'react', localReact, 'loaded-first')
+    ).toBeUndefined();
+  });
+
   it('compares external and local singleton providers with version-first', async () => {
     const selectExternalProvider = await getExternalSharedProviderSelector();
     const hostGet = vi.fn();

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -587,7 +587,9 @@ export const externalSharedProviderSelectionHelperCode = `const __mfSelectExtern
           ) => {
             const isLocalProvider = (provider) => __mfMatchesSharedProvider(provider, localShare);
             const candidates = Object.fromEntries(
-              Object.entries(versions || {}).filter(([, provider]) => !isLocalProvider(provider))
+              Object.entries(versions || {}).filter(([, provider]) =>
+                !isLocalProvider(provider) && provider?.shareConfig?.import !== false
+              )
             );
             if (localShare?.version && localShare.shareConfig?.import !== false) {
               const sameVersionProvider = candidates[localShare.version];


### PR DESCRIPTION
Prevents consumer-only shared records from being selected as external providers during bidirectional federation initialization.

Closes #1144
 