### PR TITLE
fix: honor vite-ignore during dev transforms

### DIFF
--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -98,6 +98,20 @@ describe('rewriteEntryScripts', () => {
     expect(result).toContain(`src="/proxy?entry=%2Fsrc%2Fmain.js"`);
   });
 
+  it.each([
+    '<script type="module" src="/external/external.js" vite-ignore></script>',
+    '<script vite-ignore="" src="/external/external.js" type="module"></script>',
+  ])('preserves vite-ignore script tags', (script) => {
+    const result = rewriteEntryScripts(script, (src) => `/proxy?entry=${encodeURIComponent(src)}`);
+    expect(result).toBe(script);
+  });
+
+  it('does not confuse similarly named attributes with vite-ignore', () => {
+    const html = '<script type="module" src="/src/main.js" data-vite-ignore="true"></script>';
+    const result = rewriteEntryScripts(html, (src) => `/proxy?entry=${encodeURIComponent(src)}`);
+    expect(result).toContain('src="/proxy?entry=%2Fsrc%2Fmain.js"');
+  });
+
   it('handles multiple entry scripts', () => {
     const html =
       '<body>' +

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -94,6 +94,7 @@ export function rewriteEntryScripts(
     /<script\b(?=[^>]*\btype=["']module["'])(?=[^>]*\bsrc=["'][^"']+["'])([^>]*)>/gi;
 
   return html.replace(scriptTagRegex, (match, attrs) => {
+    if (/\svite-ignore(?:\s|=|\/|$)/i.test(attrs)) return match;
     const srcMatch = attrs.match(/\bsrc=["']([^"']+)["']/i);
     if (!srcMatch) return match;
     const originalSrc = srcMatch[1];


### PR DESCRIPTION
Preserves vite-ignore module scripts during dev HTML rewriting, matching build behavior.