### PR TITLE
fix: expand react/ prefix in SSR loadShare and eager seed

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -723,6 +723,75 @@ describe('virtualRemoteEntry', () => {
     expect(code).toMatch(/loaded: false,\s+materialize: true,\s+eager: true,\s+from: "host"/);
   });
 
+  it('expands eager react/ prefix into concrete shared modules, never the prefix string', async () => {
+    const mod = await import('../virtualRemoteEntry');
+    const reactNamespace = {
+      name: 'react/',
+      from: '',
+      version: '19.2.4',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        eager: true,
+        import: false,
+        requiredVersion: '^19.2.4',
+        strictVersion: false,
+      },
+    };
+    const options = {
+      internalName: '__mfe_internal__react_prefix',
+      name: 'react-prefix-host',
+      filename: 'remoteEntry.js',
+      shared: { 'react/': reactNamespace },
+      shareScope: 'default',
+      runtimePlugins: [],
+      shareStrategy: 'version-first',
+    } as any;
+
+    mod.addUsedShares('react/jsx-runtime', options);
+    mod.addUsedShares('react/jsx-dev-runtime', options);
+
+    const code = mod.generateLocalSharedImportMap(options);
+
+    expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
+    expect(code).toMatch(/"react\/jsx-runtime": \{[\s\S]*?materialize: true,/);
+    expect(code).toMatch(/"react\/jsx-dev-runtime": \{[\s\S]*?materialize: true,/);
+    expect(code).not.toMatch(/"react\/": \{/);
+  });
+
+  it('eager react/ still seeds the package root when no subpaths were imported yet', async () => {
+    const mod = await import('../virtualRemoteEntry');
+    const options = {
+      internalName: '__mfe_internal__react_eager_root',
+      name: 'react-eager-root',
+      filename: 'remoteEntry.js',
+      shared: {
+        'react/': {
+          name: 'react/',
+          from: '',
+          version: '19.2.4',
+          scope: 'default',
+          shareConfig: {
+            singleton: true,
+            eager: true,
+            import: false,
+            requiredVersion: '^19.2.4',
+            strictVersion: false,
+          },
+        },
+      },
+      shareScope: 'default',
+      runtimePlugins: [],
+      shareStrategy: 'version-first',
+    } as any;
+
+    const code = mod.generateLocalSharedImportMap(options);
+
+    expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
+    expect(code).not.toMatch(/"react\/": \{/);
+    expect(code).not.toContain('"react/jsx-runtime"');
+  });
+
   it('registers configured shares without materializing unused providers', async () => {
     const mod = await import('../virtualRemoteEntry');
     const options = {

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -725,45 +725,9 @@ describe('virtualRemoteEntry', () => {
 
   it('expands eager react/ prefix into concrete shared modules, never the prefix string', async () => {
     const mod = await import('../virtualRemoteEntry');
-    const reactNamespace = {
-      name: 'react/',
-      from: '',
-      version: '19.2.4',
-      scope: 'default',
-      shareConfig: {
-        singleton: true,
-        eager: true,
-        import: false,
-        requiredVersion: '^19.2.4',
-        strictVersion: false,
-      },
-    };
     const options = {
       internalName: '__mfe_internal__react_prefix',
       name: 'react-prefix-host',
-      filename: 'remoteEntry.js',
-      shared: { 'react/': reactNamespace },
-      shareScope: 'default',
-      runtimePlugins: [],
-      shareStrategy: 'version-first',
-    } as any;
-
-    mod.addUsedShares('react/jsx-runtime', options);
-    mod.addUsedShares('react/jsx-dev-runtime', options);
-
-    const code = mod.generateLocalSharedImportMap(options);
-
-    expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
-    expect(code).toMatch(/"react\/jsx-runtime": \{[\s\S]*?materialize: true,/);
-    expect(code).toMatch(/"react\/jsx-dev-runtime": \{[\s\S]*?materialize: true,/);
-    expect(code).not.toMatch(/"react\/": \{/);
-  });
-
-  it('eager react/ still seeds the package root when no subpaths were imported yet', async () => {
-    const mod = await import('../virtualRemoteEntry');
-    const options = {
-      internalName: '__mfe_internal__react_eager_root',
-      name: 'react-eager-root',
       filename: 'remoteEntry.js',
       shared: {
         'react/': {
@@ -785,11 +749,15 @@ describe('virtualRemoteEntry', () => {
       shareStrategy: 'version-first',
     } as any;
 
+    mod.addUsedShares('react/jsx-runtime', options);
+    mod.addUsedShares('react/jsx-dev-runtime', options);
+
     const code = mod.generateLocalSharedImportMap(options);
 
     expect(code).toMatch(/"react": \{[\s\S]*?materialize: true,/);
+    expect(code).toMatch(/"react\/jsx-runtime": \{[\s\S]*?materialize: true,/);
+    expect(code).toMatch(/"react\/jsx-dev-runtime": \{[\s\S]*?materialize: true,/);
     expect(code).not.toMatch(/"react\/": \{/);
-    expect(code).not.toContain('"react/jsx-runtime"');
   });
 
   it('registers configured shares without materializing unused providers', async () => {

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -283,7 +283,7 @@ describe('virtualRemoteEntrySSR', () => {
     expect((globalThis as any).__mf_module_cache__).toBeUndefined();
   });
 
-  it('expands consumer-only react/ prefix into concrete SSR loadShare targets', async () => {
+  it('expands react/ prefix into concrete SSR loadShare targets, never the prefix string', async () => {
     const reactNamespace = {
       name: 'react/',
       version: '19.0.0',
@@ -293,9 +293,7 @@ describe('virtualRemoteEntrySSR', () => {
     };
     const options = getDefaultMockOptions({
       name: 'remote',
-      shared: {
-        'react/': reactNamespace,
-      },
+      shared: { 'react/': reactNamespace },
     } as any);
 
     addUsedShares('react', options);
@@ -309,39 +307,9 @@ describe('virtualRemoteEntrySSR', () => {
     const loadShare = vi.fn(async (pkg: string) => () => ({ marker: pkg }));
     const entry = evaluateGeneratedEntry(code, createRuntime(undefined, loadShare));
 
-    await expect(
-      entry.init({
-        react: {},
-        'react/jsx-runtime': {},
-      })
-    ).resolves.toBeDefined();
+    await expect(entry.init({ react: {}, 'react/jsx-runtime': {} })).resolves.toBeDefined();
 
     expect(loadShare.mock.calls.map(([pkg]) => pkg).sort()).toEqual(['react', 'react/jsx-runtime']);
     expect(loadShare.mock.calls.some(([pkg]) => pkg === 'react/')).toBe(false);
-    expect((globalThis as any).__mf_module_cache__.share).toMatchObject({
-      'default:react': { marker: 'react' },
-      'default:react/jsx-runtime': { marker: 'react/jsx-runtime' },
-      react: { marker: 'react' },
-      'react/jsx-runtime': { marker: 'react/jsx-runtime' },
-    });
-  });
-
-  it('does not invent SSR loadShare targets for an unused react/ prefix', () => {
-    const options = getDefaultMockOptions({
-      name: 'remote',
-      shared: {
-        'react/': {
-          name: 'react/',
-          version: '19.0.0',
-          scope: 'default',
-          from: '',
-          shareConfig: { singleton: true, import: false, requiredVersion: '^19.0.0' },
-        },
-      },
-    } as any);
-
-    const code = generateRemoteEntrySSR(options);
-    expect(code).toContain('const sharedSingletons = {}');
-    expect(code).not.toContain('"react/"');
   });
 });

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultMockOptions } from '../../utils/__tests__/helpers';
+import { addUsedShares, getUsedShares } from '../virtualRemoteEntry';
 import { generateRemoteEntrySSR, getRemoteEntrySSRId } from '../virtualRemoteEntrySSR';
 import { MODULE_CACHE_SHARE_SCOPE_KEY } from '../virtualRuntimeInitStatus';
 
@@ -64,8 +65,13 @@ function createRuntime(
   }));
 }
 
+beforeEach(() => {
+  getUsedShares().clear();
+});
+
 afterEach(() => {
   delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+  getUsedShares().clear();
 });
 
 describe('virtualRemoteEntrySSR', () => {
@@ -275,5 +281,67 @@ describe('virtualRemoteEntrySSR', () => {
       react: module,
     });
     expect((globalThis as any).__mf_module_cache__).toBeUndefined();
+  });
+
+  it('expands consumer-only react/ prefix into concrete SSR loadShare targets', async () => {
+    const reactNamespace = {
+      name: 'react/',
+      version: '19.0.0',
+      scope: 'default',
+      from: '',
+      shareConfig: { singleton: true, import: false, requiredVersion: '^19.0.0' },
+    };
+    const options = getDefaultMockOptions({
+      name: 'remote',
+      shared: {
+        'react/': reactNamespace,
+      },
+    } as any);
+
+    addUsedShares('react', options);
+    addUsedShares('react/jsx-runtime', options);
+
+    const code = generateRemoteEntrySSR(options);
+    expect(code).toContain('"react"');
+    expect(code).toContain('"react/jsx-runtime"');
+    expect(code).not.toContain('"react/"');
+
+    const loadShare = vi.fn(async (pkg: string) => () => ({ marker: pkg }));
+    const entry = evaluateGeneratedEntry(code, createRuntime(undefined, loadShare));
+
+    await expect(
+      entry.init({
+        react: {},
+        'react/jsx-runtime': {},
+      })
+    ).resolves.toBeDefined();
+
+    expect(loadShare.mock.calls.map(([pkg]) => pkg).sort()).toEqual(['react', 'react/jsx-runtime']);
+    expect(loadShare.mock.calls.some(([pkg]) => pkg === 'react/')).toBe(false);
+    expect((globalThis as any).__mf_module_cache__.share).toMatchObject({
+      'default:react': { marker: 'react' },
+      'default:react/jsx-runtime': { marker: 'react/jsx-runtime' },
+      react: { marker: 'react' },
+      'react/jsx-runtime': { marker: 'react/jsx-runtime' },
+    });
+  });
+
+  it('does not invent SSR loadShare targets for an unused react/ prefix', () => {
+    const options = getDefaultMockOptions({
+      name: 'remote',
+      shared: {
+        'react/': {
+          name: 'react/',
+          version: '19.0.0',
+          scope: 'default',
+          from: '',
+          shareConfig: { singleton: true, import: false, requiredVersion: '^19.0.0' },
+        },
+      },
+    } as any);
+
+    const code = generateRemoteEntrySSR(options);
+    expect(code).toContain('const sharedSingletons = {}');
+    expect(code).not.toContain('"react/"');
   });
 });

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -321,12 +321,49 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
       `;
 }
 
+/**
+ * Expand a trailing-slash shared key (`react/`) to concrete package names.
+ * Always includes the package root; also includes imported subpaths from
+ * `used` that fall under the prefix. Never returns the prefix string itself.
+ */
+function expandEagerSharedPrefix(prefixKey: string, used: Iterable<string>): string[] {
+  const base = prefixKey.slice(0, -1);
+  const expanded = new Set<string>([base]);
+  for (const pkg of used) {
+    if (pkg.endsWith('/')) continue;
+    if (pkg === base || pkg.startsWith(`${base}/`)) expanded.add(pkg);
+  }
+  return [...expanded];
+}
+
+function getEagerSharedPackages(
+  shared: NormalizedModuleFederationOptions['shared'],
+  used: Iterable<string>
+): string[] {
+  const packages: string[] = [];
+  for (const [pkg, share] of Object.entries(shared ?? {})) {
+    if (!share.shareConfig?.eager) continue;
+    if (pkg.endsWith('/')) {
+      packages.push(...expandEagerSharedPrefix(pkg, used));
+    } else {
+      packages.push(pkg);
+    }
+  }
+  return packages;
+}
+
 function getOrderedUsedShares(options?: NormalizedModuleFederationOptions) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
-  const shares = new Set(getUsedShares(options));
+  const used = getUsedShares(options);
+  const shares = new Set(used);
   Object.keys(resolvedOptions.shared ?? {}).forEach((pkg) => {
     if (!pkg.endsWith('/')) shares.add(pkg);
   });
+  // Eager prefix keys (`react/`) must appear as concrete packages in usedShared
+  // (root + imported subpaths), never as the prefix string itself.
+  for (const pkg of getEagerSharedPackages(resolvedOptions.shared, used)) {
+    shares.add(pkg);
+  }
   const sorted = Array.from(shares).sort((a, b) => {
     const priority = (pkg: string) =>
       pkg === 'react' ? 0 : pkg === 'react-dom' ? 1 : pkg.startsWith('react/') ? 2 : 3;
@@ -343,8 +380,9 @@ function getMaterializedShares(options?: NormalizedModuleFederationOptions) {
       ? (materializedSharesByOptions.get(options) ?? [])
       : usedShares
   );
-  for (const [pkg, share] of Object.entries(resolvedOptions.shared ?? {})) {
-    if (!pkg.endsWith('/') && share.shareConfig?.eager) shares.add(pkg);
+  const usedForEager = options ? (usedSharesByOptions.get(options) ?? []) : usedShares;
+  for (const pkg of getEagerSharedPackages(resolvedOptions.shared, usedForEager)) {
+    shares.add(pkg);
   }
   const configured = new Map<string, string>();
   for (const pkg of getOrderedUsedShares(options)) {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -321,12 +321,8 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
       `;
 }
 
-/**
- * Expand a trailing-slash shared key (`react/`) to concrete package names.
- * Always includes the package root; also includes imported subpaths from
- * `used` that fall under the prefix. Never returns the prefix string itself.
- */
-function expandEagerSharedPrefix(prefixKey: string, used: Iterable<string>): string[] {
+/** Expand `pkg/` → package root + matching usedShares; never returns the prefix string. */
+export function expandSharedPrefixKey(prefixKey: string, used: Iterable<string>): string[] {
   const base = prefixKey.slice(0, -1);
   const expanded = new Set<string>([base]);
   for (const pkg of used) {
@@ -336,22 +332,6 @@ function expandEagerSharedPrefix(prefixKey: string, used: Iterable<string>): str
   return [...expanded];
 }
 
-function getEagerSharedPackages(
-  shared: NormalizedModuleFederationOptions['shared'],
-  used: Iterable<string>
-): string[] {
-  const packages: string[] = [];
-  for (const [pkg, share] of Object.entries(shared ?? {})) {
-    if (!share.shareConfig?.eager) continue;
-    if (pkg.endsWith('/')) {
-      packages.push(...expandEagerSharedPrefix(pkg, used));
-    } else {
-      packages.push(pkg);
-    }
-  }
-  return packages;
-}
-
 function getOrderedUsedShares(options?: NormalizedModuleFederationOptions) {
   const resolvedOptions = options ?? getNormalizeModuleFederationOptions();
   const used = getUsedShares(options);
@@ -359,10 +339,10 @@ function getOrderedUsedShares(options?: NormalizedModuleFederationOptions) {
   Object.keys(resolvedOptions.shared ?? {}).forEach((pkg) => {
     if (!pkg.endsWith('/')) shares.add(pkg);
   });
-  // Eager prefix keys (`react/`) must appear as concrete packages in usedShared
-  // (root + imported subpaths), never as the prefix string itself.
-  for (const pkg of getEagerSharedPackages(resolvedOptions.shared, used)) {
-    shares.add(pkg);
+  for (const [pkg, share] of Object.entries(resolvedOptions.shared ?? {})) {
+    if (pkg.endsWith('/') && share.shareConfig?.eager) {
+      for (const concrete of expandSharedPrefixKey(pkg, used)) shares.add(concrete);
+    }
   }
   const sorted = Array.from(shares).sort((a, b) => {
     const priority = (pkg: string) =>
@@ -381,8 +361,13 @@ function getMaterializedShares(options?: NormalizedModuleFederationOptions) {
       : usedShares
   );
   const usedForEager = options ? (usedSharesByOptions.get(options) ?? []) : usedShares;
-  for (const pkg of getEagerSharedPackages(resolvedOptions.shared, usedForEager)) {
-    shares.add(pkg);
+  for (const [pkg, share] of Object.entries(resolvedOptions.shared ?? {})) {
+    if (!share.shareConfig?.eager) continue;
+    if (pkg.endsWith('/')) {
+      for (const concrete of expandSharedPrefixKey(pkg, usedForEager)) shares.add(concrete);
+    } else {
+      shares.add(pkg);
+    }
   }
   const configured = new Map<string, string>();
   for (const pkg of getOrderedUsedShares(options)) {

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -1,10 +1,9 @@
-import { findSharedKey } from '../plugins/pluginProxySharedModule_preBuild';
 import {
   NormalizedModuleFederationOptions,
   ShareItem,
 } from '../utils/normalizeModuleFederationOptions';
 import { getVirtualExposesSSRId } from './virtualExposesSSR';
-import { getUsedShares } from './virtualRemoteEntry';
+import { expandSharedPrefixKey, getUsedShares } from './virtualRemoteEntry';
 import { getVirtualModuleScopeKey } from './virtualModuleScope';
 import { MODULE_CACHE_SHARE_SCOPE_KEY } from './virtualRuntimeInitStatus';
 
@@ -22,16 +21,7 @@ export function getSsrRemoteEntryFileName(browserFilename: string): string {
   return `${base}.ssr${ext}`;
 }
 
-/**
- * Build-time singleton map for SSR init loadShare.
- *
- * Trailing-slash keys (`react/`) are namespace prefixes, not host share-scope
- * entries. After #1148 they stay as prefixes, so JSON-serializing them and
- * probing `scopeShare['react/']` would skip seeding. Expand via the same
- * matcher + usedShares path as the browser entry: concrete packages that
- * matched the prefix (e.g. `react`, `react/jsx-runtime`), never the prefix
- * string itself.
- */
+/** Singleton map for SSR loadShare: expand `pkg/` via usedShares; never serialize the prefix. */
 function getSsrSharedSingletons(
   options: NormalizedModuleFederationOptions
 ): Record<string, ShareItem> {
@@ -40,16 +30,12 @@ function getSsrSharedSingletons(
 
   for (const [pkg, share] of Object.entries(options.shared)) {
     if (!share.shareConfig.singleton) continue;
-
     if (pkg.endsWith('/')) {
-      for (const usedPkg of used) {
-        if (usedPkg.endsWith('/')) continue;
-        if (findSharedKey(usedPkg, options.shared) !== pkg) continue;
-        result[usedPkg] = { ...share, name: usedPkg };
+      for (const concrete of expandSharedPrefixKey(pkg, used)) {
+        result[concrete] = { ...share, name: concrete };
       }
       continue;
     }
-
     result[pkg] = share;
   }
 

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -1,5 +1,10 @@
-import { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
+import { findSharedKey } from '../plugins/pluginProxySharedModule_preBuild';
+import {
+  NormalizedModuleFederationOptions,
+  ShareItem,
+} from '../utils/normalizeModuleFederationOptions';
 import { getVirtualExposesSSRId } from './virtualExposesSSR';
+import { getUsedShares } from './virtualRemoteEntry';
 import { getVirtualModuleScopeKey } from './virtualModuleScope';
 import { MODULE_CACHE_SHARE_SCOPE_KEY } from './virtualRuntimeInitStatus';
 
@@ -18,6 +23,40 @@ export function getSsrRemoteEntryFileName(browserFilename: string): string {
 }
 
 /**
+ * Build-time singleton map for SSR init loadShare.
+ *
+ * Trailing-slash keys (`react/`) are namespace prefixes, not host share-scope
+ * entries. After #1148 they stay as prefixes, so JSON-serializing them and
+ * probing `scopeShare['react/']` would skip seeding. Expand via the same
+ * matcher + usedShares path as the browser entry: concrete packages that
+ * matched the prefix (e.g. `react`, `react/jsx-runtime`), never the prefix
+ * string itself.
+ */
+function getSsrSharedSingletons(
+  options: NormalizedModuleFederationOptions
+): Record<string, ShareItem> {
+  const used = getUsedShares(options);
+  const result: Record<string, ShareItem> = {};
+
+  for (const [pkg, share] of Object.entries(options.shared)) {
+    if (!share.shareConfig.singleton) continue;
+
+    if (pkg.endsWith('/')) {
+      for (const usedPkg of used) {
+        if (usedPkg.endsWith('/')) continue;
+        if (findSharedKey(usedPkg, options.shared) !== pkg) continue;
+        result[usedPkg] = { ...share, name: usedPkg };
+      }
+      continue;
+    }
+
+    result[pkg] = share;
+  }
+
+  return result;
+}
+
+/**
  * Generates the SSR remote entry module.
  *
  * This is intentionally minimal — no HMR shim, no loadShare virtual modules,
@@ -29,9 +68,7 @@ export function getSsrRemoteEntryFileName(browserFilename: string): string {
  */
 export function generateRemoteEntrySSR(options: NormalizedModuleFederationOptions): string {
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
-  const sharedSingletons = Object.fromEntries(
-    Object.entries(options.shared).filter(([, share]) => share.shareConfig.singleton)
-  );
+  const sharedSingletons = getSsrSharedSingletons(options);
 
   return `
   import { init as runtimeInit } from "@module-federation/runtime";


### PR DESCRIPTION
## Summary

Follow-up to #1148 (`react/` stays a namespace prefix). Two holes in `virtualRemoteEntry`:

1. **SSR `loadShare`:** `generateRemoteEntrySSR` iterated `options.shared` keys. After #1148, `react/` stays `react/`. The host share scope has `react` / `react/jsx-runtime`, not `react/`, so `if (!scopeShare[pkg]) continue` skipped the prefix and never seeded `jsx-runtime` into `__mf_module_cache__`.
2. **Eager seed:** `if (!pkg.endsWith('/') && share.shareConfig?.eager)` meant `eager: true` on `react/` was a no-op.

Fix: skip keys ending in `/`; expand via the same matcher/usedShares as the browser entry. Do not seed the string `react/`. Does not change `normalizeSharedKey`.

## Test plan

- [ ] `shared: { 'react/': { singleton: true, import: false } }` → SSR init `loadShare`s `react` + `react/jsx-runtime`, never the string `react/`
- [ ] `eager: true` on `react/` seeds `react` + imported subpaths
- [ ] Existing #1148 `react/` prefix tests still pass