### PR TITLE
fix: cache repeated shared export inspections

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -363,6 +363,18 @@ describe('federation in test environment', () => {
 });
 
 describe('virtual module resolution', () => {
+  it('invalidates shared export inspections for workspace watcher events', () => {
+    const on = vi.fn();
+
+    callHook(
+      getVirtualModulesPlugin().configureServer,
+      {} as MinimalPluginContextWithoutEnvironment,
+      { watcher: { on } } as any
+    );
+
+    expect(on.mock.calls.map(([event]) => event)).toEqual(['change', 'add', 'unlink']);
+  });
+
   it('resolves the SSR entry loader from the plugin package', () => {
     const loaderPath = '/plugin/lib/utils/ssrEntryLoader.js';
     const resolverMock = vi.mocked(resolveImportPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,14 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'url';
-import type { ConfigEnv, EnvironmentOptions, Plugin, ResolvedConfig, UserConfig } from 'vite';
+import type {
+  ConfigEnv,
+  EnvironmentOptions,
+  Plugin,
+  ResolvedConfig,
+  UserConfig,
+  ViteDevServer,
+} from 'vite';
 import { version as viteVersion } from 'vite';
 import addEntry, { getBuildInput } from './plugins/pluginAddEntry';
 import { checkAliasConflicts } from './plugins/pluginCheckAliasConflicts';
@@ -100,6 +107,7 @@ import {
   getCachedPreBuildPkg,
   getLoadShareModulePath,
   getPreBuildLibImportId,
+  invalidateSharedExportInspectionCache,
   materializeCachedLoadShareModule,
   prependWorkspaceSingletonSsrImport,
   resetConcreteSharedImportSourceCache,
@@ -1174,6 +1182,11 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
     {
       name: 'vite:module-federation-virtual-modules',
       enforce: 'pre',
+      configureServer(server: ViteDevServer) {
+        server.watcher.on('change', invalidateSharedExportInspectionCache);
+        server.watcher.on('add', invalidateSharedExportInspectionCache);
+        server.watcher.on('unlink', invalidateSharedExportInspectionCache);
+      },
       resolveId(id: string) {
         if (id === SSR_ENTRY_LOADER_SPECIFIER) return resolveImportPath(id);
         let virtualModule = VirtualModule.findById(id);

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -15,6 +15,7 @@ import {
   getTreeShakingGraphToken,
   getTreeShakingSharedProviderImportId,
   hasTreeShakingSharedProvider,
+  invalidateSharedExportInspectionCache,
   refreshTreeShakingModules,
   resetConcreteSharedImportSourceCache,
   stripTreeShakingGraphQuery,
@@ -537,7 +538,9 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/typed-destructuring.ts') ||
       filePath.endsWith('/repo/packages/decorated-export.ts') ||
       filePath.endsWith('/repo/packages/export-import-alias.ts') ||
-      filePath.endsWith('/repo/packages/custom-shared-source/index.ts')
+      filePath.endsWith('/repo/packages/custom-shared-source/index.ts') ||
+      filePath.endsWith('/repo/packages/cached-shared-source/index.ts') ||
+      filePath.endsWith('/repo/packages/cached-shared-source/leaf.ts')
     );
   }),
   readFileSync: vi.fn((filePath: string) => {
@@ -931,6 +934,12 @@ export const [firstItem, ...restItems] = tuple;`;
               export function useSharedFeature() {
                 return sharedValue;
               }`;
+    }
+    if (filePath.endsWith('/repo/packages/cached-shared-source/index.ts')) {
+      return "export * from './leaf';";
+    }
+    if (filePath.endsWith('/repo/packages/cached-shared-source/leaf.ts')) {
+      return 'export const leafValue = true;';
     }
     if (filePath.endsWith('/mock-package-browser-esm-internal-cjs/index.js')) {
       return `const internalModule = { exports: {} };
@@ -1419,6 +1428,70 @@ describe('writeLoadShareModule', () => {
       'export { __mf_0 as sharedValue, __mf_1 as useSharedFeature };'
     );
     expect(generatedCode).not.toContain('export * from "/repo/packages/custom-shared-source"');
+  });
+
+  it('inspects a configured shared source once', () => {
+    const shareItem: ShareItem = {
+      name: '@repo/cached-shared-source',
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/cached-shared-source',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+    const readFileSyncMock = vi.mocked(readFileSync);
+    readFileSyncMock.mockClear();
+
+    getSharedNamedExports(shareItem.name, shareItem, ['cache-regression']);
+    getSharedNamedExports(shareItem.name, shareItem, ['cache-regression']);
+
+    expect(
+      readFileSyncMock.mock.calls.filter(([filePath]) =>
+        String(filePath).includes('/repo/packages/cached-shared-source/')
+      )
+    ).toHaveLength(2);
+  });
+
+  it('reinspects configured shared sources after a workspace change', () => {
+    const shareItem: ShareItem = {
+      name: '@repo/cached-shared-source',
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/cached-shared-source',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+    const readFileSyncMock = vi.mocked(readFileSync);
+    const originalRead = readFileSyncMock.getMockImplementation() as typeof readFileSync;
+    let source = 'export const before = true;';
+    readFileSyncMock.mockImplementation(((filePath: string, ...args: unknown[]) =>
+      String(filePath).endsWith('/repo/packages/cached-shared-source/leaf.ts')
+        ? source
+        : (originalRead as (...args: unknown[]) => unknown)(
+            filePath,
+            ...args
+          )) as typeof readFileSync);
+
+    try {
+      expect(getSharedNamedExports(shareItem.name, shareItem, ['invalidation-regression'])).toEqual(
+        ['before']
+      );
+      source = 'export const after = true;';
+      invalidateSharedExportInspectionCache('/repo/packages/cached-shared-source/leaf.ts');
+      expect(getSharedNamedExports(shareItem.name, shareItem, ['invalidation-regression'])).toEqual(
+        ['after']
+      );
+    } finally {
+      readFileSyncMock.mockImplementation(originalRead);
+    }
   });
 
   it('inlines a build-only cache bootstrap without importing runtimeInit', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -109,6 +109,13 @@ type SharedExportInspection = {
 type CachedNamedExports = { value: string[] | undefined };
 
 const packageNamedExportsCache = new Map<string, CachedNamedExports>();
+const sharedExportInspectionCache = new Map<string, SharedExportInspection | undefined>();
+
+export function invalidateSharedExportInspectionCache(filePath: string): void {
+  if (!/(?:^|[/\\])node_modules(?:[/\\]|$)/.test(filePath)) {
+    sharedExportInspectionCache.clear();
+  }
+}
 
 type NamedExportScanState = {
   complete: boolean;
@@ -157,8 +164,13 @@ function inspectSharedExportsFromFile(
   entryPath: string | undefined,
   exportConditions = DEFAULT_SHARED_EXPORT_CONDITIONS
 ): SharedExportInspection | undefined {
+  if (!entryPath) return undefined;
+  const cacheKey = `${entryPath}\0${exportConditions.join('\0')}`;
+  if (sharedExportInspectionCache.has(cacheKey)) {
+    return sharedExportInspectionCache.get(cacheKey);
+  }
+
   try {
-    if (!entryPath) return undefined;
     const source = readFileSync(entryPath, 'utf-8');
     const scanState: NamedExportScanState = { complete: true };
     const namedExports = getNamedExportsViaRegex(
@@ -169,13 +181,16 @@ function inspectSharedExportsFromFile(
       exportConditions
     );
     const commonJs = hasCommonJsExports(source);
-    return {
+    const inspection = {
       // A complete empty ESM scan is a known default-only export surface. Keep
       // unresolved re-exports and CommonJS sources conservative instead.
       namedExports: scanState.complete && !commonJs ? namedExports : undefined,
       commonJs,
     };
+    sharedExportInspectionCache.set(cacheKey, inspection);
+    return inspection;
   } catch {
+    sharedExportInspectionCache.set(cacheKey, undefined);
     return undefined;
   }
 }


### PR DESCRIPTION
Closes #1150

Memoizes shared export graph scans and invalidates cached results when workspace files change, improving startup performance without stale exports.
 