### PR TITLE
fix: keep Lazy Remotes On Demand

### DIFF
--- a/integration/fixtures/loaded-first-lazy-remote-host/entry.js
+++ b/integration/fixtures/loaded-first-lazy-remote-host/entry.js
@@ -1,0 +1,4 @@
+import { REMOTE_NAME } from 'remote1/Module';
+
+document.querySelector('#app').textContent = REMOTE_NAME;
+export const loadLazy = () => import('./lazy.js');

--- a/integration/fixtures/loaded-first-lazy-remote-host/index.html
+++ b/integration/fixtures/loaded-first-lazy-remote-host/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script type="module" src="./entry.js"></script>

--- a/integration/fixtures/loaded-first-lazy-remote-host/lazy.js
+++ b/integration/fixtures/loaded-first-lazy-remote-host/lazy.js
@@ -1,0 +1,3 @@
+import { REMOTE_NAME } from 'remote2/Module';
+
+export const lazyName = REMOTE_NAME;

--- a/integration/host-build.test.ts
+++ b/integration/host-build.test.ts
@@ -84,6 +84,32 @@ describe('host build', () => {
     expect(bootstrapCode).toContain('await initHost();');
   });
 
+  it('does not preload static remote imports behind a dynamic chunk', async () => {
+    const output = await buildFixture({
+      fixture: 'loaded-first-lazy-remote-host',
+      mfOptions: {
+        ...LOADED_FIRST_STATIC_MF_OPTIONS,
+        remotes: {
+          ...LOADED_FIRST_STATIC_MF_OPTIONS.remotes,
+          remote2: {
+            name: 'remote2',
+            entry: 'http://localhost:3002/remoteEntry.js',
+            type: 'module',
+          },
+        },
+      },
+    });
+    const bootstrapAsset = output.output.find(
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
+    );
+    const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
+
+    expect(bootstrapCode).toContain('"remote1/Module"');
+    expect(bootstrapCode).not.toContain('remote2/Module');
+    expect(bootstrapCode).not.toContain('http://localhost:3002/remoteEntry.js');
+    expect(bootstrapCode).not.toMatch(/^await /m);
+  });
+
   it('prefetches module remote entries before host init for version-first', async () => {
     const output = await buildFixture({
       fixture: 'loaded-first-static-host',

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -80,7 +80,11 @@ import {
   getResolvedLocalSharedImportMapId,
   getUsedShares,
 } from '../virtualModules/virtualRemoteEntry';
-import { getStaticRemotes, getUsedRemotesMap } from '../virtualModules/virtualRemotes';
+import {
+  getPreloadRemotes,
+  getStaticRemotes,
+  getUsedRemotesMap,
+} from '../virtualModules/virtualRemotes';
 import { virtualRuntimeInitStatus } from '../virtualModules/virtualRuntimeInitStatus';
 
 const REACT_EXAMPLE_ROOT = path.join(process.cwd(), 'examples/vite-vite/vite-host');
@@ -1391,6 +1395,7 @@ describe('vite:module-federation-early-init', () => {
 
       expect([...getUsedRemotesMap(owner._options).modules]).toContain('modules/authSlice');
       expect([...getUsedRemotesMap(owner._options).modules]).not.toContain('modules/lazy');
+      expect(getPreloadRemotes(owner._options)).toEqual(new Set(['modules/authSlice']));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,11 @@ import {
   isOwnedHostAutoInitId,
   refreshHostAutoInit,
 } from './virtualModules/virtualRemoteEntry';
-import { addUsedRemote, markStaticRemote } from './virtualModules/virtualRemotes';
+import {
+  addUsedRemote,
+  markPreloadRemote,
+  markStaticRemote,
+} from './virtualModules/virtualRemotes';
 import { getRuntimeInitStatusImportId } from './virtualModules/virtualRuntimeInitStatus';
 import {
   findCurrentLoadShareForStaleOwnerId,
@@ -561,6 +565,7 @@ function registerEntryImports(
       if (remoteKey) {
         addUsedRemote(remoteKey, request, options);
         markStaticRemote(request, options);
+        markPreloadRemote(request, options);
       } else if (sharedKey && recordShared) {
         addUsedShares(request, options);
       } else if (request && !typeOnly) {

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -54,6 +54,7 @@ import {
   addUsedRemote,
   getUsedRemotesMap,
   markDynamicRemote,
+  markPreloadRemote,
   markStaticRemote,
 } from '../../virtualModules/virtualRemotes';
 import { addUsedShares } from '../../virtualModules/virtualRemoteEntry';
@@ -1346,6 +1347,7 @@ describe('pluginAddEntry', () => {
       },
     } as any;
     markStaticRemote('employees/staff', federationOptions);
+    markPreloadRemote('employees/staff', federationOptions);
     markDynamicRemote('employees/lazy', federationOptions);
 
     const plugins = addEntry({

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -24,9 +24,9 @@ import {
 } from '../utils/VirtualModule';
 import {
   addUsedRemote,
+  getPreloadRemotes,
   getRemoteRegistration,
   getRuntimeRemoteId,
-  getStaticRemotes,
   getUsedRemotesMap,
   isDynamicOnlyRemote,
 } from '../virtualModules/virtualRemotes';
@@ -419,7 +419,7 @@ const __mfCurrentScript = document.currentScript;
       normalizedOptions.shareStrategy === 'loaded-first';
     if (normalizedOptions.shareStrategy === 'loaded-first' && !isLoadedFirstClientBuild) return [];
     const remoteSources = isLoadedFirstClientBuild
-      ? Array.from(getStaticRemotes(normalizedOptions))
+      ? Array.from(getPreloadRemotes(normalizedOptions))
       : Object.entries(getUsedRemotesMap(federationOptions))
           .flatMap(([, remotes]) => Array.from(remotes))
           .filter(
@@ -490,7 +490,7 @@ const __mfCurrentScript = document.currentScript;
       (normalizedOptions.shareStrategy !== 'loaded-first' || isLoadedFirstClientBuild);
 
     const remoteSources = isLoadedFirstClientBuild
-      ? Array.from(getStaticRemotes(normalizedOptions))
+      ? Array.from(getPreloadRemotes(normalizedOptions))
       : Object.entries(getUsedRemotesMap(federationOptions))
           .flatMap(([, remotes]) => Array.from(remotes))
           .filter(

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -41,6 +41,15 @@ describe('findModuleImportSources', () => {
       `)
     ).toEqual(['remote/runtime', 'remote/lazy']);
   });
+
+  it('finds a namespace import after a comment mentioning an import', () => {
+    expect(
+      findModuleImportDescriptors(`
+        // Static import of the entry remote.
+        import * as remote from 'remote/namespace';
+      `)
+    ).toEqual([{ kind: 'static', syntax: 'import', source: 'remote/namespace', typeOnly: false }]);
+  });
 });
 
 describe('findModuleImportDescriptors', () => {

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -37,8 +37,12 @@ export function findModuleImportDescriptors(code: string): ModuleImportDescripto
   const requirePattern = /\brequire\s*\(\s*(["'])([^"']+)\1\s*\)/g;
   const sideEffectPattern = /\bimport\s*(["'])([^"']+)\1/g;
 
-  for (const match of code.matchAll(staticFromPattern)) {
-    if (!codePositions[match.index!]) continue;
+  let match: RegExpExecArray | null;
+  while ((match = staticFromPattern.exec(code))) {
+    if (!codePositions[match.index!]) {
+      staticFromPattern.lastIndex = match.index! + 1;
+      continue;
+    }
     descriptors.push({
       kind: 'static',
       syntax: 'import',

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -98,6 +98,7 @@ const usedRemotesByOptions = new WeakMap<
 >();
 const dynamicRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
 const staticRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
+const preloadRemotesByOptions = new WeakMap<NormalizedModuleFederationOptions, Set<string>>();
 const EMPTY_STATIC_REMOTES: ReadonlySet<string> = new Set();
 
 function getScopedUsedRemotesMap(options: NormalizedModuleFederationOptions) {
@@ -151,6 +152,19 @@ export function markStaticRemote(remote: string, options: NormalizedModuleFedera
 
 export function getStaticRemotes(options: NormalizedModuleFederationOptions): ReadonlySet<string> {
   return staticRemotesByOptions.get(options) ?? EMPTY_STATIC_REMOTES;
+}
+
+export function markPreloadRemote(remote: string, options: NormalizedModuleFederationOptions) {
+  let remotes = preloadRemotesByOptions.get(options);
+  if (!remotes) {
+    remotes = new Set();
+    preloadRemotesByOptions.set(options, remotes);
+  }
+  remotes.add(remote);
+}
+
+export function getPreloadRemotes(options: NormalizedModuleFederationOptions): ReadonlySet<string> {
+  return preloadRemotesByOptions.get(options) ?? EMPTY_STATIC_REMOTES;
 }
 
 export function isDynamicOnlyRemote(remote: string, options: NormalizedModuleFederationOptions) {


### PR DESCRIPTION
Closes #1161

Preload only remotes reachable through static entry imports, preserving code splitting and offline resilience.
