### PR TITLE
fix: preserve react/ as consumer-only namespace prefix

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -364,6 +364,9 @@ describe('pluginProxySharedModule_preBuild', () => {
       const shared = makeShared();
       shared.react.shareConfig.import = false;
 
+      // Bare `react` + import:false shares only the package root. Known JSX
+      // subpaths are not auto-mapped (that would invent unfulfillable
+      // runtime-only entries). Opt into namespace coverage with `react/` instead.
       expect(findSharedKey('react', shared)).toBe('react');
       expect(findSharedKey('react/jsx-runtime', shared)).toBeUndefined();
 
@@ -374,6 +377,52 @@ describe('pluginProxySharedModule_preBuild', () => {
         name: 'react/jsx-runtime',
       };
       expect(findSharedKey('react/jsx-runtime', explicitlyShared)).toBe('react/jsx-runtime');
+    });
+
+    it('covers imported react subpaths via a consumer-only react/ namespace prefix', () => {
+      const shared: NormalizedShared = {
+        'react/': {
+          name: 'react/',
+          from: '',
+          version: '19.2.4',
+          scope: 'default',
+          shareConfig: {
+            singleton: true,
+            import: false,
+            requiredVersion: '^19.2.4',
+            strictVersion: false,
+          },
+        },
+      };
+
+      expect(findSharedKey('react', shared)).toBe('react/');
+      expect(findSharedKey('react/jsx-runtime', shared)).toBe('react/');
+      expect(findSharedKey('react/jsx-dev-runtime', shared)).toBe('react/');
+      // Namespace coverage, not a hardcoded JSX list: any imported subpath matches.
+      expect(findSharedKey('react/compiler-runtime', shared)).toBe('react/');
+      expect(findSharedKey('react/some-future-export', shared)).toBe('react/');
+    });
+
+    it('does not share react-dom/server* via a browser-wide react-dom/ prefix', () => {
+      // normalize collapses react-dom/ (see normalizeModuleFederationOption tests).
+      // With import:false on the package root, server* must not be auto-mapped.
+      // Browser-safe client sharing stays an explicit key.
+      const collapsed = makeShared();
+      collapsed['react-dom'].shareConfig.import = false;
+      expect(findSharedKey('react-dom/server', collapsed)).toBeUndefined();
+      expect(findSharedKey('react-dom/server.browser', collapsed)).toBeUndefined();
+      expect(findSharedKey('react-dom/client', collapsed)).toBeUndefined();
+
+      // New object: findSharedKey caches its matcher per `shared` reference.
+      const withClient = makeShared();
+      withClient['react-dom'].shareConfig.import = false;
+      withClient['react-dom/client'] = {
+        ...withClient['react-dom'],
+        name: 'react-dom/client',
+      };
+      expect(findSharedKey('react-dom/client', withClient)).toBe('react-dom/client');
+      expect(findSharedKey('react-dom/server', withClient)).toBeUndefined();
+      expect(findSharedKey('react-dom/server.browser', withClient)).toBeUndefined();
     });
 
     // findSharedKey memoizes its matcher per `shared` object reference. If
@@ -1146,6 +1195,60 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect((resolution as { id: string }).id).toBeDefined();
     expect(preBuildShareItemMap.has('transitive/button')).toBe(true);
     expect(preBuildShareItemMap.has('transitive')).toBe(false);
+  });
+
+  it('materializes imported react subpaths from a consumer-only react/ prefix', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const reactNamespace: NormalizedShared[string] = {
+      name: 'react/',
+      from: '',
+      version: '19.2.4',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        import: false,
+        requiredVersion: '^19.2.4',
+        strictVersion: false,
+      },
+    };
+    const shared: NormalizedShared = {
+      'react/': reactNamespace,
+    };
+
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    for (const source of ['react/jsx-runtime', 'react/jsx-dev-runtime', 'react/compiler-runtime']) {
+      addUsedSharesMock.mockClear();
+      writeLoadShareModuleMock.mockClear();
+      const resolution = await callHook(
+        sharedResolvePlugin.resolveId,
+        {
+          resolve: async (id: string) => ({ id }),
+        } as any,
+        source,
+        '/src/App.tsx',
+        { isEntry: false }
+      );
+
+      expect((resolution as { id: string }).id).toBeDefined();
+      expect(writeLoadShareModuleMock).toHaveBeenCalledWith(source, reactNamespace, 'build', false);
+      expect(addUsedSharesMock).toHaveBeenCalledWith(source);
+      // import:false must not invent a local prebuild fallback.
+      expect(preBuildShareItemMap.has(source)).toBe(false);
+    }
   });
 
   it('resolves prebuild aliases to configured share import sources in build mode', async () => {

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -517,7 +517,7 @@ describe('normalizeModuleFederationOption', () => {
       });
     });
 
