### PR TITLE
fix: ignore package-manager protocol requiredVersion

### DIFF
--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -617,6 +617,83 @@ describe('normalizeModuleFederationOption', () => {
       });
     });
 
+    it('ignores package-manager protocol requiredVersion and falls back to installed version', () => {
+      const path = require('node:path');
+      const fs = require('node:fs');
+      const fixtureRoot = path.join(
+        require('node:os').tmpdir(),
+        'mf-vite-protocol-required-version'
+      );
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      const reactDir = path.join(fixtureRoot, 'node_modules/react');
+      fs.mkdirSync(reactDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'package.json'),
+        JSON.stringify({ name: 'consumer-app', dependencies: { react: 'catalog:' } })
+      );
+      fs.writeFileSync(
+        path.join(reactDir, 'package.json'),
+        JSON.stringify({ name: 'react', version: '19.2.7', main: 'index.js' })
+      );
+      fs.writeFileSync(path.join(reactDir, 'index.js'), '');
+
+      setPackageDetectionCwd(fixtureRoot);
+
+      try {
+        for (const protocol of [
+          'catalog:',
+          'catalog:react19',
+          'workspace:*',
+          'npm:react@^19.0.0',
+          'patch:react@19.2.7#./patches/react.patch',
+          '',
+        ]) {
+          const shared = normalizeModuleFederationOptions({
+            ...minimalOptions,
+            shared: {
+              react: {
+                singleton: true,
+                requiredVersion: protocol,
+              },
+            },
+          }).shared;
+
+          expect(shared.react.shareConfig.requiredVersion).toBe('^19.2.7');
+          expect(shared.react.shareConfig.requiredVersion).not.toMatch(
+            /^(catalog:|workspace:|npm:|patch:|$)/
+          );
+        }
+
+        // Normal semver ranges still pass through unchanged.
+        const semverShared = normalizeModuleFederationOptions({
+          ...minimalOptions,
+          shared: {
+            react: {
+              singleton: true,
+              requiredVersion: '^19.0.0',
+            },
+          },
+        }).shared;
+        expect(semverShared.react.shareConfig.requiredVersion).toBe('^19.0.0');
+      } finally {
+        setPackageDetectionCwd(process.cwd());
+      }
+    });
+
+    it('falls back to * when protocol requiredVersion has no installed package', () => {
+      const shared = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          'missing-protocol-dep': {
+            singleton: true,
+            requiredVersion: 'catalog:',
+          },
+        },
+      }).shared;
+
+      expect(shared['missing-protocol-dep'].shareConfig.requiredVersion).toBe('*');
+    });
+
     it('preserves react/ as a namespace prefix and collapses react-dom/', () => {
       const shared = normalizeModuleFederationOptions({
         ...minimalOptions,

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -646,6 +646,9 @@ describe('normalizeModuleFederationOption', () => {
           'workspace:*',
           'npm:react@^19.0.0',
           'patch:react@19.2.7#./patches/react.patch',
+          'file:../react',
+          'link:../react',
+          'portal:../react',
           '',
         ]) {
           const shared = normalizeModuleFederationOptions({
@@ -659,22 +662,22 @@ describe('normalizeModuleFederationOption', () => {
           }).shared;
 
           expect(shared.react.shareConfig.requiredVersion).toBe('^19.2.7');
-          expect(shared.react.shareConfig.requiredVersion).not.toMatch(
-            /^(catalog:|workspace:|npm:|patch:|$)/
-          );
         }
 
-        // Normal semver ranges still pass through unchanged.
-        const semverShared = normalizeModuleFederationOptions({
-          ...minimalOptions,
-          shared: {
-            react: {
-              singleton: true,
-              requiredVersion: '^19.0.0',
+        // Real ranges — including leading spaces / compound OR — stay unchanged.
+        // Do not use isRequiredVersion(); it only checks a prefix regex.
+        for (const range of ['^19.0.0', ' >= 8.0.0', '* || ^8.0.0']) {
+          const shared = normalizeModuleFederationOptions({
+            ...minimalOptions,
+            shared: {
+              react: {
+                singleton: true,
+                requiredVersion: range,
+              },
             },
-          },
-        }).shared;
-        expect(semverShared.react.shareConfig.requiredVersion).toBe('^19.0.0');
+          }).shared;
+          expect(shared.react.shareConfig.requiredVersion).toBe(range);
+        }
       } finally {
         setPackageDetectionCwd(process.cwd());
       }

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -649,6 +649,12 @@ describe('normalizeModuleFederationOption', () => {
           'file:../react',
           'link:../react',
           'portal:../react',
+          'exec:./build-react.js',
+          'jsr:@scope/react@^19.0.0',
+          'git:https://github.com/facebook/react.git',
+          'git+https://github.com/facebook/react.git',
+          'https://registry.example.com/react.tgz',
+          'github:facebook/react',
           '',
         ]) {
           const shared = normalizeModuleFederationOptions({
@@ -661,7 +667,7 @@ describe('normalizeModuleFederationOption', () => {
             },
           }).shared;
 
-          expect(shared.react.shareConfig.requiredVersion).toBe('^19.2.7');
+          expect.soft(shared.react.shareConfig.requiredVersion, protocol).toBe('^19.2.7');
         }
 
         // Real ranges — including leading spaces / compound OR — stay unchanged.

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -1,5 +1,5 @@
 import { SharedConfig, ShareStrategy } from '@module-federation/runtime/types';
-import { isRequiredVersion, type moduleFederationPlugin } from '@module-federation/sdk';
+import type { moduleFederationPlugin } from '@module-federation/sdk';
 
 export type RemoteEntryType =
   | 'var'
@@ -192,6 +192,13 @@ function inferVersionFromRequiredVersion(
   return match?.[0];
 }
 
+/** Package-manager protocols that are not semver ranges for runtime satisfy(). */
+const PACKAGE_MANAGER_PROTOCOL_RE = /^(catalog|workspace|npm|patch|file|link|portal):/;
+
+function isPackageManagerProtocolRequiredVersion(requiredVersion: string): boolean {
+  return PACKAGE_MANAGER_PROTOCOL_RE.test(requiredVersion.trim());
+}
+
 function getLitExportSubpathShares(sharedName: string): string[] {
   if (sharedName !== 'lit') return [];
 
@@ -278,13 +285,16 @@ function normalizeShareItem(
       },
     };
   }
-  // Package-manager protocols (catalog:, workspace:*, npm:pkg@range, patch:, …)
+  // Package-manager protocols (catalog:, workspace:*, npm:, patch:, file:, …)
   // are not semver ranges. Passing them through breaks runtime satisfy().
-  // Treat non-isRequiredVersion strings as unset and fall back like auto-path.
+  // Only rewrite known protocols / empty string — keep real ranges as-is
+  // (including leading spaces and compound ranges like "* || ^8.0.0").
   const userRequiredVersion = shareItem.requiredVersion;
-  const hasUsableRequiredVersion =
+  const keepUserRequiredVersion =
     userRequiredVersion === false ||
-    (typeof userRequiredVersion === 'string' && isRequiredVersion(userRequiredVersion));
+    (typeof userRequiredVersion === 'string' &&
+      userRequiredVersion.trim() !== '' &&
+      !isPackageManagerProtocolRequiredVersion(userRequiredVersion));
 
   return {
     name: key,
@@ -295,7 +305,7 @@ function normalizeShareItem(
       import: shareItem.import,
       singleton: shareItem.singleton || false,
       eager: shareItem.eager || false,
-      requiredVersion: hasUsableRequiredVersion
+      requiredVersion: keepUserRequiredVersion
         ? userRequiredVersion
         : isImportFalse || shareItem.version
           ? '*'

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -192,11 +192,11 @@ function inferVersionFromRequiredVersion(
   return match?.[0];
 }
 
-/** Package-manager protocols that are not semver ranges for runtime satisfy(). */
-const PACKAGE_MANAGER_PROTOCOL_RE = /^(catalog|workspace|npm|patch|file|link|portal):/;
+/** URI-style package specifiers are not semver ranges for runtime satisfy(). */
+const PACKAGE_SPECIFIER_PROTOCOL_RE = /^[a-z][a-z\d+.-]*:/i;
 
-function isPackageManagerProtocolRequiredVersion(requiredVersion: string): boolean {
-  return PACKAGE_MANAGER_PROTOCOL_RE.test(requiredVersion.trim());
+function isProtocolRequiredVersion(requiredVersion: string): boolean {
+  return PACKAGE_SPECIFIER_PROTOCOL_RE.test(requiredVersion.trim());
 }
 
 function getLitExportSubpathShares(sharedName: string): string[] {
@@ -294,7 +294,7 @@ function normalizeShareItem(
     userRequiredVersion === false ||
     (typeof userRequiredVersion === 'string' &&
       userRequiredVersion.trim() !== '' &&
-      !isPackageManagerProtocolRequiredVersion(userRequiredVersion));
+      !isProtocolRequiredVersion(userRequiredVersion));
 
   return {
     name: key,

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -1,5 +1,5 @@
 import { SharedConfig, ShareStrategy } from '@module-federation/runtime/types';
-import type { moduleFederationPlugin } from '@module-federation/sdk';
+import { isRequiredVersion, type moduleFederationPlugin } from '@module-federation/sdk';
 
 export type RemoteEntryType =
   | 'var'
@@ -278,6 +278,14 @@ function normalizeShareItem(
       },
     };
   }
+  // Package-manager protocols (catalog:, workspace:*, npm:pkg@range, patch:, …)
+  // are not semver ranges. Passing them through breaks runtime satisfy().
+  // Treat non-isRequiredVersion strings as unset and fall back like auto-path.
+  const userRequiredVersion = shareItem.requiredVersion;
+  const hasUsableRequiredVersion =
+    userRequiredVersion === false ||
+    (typeof userRequiredVersion === 'string' && isRequiredVersion(userRequiredVersion));
+
   return {
     name: key,
     from: '',
@@ -287,14 +295,13 @@ function normalizeShareItem(
       import: shareItem.import,
       singleton: shareItem.singleton || false,
       eager: shareItem.eager || false,
-      requiredVersion:
-        shareItem.requiredVersion !== undefined
-          ? shareItem.requiredVersion
-          : isImportFalse || shareItem.version
-            ? '*'
-            : version
-              ? `^${version}`
-              : '*',
+      requiredVersion: hasUsableRequiredVersion
+        ? userRequiredVersion
+        : isImportFalse || shareItem.version
+          ? '*'
+          : version
+            ? `^${version}`
+            : '*',
       strictVersion: !!shareItem.strictVersion,
       ...(shareItem.suppressMissingImportWarning ? { suppressMissingImportWarning: true } : {}),
       ...(treeShaking ? { treeShaking: { ...treeShaking } } : {}),


### PR DESCRIPTION
Prevents package-manager protocol specifiers from reaching runtime semver checks by falling back to the installed package version. Supports catalog, workspace, Yarn, npm, Git, and URL protocols.