### PR TITLE
chore: improve preserve ignored scripts through Vite

### DIFF
--- a/integration/fixtures/vite-ignore-host/entry.js
+++ b/integration/fixtures/vite-ignore-host/entry.js
@@ -1,0 +1,1 @@
+console.log('entry');

--- a/integration/fixtures/vite-ignore-host/index.html
+++ b/integration/fixtures/vite-ignore-host/index.html
@@ -1,0 +1,2 @@
+<script type="module" src="./entry.js"></script>
+<script type="module" src="/external/external.js" vite-ignore></script>

--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm, symlink } from 'fs/promises';
 import { dirname, resolve } from 'path';
+import { version as viteVersion } from 'vite';
 import { describe, expect, it } from 'vitest';
 import type { ModuleFederationOptions } from '../src/utils/normalizeModuleFederationOptions';
 import { buildFixture, FIXTURES } from './helpers/build';
@@ -26,6 +27,8 @@ const LOADED_FIRST_STATIC_MF_OPTIONS = {
 
 const hostInitChunkRegex = /<script\s+type="module"\s+src="[^"]*hostInit[^"]*">/;
 const bootstrapScriptRegex = /<script\s+type="module"[^>]+src="[^"]*mf-entry-bootstrap[^"]*">/;
+// Vite 5 does not support the vite-ignore HTML attribute.
+const itSupportsViteIgnore = it.skipIf(viteVersion.startsWith('5.'));
 
 async function createWorkspaceFixture() {
   const root = resolve(FIXTURES, 'workspace-source-remote');
@@ -144,6 +147,22 @@ describe('host build', () => {
     expect(bootstrapAsset?.source).toContain('})().then(() => __mfImport(');
     expect(bootstrapAsset?.source).toContain('globalThis.System.import(src)');
     expect(bootstrapAsset?.source).toContain('hostInit');
+  });
+
+  itSupportsViteIgnore('leaves vite-ignore scripts unchanged in a Vite build', async () => {
+    const output = await buildFixture({
+      fixture: 'vite-ignore-host',
+      mfOptions: { ...HOST_BASE_MF_OPTIONS, hostInitInjectLocation: 'html' },
+    });
+    const html = getHtmlAsset(output)?.source as string;
+    const bootstrapAssets = output.output.filter(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+
+    expect(html).toContain('src="/external/external.js"');
+    expect(html).not.toContain('vite-ignore');
+    expect(bootstrapAssets).toHaveLength(1);
+    expect(bootstrapAssets[0].source).not.toContain('/external/external.js');
   });
 
   it('builds when rolldownOptions.input points at a named HTML entry', async () => {

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -1958,61 +1958,6 @@ describe('pluginAddEntry', () => {
     expect(bootstrapFile!.source as string).toContain('__mfImport("../../src/main.tsx")');
   });
 
-  it('leaves vite-ignore scripts unchanged', () => {
-    const plugins = addEntry({
-      entryName: 'hostInit',
-      entryPath: '/virtual/hostInit.js',
-      inject: 'html',
-    });
-    const buildPlugin = plugins[1];
-    const emitted: Rollup.EmittedFile[] = [];
-    const bundle: any = {
-      'index.html': {
-        type: 'asset',
-        source:
-          '<script type="module" src="/src/main.tsx"></script><script type="module" src="/external/external.js" vite-ignore></script>',
-      },
-    };
-
-    runConfigResolved(buildPlugin, {
-      root: '/repo/host',
-      base: '/',
-      command: 'build',
-      build: { rollupOptions: {} },
-    } as unknown as ResolvedConfig);
-    runBuildStart(
-      buildPlugin,
-      {
-        emitFile: (file: Rollup.EmittedFile) => {
-          emitted.push(file);
-          return file.type === 'chunk' ? 'host-init-ref' : `bootstrap-${emitted.length}`;
-        },
-      } as unknown as Rollup.PluginContext,
-      {} as Rollup.NormalizedInputOptions
-    );
-    runGenerateBundle(
-      buildPlugin,
-      {
-        getFileName: (ref: string) => (ref === 'host-init-ref' ? 'assets/hostInit.js' : ref),
-        emitFile: (file: Rollup.EmittedFile) => {
-          emitted.push(file);
-          return `bootstrap-${emitted.length}`;
-        },
-      } as unknown as Rollup.PluginContext,
-      {} as Rollup.NormalizedOutputOptions,
-      bundle as unknown as Rollup.OutputBundle
-    );
-
-    expect(bundle['index.html'].source).toContain(
-      '<script type="module" src="/external/external.js" vite-ignore></script>'
-    );
-    expect(
-      emitted.filter(
-        (file) => file.type === 'asset' && file.fileName?.includes('mf-entry-bootstrap')
-      )
-    ).toHaveLength(1);
-  });
-
   it('emits bootstrap file at root when entryFileNames is not set', () => {
     const plugins = addEntry({
       entryName: 'hostInit',

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -309,6 +309,7 @@ const addEntry = ({
   let emittedFileName: string | undefined;
   let skipTransformIds = new Set<string>();
   let injectedTransformIds = new Set<string>();
+  const ignoredHtmlScriptSources = new Set<string>();
   let bootstrapDir = '';
 
   function skipSvelteKitSsrBuild() {
@@ -715,6 +716,10 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
     let match: RegExpExecArray | null;
 
     while ((match = scriptRegex.exec(htmlContent)) !== null) {
+      if (/\svite-ignore(?:\s|=|\/?>)/i.test(match[0])) {
+        ignoredHtmlScriptSources.add(match[1]);
+        continue;
+      }
       const scriptSrc = stripQueryAndHash(match[1]);
       if (/^(?:[a-z]+:)?\/\//i.test(scriptSrc)) continue;
       addEntryFile(scriptSrc);
@@ -1040,7 +1045,7 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
             /<script\b(?=[^>]*\btype=["']module["'])(?=[^>]*\bsrc=["']([^"']+)["'])[^>]*>\s*<\/script>/gi;
           let rewritten = false;
           htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
-            if (/\svite-ignore(?:\s|=|\/?>)/i.test(scriptTag)) return scriptTag;
+            if (ignoredHtmlScriptSources.has(entrySrc)) return scriptTag;
             rewritten = true;
             const strippedInit = stripBase(initPath);
             const strippedEntry = stripBase(entrySrc);


### PR DESCRIPTION
Tracks ignored script sources before Vite removes their marker, then excludes them from federation bootstrap rewriting.