-    it('normalizes docs-style trailing slash keys for common subpath shares', () => {
+    it('preserves react/ as a namespace prefix and collapses react-dom/', () => {
       const shared = normalizeModuleFederationOptions({
         ...minimalOptions,
         shared: {
@@ -535,13 +535,18 @@ describe('normalizeModuleFederationOption', () => {
         },
       }).shared;
 
-      expect(shared.react).toMatchObject({
-        name: 'react',
+      // react/ stays a prefix so consumer-only (and provider) shares cover any
+      // actually-imported subpath instead of a hardcoded JSX export list.
+      expect(shared['react/']).toMatchObject({
+        name: 'react/',
         shareConfig: {
           singleton: true,
           requiredVersion: '^19.0.0',
         },
       });
+      expect(shared.react).toBeUndefined();
+      // react-dom/ must not become a browser-wide prefix: that would also
+      // capture react-dom/server*. Collapse to the package root instead.
       expect(shared['react-dom']).toMatchObject({
         name: 'react-dom',
         shareConfig: {
@@ -549,9 +554,29 @@ describe('normalizeModuleFederationOption', () => {
           singleton: true,
         },
       });
-      expect(shared['react/']).toBeUndefined();
       expect(shared['react-dom/']).toBeUndefined();
       expect(shared['@scope/ui/']).toBeDefined();
+    });
+
+    it('preserves consumer-only react/ with import: false as a namespace prefix', () => {
+      const shared = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          'react/': {
+            singleton: true,
+            import: false,
+          },
+        },
+      }).shared;
+
+      expect(shared['react/']).toMatchObject({
+        name: 'react/',
+        shareConfig: {
+          singleton: true,
+          import: false,
+        },
+      });
+      expect(shared.react).toBeUndefined();
     });
 
     it('prefers the installed package version over an inferred requiredVersion', () => {

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -288,9 +288,26 @@ function normalizeShareItem(
   };
 }
 
+/**
+ * Trailing-slash keys are package namespace prefixes (`lodash/`, `@scope/ui/`).
+ *
+ * Packages in COMMON_SHARED_SUBPATHS historically collapsed `pkg/` → `pkg` so
+ * Vite would not resolve the invalid `pkg/` specifier, while still auto-mapping
+ * known subpaths when a local provider exists.
+ *
+ * `react/` is different: consumer-only shares need true namespace coverage for
+ * any actually-imported subpath, not a hardcoded export list. Keep `react/` as
+ * a prefix; concrete subpaths materialize on import via the generic matcher.
+ *
+ * `react-dom/` must keep collapsing. A browser-wide `react-dom/` prefix would
+ * also capture `react-dom/server*`, which is unsafe without environment-aware
+ * filtering. Browser-safe entries such as `react-dom/client` stay explicit via
+ * COMMON_SHARED_SUBPATHS (local provider) or an exact shared key.
+ */
 function normalizeSharedKey(key: string): string {
   if (!key.endsWith('/')) return key;
   const baseKey = key.slice(0, -1);
+  if (baseKey === 'react') return key;
   return getCommonSharedSubpaths(baseKey).length > 0 ? baseKey : key;
 }
 


### PR DESCRIPTION
## Summary

The Vite plugin already has generic prefix matching, but it special-cases React: `react/` is normalized to `react`, and known subpaths (`jsx-runtime`, etc.) are only auto-mapped when a local provider exists. With `import: false`, that mapping is skipped, so the generic prefix matcher never receives `react/`.

This PR preserves `react/` as a namespace prefix so consumer-only shares cover actually-imported subpaths (namespace coverage, not a hardcoded React export list).

`react-dom/` still collapses. A browser-wide prefix would also capture `react-dom/server.*`, so `react-dom/client` stays an explicit browser-safe entry unless the plugin gains environment-aware filtering.

## Test plan

- [ ] `normalizeSharedKey('react/')` stays `react/` (does not collapse to `react`)
- [ ] `normalizeSharedKey('react-dom/')` still collapses so `react-dom/server*` is not captured by a browser prefix
- [ ] Consumer-only `import: false` + `react/` materializes `react/jsx-runtime` (and siblings) when actually imported
- [ ] Existing local-provider React auto-mapping tests still pass