### PR TITLE
fix: honor vite-ignore in HTML bootstrap

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -1958,6 +1958,61 @@ describe('pluginAddEntry', () => {
     expect(bootstrapFile!.source as string).toContain('__mfImport("../../src/main.tsx")');
   });
 
+  it('leaves vite-ignore scripts unchanged', () => {
+    const plugins = addEntry({
+      entryName: 'hostInit',
+      entryPath: '/virtual/hostInit.js',
+      inject: 'html',
+    });
+    const buildPlugin = plugins[1];
+    const emitted: Rollup.EmittedFile[] = [];
+    const bundle: any = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<script type="module" src="/src/main.tsx"></script><script type="module" src="/external/external.js" vite-ignore></script>',
+      },
+    };
+
+    runConfigResolved(buildPlugin, {
+      root: '/repo/host',
+      base: '/',
+      command: 'build',
+      build: { rollupOptions: {} },
+    } as unknown as ResolvedConfig);
+    runBuildStart(
+      buildPlugin,
+      {
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return file.type === 'chunk' ? 'host-init-ref' : `bootstrap-${emitted.length}`;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedInputOptions
+    );
+    runGenerateBundle(
+      buildPlugin,
+      {
+        getFileName: (ref: string) => (ref === 'host-init-ref' ? 'assets/hostInit.js' : ref),
+        emitFile: (file: Rollup.EmittedFile) => {
+          emitted.push(file);
+          return `bootstrap-${emitted.length}`;
+        },
+      } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle as unknown as Rollup.OutputBundle
+    );
+
+    expect(bundle['index.html'].source).toContain(
+      '<script type="module" src="/external/external.js" vite-ignore></script>'
+    );
+    expect(
+      emitted.filter(
+        (file) => file.type === 'asset' && file.fileName?.includes('mf-entry-bootstrap')
+      )
+    ).toHaveLength(1);
+  });
+
   it('emits bootstrap file at root when entryFileNames is not set', () => {
     const plugins = addEntry({
       entryName: 'hostInit',

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -1040,6 +1040,7 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
             /<script\b(?=[^>]*\btype=["']module["'])(?=[^>]*\bsrc=["']([^"']+)["'])[^>]*>\s*<\/script>/gi;
           let rewritten = false;
           htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
+            if (/\svite-ignore(?:\s|=|\/?>)/i.test(scriptTag)) return scriptTag;
             rewritten = true;
             const strippedInit = stripBase(initPath);
             const strippedEntry = stripBase(entrySrc);


### PR DESCRIPTION
Closes #1149

Preserves ignored module scripts during HTML rewriting, preventing root-relative external paths from being rebased.
vite-ignore is an official Vite HTML attribute. It tells Vite to skip processing that element, especially useful for external/CDN assets. Vite documentation
