### PR TITLE
fix: manage shared exports and providers

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2869,6 +2869,12 @@ describe('virtualRemoteEntry', () => {
     );
     expect(preSeedBridgeCode).toContain('if (usedShare.canLiveRebind === false) return;');
     expect(preSeedBridgeCode).toContain('const provider = __mfSelectExternalSharedProvider(');
+    expect(preSeedBridgeCode).toContain(
+      'if (usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)) return;'
+    );
+    expect(preSeedBridgeCode.indexOf('shareConfig?.import === false')).toBeLessThan(
+      preSeedBridgeCode.indexOf('directFactory = await provider.get()')
+    );
     expect(preSeedBridgeCode).toContain('if (!singleton && version !== usedShare.version) return;');
     expect(preSeedBridgeCode).toContain("!(provider.loaded && typeof provider.get === 'function')");
     expect(preSeedBridgeCode).toContain('directFactory = await provider.get();');
@@ -2972,6 +2978,10 @@ describe('virtualRemoteEntry', () => {
     );
     expect(bridgeHelperCode).not.toContain('if (!usedShare.shareConfig?.singleton) return;');
     expect(bridgeHelperCode).toContain('if (usedShare.canLiveRebind === false) return;');
+    expect(bridgeHelperCode).toContain(
+      'if (usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)) return;'
+    );
+    expect(bridgeHelperCode.indexOf('shareConfig?.import === false')).toBeLessThan(providerLoad);
     expect(bridgeHelperCode.indexOf('if (usedShare.canLiveRebind === false) return;')).toBeLessThan(
       providerLoad
     );
@@ -3004,6 +3014,13 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('expectedFrom');
     expect(code).not.toContain('__mfModuleCache.share[usedCacheKey] = normalized;');
     expect(code.match(/runtimeResolveShareHook/g)).toHaveLength(2);
+    expect(code).toContain('if (__mfMatchesSharedProvider(provider, share)) return;');
+    expect(code.indexOf('if (__mfMatchesSharedProvider(provider, share)) return;')).toBeLessThan(
+      code.indexOf(
+        'const loadedShare = await __mfLoadPinnedRuntimeShare(',
+        code.indexOf('const __mfResolveImportFalseShared')
+      )
+    );
   });
 
   it('materializes only an originally passed root provider replaced by a later instance', async () => {

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -529,6 +529,7 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/relational-multi-declarator.ts') ||
       filePath.endsWith('/repo/packages/multi-declarator.js') ||
       filePath.endsWith('/repo/packages/postfix-multi-declarator.js') ||
+      filePath.endsWith('/repo/packages/semicolonless-jsx.jsx') ||
       filePath.endsWith('/repo/packages/string-export-list.js') ||
       filePath.endsWith('/repo/packages/trailing-comma-export-list.js') ||
       filePath.endsWith('/repo/packages/default-reexport-list.js') ||
@@ -632,6 +633,20 @@ export const assertedRegistry = <Map<object, any>>new Map();`;
     }
     if (filePath.endsWith('/repo/packages/postfix-multi-declarator.js')) {
       return 'export let first = count++ / total, second = /x/;';
+    }
+    if (filePath.endsWith('/repo/packages/semicolonless-jsx.jsx')) {
+      return `export const a = 1, b = 2
+export const withTheme = Component => props => <Component {...props} theme="light" />
+
+export const Badge = () => (
+  <span>
+    ok
+  </span>
+)
+
+export const Inline = <span>
+  ok
+</span>, later = 3`;
     }
     if (filePath.endsWith('/repo/packages/string-export-list.js')) {
       return 'const foo = 1; export { foo as "a-b", foo as valid };';
@@ -2059,6 +2074,35 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain(
       'export * from "/repo/packages/postfix-multi-declarator.js"'
     );
+  });
+
+  it('keeps semicolonless JSX exports live', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/semicolonless-jsx.jsx',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expectLiveSingletonProxy(generatedCode, pkg, [
+      'a',
+      'withTheme',
+      'Badge',
+      'Inline',
+      'b',
+      'later',
+    ]);
   });
 
   it('does not treat string-named export lists as complete', () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1659,6 +1659,7 @@ export function generateRemoteEntry(
         );
         const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
         if (!providerEntry) return;
+        if (usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)) return;
         const { version } = providerEntry;
         if (!singleton && version !== usedShare.version) return;
         if (
@@ -1780,6 +1781,7 @@ export function generateRemoteEntry(
           scopeRootProvider: undefined
         };
         if (usedShare.canLiveRebind === false) return;
+        if (usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)) return;
         // Preserve a singleton already selected by another container. The bridge may
         // only replace the provisional local fallback seeded by this container.
         if (cachedShare !== undefined && cachedShareOwner !== mfName) return;
@@ -1948,6 +1950,7 @@ export function generateRemoteEntry(
       ) || share;
       const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
       if (!providerEntry) return;
+      if (__mfMatchesSharedProvider(provider, share)) return;
       const { version } = providerEntry;
       const currentProvider = versionMap?.[version];
       const loadedShare = await __mfLoadPinnedRuntimeShare(

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -434,6 +434,16 @@ function getAdditionalTopLevelDeclaratorNames(
       canStartRegex = false;
       continue;
     }
+    if (char === '<' && source[index + 1] === '/') {
+      const jsxClosingTag = source
+        .slice(index)
+        .match(/^<\/\s*(?:[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}.:-]*\s*)?>/u);
+      if (jsxClosingTag) {
+        index += jsxClosingTag[0].length - 1;
+        canStartRegex = false;
+        continue;
+      }
+    }
     if (char === '/' && source[index + 1] === '/') {
       index = source.indexOf('\n', index + 2);
       if (index === -1) return names;


### PR DESCRIPTION
Closes #1164

Handles semicolonless JSX exports and skips unresolved consume-only stubs.