### PR TITLE
fix: clean up settled pending shared loads

### DIFF
--- a/integration/shared-cache-deferred-exports.test.ts
+++ b/integration/shared-cache-deferred-exports.test.ts
@@ -1,7 +1,16 @@
 import { resolve } from 'path';
 import { describe, expect, it } from 'vitest';
 import { parseAst } from 'rollup/parseAst';
-import type { ModuleFederationOptions } from '../src/utils/normalizeModuleFederationOptions';
+import {
+  normalizeModuleFederationOptions,
+  type ModuleFederationOptions,
+} from '../src/utils/normalizeModuleFederationOptions';
+import VirtualModule from '../src/utils/VirtualModule';
+import { generateRemoteEntry } from '../src/virtualModules/virtualRemoteEntry';
+import {
+  getLoadShareModulePath,
+  writeLoadShareModule,
+} from '../src/virtualModules/virtualShared_preBuild';
 import { isRollupChunk } from './helpers/assertions';
 import { buildFixture, FIXTURES } from './helpers/build';
 import { findChunk, getAllChunkCode, getHtmlAsset } from './helpers/matchers';
@@ -20,6 +29,47 @@ import { findChunk, getAllChunkCode, getHtmlAsset } from './helpers/matchers';
  */
 
 const SHARED_DEP = 'mock-shared-dep';
+
+function dataUrl(source: string): string {
+  return `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`;
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+type GeneratedRemoteModule = {
+  get(moduleName: string): Promise<() => unknown>;
+};
+
+async function importTestRemote(exposesSource: string): Promise<GeneratedRemoteModule> {
+  const remoteOptions = normalizeModuleFederationOptions({
+    name: uniqueName('pending-share-remote'),
+    exposes: { './Button': './Button.js' },
+    dts: false,
+  });
+  const remoteGenerated = generateRemoteEntry(remoteOptions, undefined, 'build');
+  const runtimeStub = dataUrl(
+    'export function init() {}\nexport function loadRemote() { return Promise.resolve(); }'
+  );
+  const exposesImport = remoteGenerated.match(/import\("(virtual:mf-exposes:[^"]+)"\)/)?.[1];
+  if (!exposesImport) throw new Error('generated remote entry did not import its exposes module');
+
+  return (await import(
+    dataUrl(
+      remoteGenerated
+        .replace('from "@module-federation/runtime"', `from ${JSON.stringify(runtimeStub)}`)
+        .replace(
+          `import(${JSON.stringify(exposesImport)})`,
+          `import(${JSON.stringify(dataUrl(exposesSource))})`
+        )
+    )
+  )) as GeneratedRemoteModule;
+}
 
 const REMOTE_MF_OPTIONS = {
   name: 'remoteApp',
@@ -161,7 +211,7 @@ describe('remote loadShare (import: false — host-provided)', () => {
     const elseMatch = code.match(/else\s*{?\s*__mfApplyHostProvidedExports\(exportModule\)/);
     expect(elseMatch).not.toBeNull();
 
-    // Must NOT push to pendingShareLoads in the else branch
+    // Must NOT register a pending share load in the else branch
     const elseIndex = code.lastIndexOf('else');
     const afterElse = code.slice(elseIndex, elseIndex + 200);
     expect(afterElse).not.toContain('pendingShareLoads');
@@ -177,20 +227,323 @@ describe('remote loadShare (import: false — host-provided)', () => {
     // pendingShareLoads. The host uses `if (__mfModuleCache.pendingShareLoads)`
     // guard so remotes (which never set pendingShareLoads) don't crash.
     const bootstrapAsset = output.output.find(
-      (item) =>
-        item.type === 'asset' &&
-        item.fileName.includes('mf-entry-bootstrap')
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
     );
     if (bootstrapAsset) {
-      const bootstrapCode = (
-        bootstrapAsset as unknown as { source: string }
-      ).source;
+      const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;
       // Must be guarded with if-check, not bare await
       if (bootstrapCode.includes('pendingShareLoads')) {
-        expect(bootstrapCode).toMatch(
-          /if\s*\(\s*__mfModuleCache\.pendingShareLoads\s*\)/
-        );
+        expect(bootstrapCode).toMatch(/if\s*\(\s*__mfModuleCache\.pendingShareLoads\s*\)/);
       }
+    }
+  });
+});
+
+describe('pendingShareLoads lifecycle', () => {
+  it('cleans a rejected import:false load and lets a later remote get recover', async () => {
+    const pkg = uniqueName('pending-import-false-share');
+    const options = normalizeModuleFederationOptions({
+      name: uniqueName('pending-import-false-owner'),
+      shared: { [pkg]: { import: false } },
+      dts: false,
+    });
+    const loadShareId = getLoadShareModulePath(pkg, false, options);
+    writeLoadShareModule(pkg, options.shared[pkg], 'build', false, options);
+    const generated = VirtualModule.findById(loadShareId)?.code;
+    expect(generated).toBeTruthy();
+    if (!generated) return;
+
+    const initKeyLiteral = generated.match(/const __mfPromiseGlobalKey = ([^;]+);/)?.[1];
+    expect(initKeyLiteral).toBeTruthy();
+    if (!initKeyLiteral) return;
+    const initStateKey = JSON.parse(initKeyLiteral) as string;
+    const exposeCallsKey = uniqueName('pending-import-false-expose-calls');
+    const exposesReadyKey = uniqueName('pending-import-false-exposes-ready');
+
+    delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+    try {
+      await import(dataUrl(`${generated}\n// import:false rejection regression`));
+      const moduleCache = (globalThis as any).__mf_module_cache__;
+      const initState = (globalThis as any)[initStateKey];
+      expect(moduleCache.pendingShareLoads).toHaveLength(1);
+
+      const remoteModule = await importTestRemote(`
+        const state = globalThis[${JSON.stringify(exposesReadyKey)}] ||= {};
+        state.promise ||= new Promise((resolve) => { state.resolve = resolve; });
+        await state.promise;
+        export default {
+          "./Button": () => {
+            globalThis[${JSON.stringify(exposeCallsKey)}] =
+              (globalThis[${JSON.stringify(exposeCallsKey)}] || 0) + 1;
+            return Promise.resolve({ recovered: true });
+          }
+        };
+      `);
+      const currentGet = remoteModule.get('./Button');
+      let currentGetSettled = false;
+      void currentGet.then(
+        () => {
+          currentGetSettled = true;
+        },
+        () => {
+          currentGetSettled = true;
+        }
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const exposesState = (globalThis as any)[exposesReadyKey];
+      expect(exposesState?.resolve).toEqual(expect.any(Function));
+      exposesState.resolve();
+      await flushMicrotasks();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(currentGetSettled).toBe(false);
+
+      const currentWaiter = Promise.all(moduleCache.pendingShareLoads);
+      initState.initResolve({});
+      const expectedError = `Shared module ${pkg} was imported before federation bootstrap finished`;
+      await expect(currentWaiter).rejects.toThrow(expectedError);
+      await expect(currentGet).rejects.toThrow(expectedError);
+      expect((globalThis as any)[exposeCallsKey] || 0).toBe(0);
+      await flushMicrotasks();
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+
+      moduleCache.share[`default:${pkg}`] = { default: { recovered: true } };
+      const factory = await remoteModule.get('./Button');
+      expect(factory()).toEqual({ recovered: true });
+      expect((globalThis as any)[exposeCallsKey]).toBe(1);
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+      delete (globalThis as Record<string, unknown>)[initStateKey];
+      delete (globalThis as Record<string, unknown>)[exposesReadyKey];
+      delete (globalThis as Record<string, unknown>)[exposeCallsKey];
+    }
+  });
+
+  it('cleans a failed lazy import before a successful retry', async () => {
+    const pkg = SHARED_DEP;
+    const options = normalizeModuleFederationOptions({
+      name: uniqueName('pending-lazy-owner'),
+      exposes: { './Button': './Button.js' },
+      shared: {
+        [pkg]: {
+          singleton: true,
+          treeShaking: { mode: 'runtime-infer', usedExports: ['value1'] },
+        },
+      },
+      dts: false,
+    });
+    const loadShareId = getLoadShareModulePath(pkg, false, options);
+    writeLoadShareModule(pkg, options.shared[pkg], 'build', false, options);
+    const generated = VirtualModule.findById(loadShareId)?.code;
+    expect(generated).toBeTruthy();
+    if (!generated) return;
+
+    const initKeyLiteral = generated.match(/const __mfPromiseGlobalKey = ([^;]+);/)?.[1];
+    const localImport = generated.match(/return import\("([^"]+)"\)/)?.[1];
+    expect(initKeyLiteral).toBeTruthy();
+    expect(localImport).toBeTruthy();
+    if (!initKeyLiteral || !localImport) return;
+    const initStateKey = JSON.parse(initKeyLiteral) as string;
+
+    delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+    try {
+      const failedChunk = dataUrl("throw new Error('simulated shared chunk failure')");
+      const firstEvaluation = generated
+        .replace(/import\.meta\.env\.SSR/g, 'false')
+        .replace(
+          `import(${JSON.stringify(localImport)})`,
+          `import(${JSON.stringify(failedChunk)})`
+        );
+      await import(dataUrl(`${firstEvaluation}\n// failed lazy import regression`));
+      const moduleCache = (globalThis as any).__mf_module_cache__;
+      const initState = (globalThis as any)[initStateKey];
+      expect(moduleCache.pendingShareLoads).toHaveLength(1);
+
+      const currentWaiter = Promise.all(moduleCache.pendingShareLoads);
+      initState.initResolve({});
+      await expect(currentWaiter).rejects.toThrow('simulated shared chunk failure');
+      await flushMicrotasks();
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+
+      const recoveredChunk = dataUrl(
+        'export const value1 = "recovered"; export default { value1: "recovered" };'
+      );
+      const retryEvaluation = generated
+        .replace(/import\.meta\.env\.SSR/g, 'false')
+        .replace(
+          `import(${JSON.stringify(localImport)})`,
+          `import(${JSON.stringify(recoveredChunk)})`
+        )
+        .concat('\n// successful lazy import retry');
+      await import(dataUrl(retryEvaluation));
+      await flushMicrotasks();
+
+      expect(moduleCache.share[`default:${pkg}`]).toMatchObject({
+        default: { value1: 'recovered' },
+      });
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+      delete (globalThis as Record<string, unknown>)[initStateKey];
+    }
+  });
+
+  it('lets a later remote get reach the expose factory after a failed lazy retry', async () => {
+    const pkg = SHARED_DEP;
+    const options = normalizeModuleFederationOptions({
+      name: uniqueName('pending-lazy-remote-owner'),
+      exposes: { './Button': './Button.js' },
+      shared: {
+        [pkg]: {
+          singleton: true,
+          treeShaking: { mode: 'runtime-infer', usedExports: ['value1'] },
+        },
+      },
+      dts: false,
+    });
+    const loadShareId = getLoadShareModulePath(pkg, false, options);
+    writeLoadShareModule(pkg, options.shared[pkg], 'build', false, options);
+    const generated = VirtualModule.findById(loadShareId)?.code;
+    expect(generated).toBeTruthy();
+    if (!generated) return;
+
+    const initKeyLiteral = generated.match(/const __mfPromiseGlobalKey = ([^;]+);/)?.[1];
+    const localImport = generated.match(/return import\("([^"]+)"\)/)?.[1];
+    expect(initKeyLiteral).toBeTruthy();
+    expect(localImport).toBeTruthy();
+    if (!initKeyLiteral || !localImport) return;
+    const initStateKey = JSON.parse(initKeyLiteral) as string;
+    const exposeCallsKey = uniqueName('pending-lazy-expose-calls');
+    const exposesReadyKey = uniqueName('pending-lazy-exposes-ready');
+
+    delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+    try {
+      const failedChunk = dataUrl("throw new Error('simulated lazy remote failure')");
+      const firstEvaluation = generated
+        .replace(/import\.meta\.env\.SSR/g, 'false')
+        .replace(
+          `import(${JSON.stringify(localImport)})`,
+          `import(${JSON.stringify(failedChunk)})`
+        );
+      await import(dataUrl(`${firstEvaluation}\n// lazy remote get failure regression`));
+
+      const moduleCache = (globalThis as any).__mf_module_cache__;
+      const initState = (globalThis as any)[initStateKey];
+      expect(moduleCache.pendingShareLoads).toHaveLength(1);
+
+      const remoteModule = await importTestRemote(`
+        const state = globalThis[${JSON.stringify(exposesReadyKey)}] ||= {};
+        state.promise ||= new Promise((resolve) => { state.resolve = resolve; });
+        await state.promise;
+        export default {
+          "./Button": () => {
+            globalThis[${JSON.stringify(exposeCallsKey)}] =
+              (globalThis[${JSON.stringify(exposeCallsKey)}] || 0) + 1;
+            return Promise.resolve({ recovered: true });
+          }
+        };
+      `);
+      const firstGet = remoteModule.get('./Button');
+      let firstGetSettled = false;
+      void firstGet.then(
+        () => {
+          firstGetSettled = true;
+        },
+        () => {
+          firstGetSettled = true;
+        }
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const exposesState = (globalThis as any)[exposesReadyKey];
+      expect(exposesState?.resolve).toEqual(expect.any(Function));
+      exposesState.resolve();
+      await flushMicrotasks();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(firstGetSettled).toBe(false);
+
+      const currentWaiter = Promise.all(moduleCache.pendingShareLoads);
+      initState.initResolve({});
+      await expect(currentWaiter).rejects.toThrow('simulated lazy remote failure');
+      await expect(firstGet).rejects.toThrow('simulated lazy remote failure');
+      expect((globalThis as any)[exposeCallsKey] || 0).toBe(0);
+      await flushMicrotasks();
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+
+      const recoveredChunk = dataUrl(
+        'export const value1 = "recovered"; export default { value1: "recovered" };'
+      );
+      const retryEvaluation = generated
+        .replace(/import\.meta\.env\.SSR/g, 'false')
+        .replace(
+          `import(${JSON.stringify(localImport)})`,
+          `import(${JSON.stringify(recoveredChunk)})`
+        )
+        .concat('\n// successful lazy remote get retry');
+      await import(dataUrl(retryEvaluation));
+      await flushMicrotasks();
+
+      const factory = await remoteModule.get('./Button');
+      expect(factory()).toEqual({ recovered: true });
+      expect((globalThis as any)[exposeCallsKey]).toBe(1);
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+      delete (globalThis as Record<string, unknown>)[initStateKey];
+      delete (globalThis as Record<string, unknown>)[exposesReadyKey];
+      delete (globalThis as Record<string, unknown>)[exposeCallsKey];
+    }
+  });
+
+  it('cleans a rejected react-server scoped shared load in its separate cache', async () => {
+    const pkg = uniqueName('pending-react-server-share');
+    const exportConditions = ['react-server', 'node', 'import', 'module', 'default'];
+    const options = normalizeModuleFederationOptions({
+      name: uniqueName('pending-react-server-owner'),
+      shared: {
+        [pkg]: {
+          import: false,
+          shareScope: 'react-server',
+        },
+      },
+      dts: false,
+    });
+    const loadShareId = getLoadShareModulePath(pkg, false, options);
+    writeLoadShareModule(pkg, options.shared[pkg], 'build', false, options, exportConditions);
+    const generated = VirtualModule.findById(loadShareId)?.code;
+    expect(generated).toBeTruthy();
+    if (!generated) return;
+
+    expect(generated).toContain('__mf_module_cache_react_server__');
+    expect(generated).toContain(`"canonical":"react-server:${pkg}"`);
+    const initKeyLiteral = generated.match(/const __mfPromiseGlobalKey = ([^;]+);/)?.[1];
+    expect(initKeyLiteral).toBeTruthy();
+    if (!initKeyLiteral) return;
+    const initStateKey = JSON.parse(initKeyLiteral) as string;
+
+    delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+    delete (globalThis as Record<string, unknown>).__mf_module_cache_react_server__;
+    try {
+      await import(dataUrl(`${generated}\n// react-server pending load regression`));
+      const moduleCache = (globalThis as any).__mf_module_cache_react_server__;
+      const initState = (globalThis as any)[initStateKey];
+      expect(options.shared[pkg].scope).toBe('react-server');
+      expect((globalThis as any).__mf_module_cache__).toBeUndefined();
+      expect(moduleCache.share[`default:${pkg}`]).toBeUndefined();
+      expect(moduleCache.pendingShareLoads).toHaveLength(1);
+
+      const currentWaiter = Promise.all(moduleCache.pendingShareLoads);
+      initState.initResolve({});
+      await expect(currentWaiter).rejects.toThrow(
+        `Shared module ${pkg} was imported before federation bootstrap finished`
+      );
+      await flushMicrotasks();
+      expect(moduleCache.pendingShareLoads).toEqual([]);
+      expect(moduleCache.share[`default:${pkg}`]).toBeUndefined();
+      expect(moduleCache.share[`react-server:${pkg}`]).toBeUndefined();
+    } finally {
+      delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+      delete (globalThis as Record<string, unknown>).__mf_module_cache_react_server__;
+      delete (globalThis as Record<string, unknown>)[initStateKey];
     }
   });
 });
@@ -211,16 +564,14 @@ describe('host loadShare (import: true — workspace singleton)', () => {
     expect(loadShareChunk).toBeDefined();
     const code = (loadShareChunk as { code: string }).code;
 
-    // Cache-miss branch (if) must push to pendingShareLoads
+    // Cache-miss branch (if) must register with the pending-share tracker
     expect(code).toContain('pendingShareLoads');
     expect(code).toContain('initPromise');
 
-    // The if branch must push a promise to pendingShareLoads
-    // Structure: if (exportModule === void 0) (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(...))
-    const ifMatch = code.match(
-      /if\s*\(exportModule\s*===\s*void 0\)\s*\(__mfModuleCache\.pendingShareLoads\s*\||=\s*\[\]\)\.push\(/
-    );
-    expect(ifMatch).not.toBeNull();
+    // The if branch must register a promise with the tracker.
+    // Structure: if (exportModule === void 0) __mfTrackPendingShareLoad(initPromise.then(...))
+    expect(code).toContain('__mfTrackPendingShareLoad(initPromise.then');
+    expect(code).not.toContain('(__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then');
   });
 
   it('applies lazy share exports synchronously when cache is populated', async () => {
@@ -245,7 +596,7 @@ describe('host loadShare (import: true — workspace singleton)', () => {
     const elseMatch = code.match(/else\s*{?\s*__mfApplyLazyShareExports\(exportModule\)/);
     expect(elseMatch).not.toBeNull();
 
-    // Must NOT push to pendingShareLoads in the else branch
+    // Must NOT register a pending share load in the else branch
     const elseIndex = code.lastIndexOf('else');
     const afterElse = code.slice(elseIndex, elseIndex + 200);
     expect(afterElse).not.toContain('pendingShareLoads');
@@ -262,9 +613,7 @@ describe('no top-level awaits in generated code', () => {
     });
 
     const bootstrapAsset = output.output.find(
-      (item) =>
-        item.type === 'asset' &&
-        item.fileName.includes('mf-entry-bootstrap')
+      (item) => item.type === 'asset' && item.fileName.includes('mf-entry-bootstrap')
     );
     expect(bootstrapAsset).toBeDefined();
     const bootstrapCode = (bootstrapAsset as unknown as { source: string }).source;

--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -496,9 +496,9 @@ describe('pluginAddEntry', () => {
 
     const bootstrap = result?.code ?? '';
     expect(bootstrap.indexOf('await initHost();')).toBeLessThan(
-      bootstrap.indexOf('__mfModuleCache.pendingShareLoads')
+      bootstrap.indexOf('if (__mfModuleCache.pendingShareLoads)')
     );
-    expect(bootstrap.indexOf('__mfModuleCache.pendingShareLoads')).toBeLessThan(
+    expect(bootstrap.indexOf('if (__mfModuleCache.pendingShareLoads)')).toBeLessThan(
       bootstrap.indexOf('.then(() => import(')
     );
   });

--- a/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
+++ b/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
@@ -74,6 +74,86 @@ describe('virtualRuntimeInitStatus', () => {
     delete (globalThis as any)['__mf_init__virtual:owner__'];
   });
 
+  it('cleans settled loads in default and react-server caches without changing the original promises', async () => {
+    const { getRuntimeModuleCacheBootstrapCode } = await import('../virtualRuntimeInitStatus');
+    const defaultTracker = runCode<(promise: Promise<unknown>) => Promise<unknown>>(
+      getRuntimeModuleCacheBootstrapCode(),
+      'return __mfTrackPendingShareLoad;'
+    );
+    const reactServerTracker = runCode<(promise: Promise<unknown>) => Promise<unknown>>(
+      getRuntimeModuleCacheBootstrapCode(['react-server', 'node']),
+      'return __mfTrackPendingShareLoad;'
+    );
+    const defaultCache = (globalThis as any).__mf_module_cache__;
+    const reactServerCache = (globalThis as any).__mf_module_cache_react_server__;
+    let rejectFirst!: (error: Error) => void;
+    let resolveSecond!: () => void;
+    let resolveReactServer!: () => void;
+    const first = new Promise<never>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    const second = new Promise<void>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const reactServer = new Promise<void>((resolve) => {
+      resolveReactServer = resolve;
+    });
+
+    expect(defaultCache.pendingShareLoads).toBeUndefined();
+    expect(reactServerCache.pendingShareLoads).toBeUndefined();
+    expect(defaultTracker(first)).toBe(first);
+    expect(defaultTracker(second)).toBe(second);
+    expect(reactServerTracker(reactServer)).toBe(reactServer);
+    expect(defaultCache.pendingShareLoads).toEqual([first, second]);
+    expect(reactServerCache.pendingShareLoads).toEqual([reactServer]);
+
+    const defaultWaiter = Promise.all(defaultCache.pendingShareLoads);
+    const reactServerWaiter = Promise.all(reactServerCache.pendingShareLoads);
+    const firstError = new Error('default shared load failed');
+    rejectFirst(firstError);
+    await expect(defaultWaiter).rejects.toBe(firstError);
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    expect(defaultCache.pendingShareLoads).toEqual([second]);
+    expect(reactServerCache.pendingShareLoads).toEqual([reactServer]);
+
+    resolveSecond();
+    resolveReactServer();
+    await expect(second).resolves.toBeUndefined();
+    await expect(reactServerWaiter).resolves.toEqual([undefined]);
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    expect(defaultCache.pendingShareLoads).toEqual([]);
+    expect(reactServerCache.pendingShareLoads).toEqual([]);
+  });
+
+  it('does not let rejected-load cleanup remove a newer retry in the same cache', async () => {
+    const { getRuntimeModuleCacheBootstrapCode } = await import('../virtualRuntimeInitStatus');
+    const tracker = runCode<(promise: Promise<unknown>) => Promise<unknown>>(
+      getRuntimeModuleCacheBootstrapCode(),
+      'return __mfTrackPendingShareLoad;'
+    );
+    const cache = (globalThis as any).__mf_module_cache__;
+    let rejectFirst!: (error: Error) => void;
+    let resolveRetry!: () => void;
+    const first = new Promise<never>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    const retry = new Promise<void>((resolve) => {
+      resolveRetry = resolve;
+    });
+
+    tracker(first);
+    tracker(retry);
+    rejectFirst(new Error('retryable shared load failed'));
+    await expect(first).rejects.toThrow('retryable shared load failed');
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    expect(cache.pendingShareLoads).toEqual([retry]);
+    resolveRetry();
+    await expect(retry).resolves.toBeUndefined();
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    expect(cache.pendingShareLoads).toEqual([]);
+  });
+
   it('aliases default-scoped and legacy share cache keys both ways', async () => {
     const { getRuntimeModuleCacheBootstrapCode } = await import('../virtualRuntimeInitStatus');
     const legacyReact = { source: 'legacy-react' };

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2357,7 +2357,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('let current = __mfLocalShare;');
     expect(generatedCode).toContain('export * from "/missing/virtual-shared-module.js"');
     expect(generatedCode).not.toContain('__mfApplyLazyShareExports');
-    expect(generatedCode).not.toContain('pendingShareLoads');
+    expect(generatedCode).not.toContain('__mfTrackPendingShareLoad(');
   });
 
   it('statically imports unknown workspace exports in serve mode', () => {
@@ -4132,7 +4132,7 @@ describe('writePreBuildLibPath', () => {
     expect(afterElse).not.toContain('pendingShareLoads');
   });
 
-  it('pushes lazy share load to pendingShareLoads in client-side undefined branch (build mode)', () => {
+  it('tracks lazy share load in client-side undefined branch (build mode)', () => {
     const pkg = 'workspace-shared-lib';
     const mockShareItem: ShareItem = {
       name: pkg,
@@ -4158,8 +4158,10 @@ describe('writePreBuildLibPath', () => {
     expect(generatedCode).toContain('if (exportModule !== undefined)');
     expect(generatedCode).toContain('return import(');
 
-    // Must use the ||= pattern for lazy initialization
-    expect(generatedCode).toContain('||= []');
+    expect(generatedCode).toContain('__mfTrackPendingShareLoad(initPromise.then');
+    expect(generatedCode).not.toContain(
+      '(__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then'
+    );
   });
 
   it('does not use bare initPromise.then without pendingShareLoads in build mode', () => {
@@ -4180,13 +4182,16 @@ describe('writePreBuildLibPath', () => {
 
     const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
 
-    // Every initPromise.then() must be wrapped in a pendingShareLoads push.
-    const pushCount = (generatedCode.match(/pendingShareLoads/g) || []).length;
+    // Every initPromise.then() must be wrapped in the pending-share tracker.
+    const trackerCount = (generatedCode.match(/__mfTrackPendingShareLoad/g) || []).length;
     const thenCount = (generatedCode.match(/initPromise\.then/g) || []).length;
-    expect(pushCount).toBeGreaterThanOrEqual(thenCount);
+    expect(trackerCount).toBeGreaterThanOrEqual(thenCount);
+    expect(generatedCode).not.toContain(
+      '(__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then'
+    );
   });
 
-  it('pushes host-provided share load to pendingShareLoads in else branch (import: false)', () => {
+  it('tracks host-provided share load in else branch (import: false)', () => {
     const pkg = 'host-only-dep';
     const mockShareItem: ShareItem = {
       name: pkg,
@@ -4210,6 +4215,44 @@ describe('writePreBuildLibPath', () => {
     expect(generatedCode).toContain('__mfApplyHostProvidedExports');
     expect(generatedCode).toContain('__mfModuleCache.share');
     expect(generatedCode).toContain('initPromise.then');
+    expect(generatedCode).toContain('__mfTrackPendingShareLoad(initPromise.then');
+    expect(generatedCode).not.toContain(
+      '(__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then'
+    );
+  });
+
+  it('tracks react-server shared loads in the react-server module cache', () => {
+    const pkg = 'react-server-host-only-dep';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: undefined,
+      shareConfig: {
+        import: false,
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '*',
+      },
+      scope: 'react-server',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false, undefined, [
+      'react-server',
+      'node',
+      'import',
+      'module',
+      'default',
+    ]);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain(
+      'const __mfCacheGlobalKey = "__mf_module_cache_react_server__";'
+    );
+    expect(generatedCode).toContain('__mfTrackPendingShareLoad(initPromise.then');
+    expect(generatedCode).not.toContain(
+      '(__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then'
+    );
   });
 });
 

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -203,6 +203,16 @@ globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
 globalThis[__mfCacheGlobalKey].share ||= {};
 globalThis[__mfCacheGlobalKey].remote ||= {};
 const __mfModuleCache = globalThis[__mfCacheGlobalKey];
+const __mfTrackPendingShareLoad = (promise) => {
+  const pendingShareLoads = (__mfModuleCache.pendingShareLoads ||= []);
+  pendingShareLoads.push(promise);
+  const cleanup = () => {
+    const index = pendingShareLoads.indexOf(promise);
+    if (index !== -1) pendingShareLoads.splice(index, 1);
+  };
+  void promise.then(cleanup, cleanup);
+  return promise;
+};
 for (const __mfShareKey of Object.keys(__mfModuleCache.share)) {
   if (__mfShareKey.startsWith("default:")) {
     const __mfLegacyShareKey = __mfShareKey.slice("default:".length);

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1751,7 +1751,7 @@ function generateLazyWorkspaceSingletonExports(
       if (import.meta.env.SSR${serveLocalFallback ? " || (import.meta.env.DEV && typeof __mfLocalShare !== 'undefined')" : ''}) {
         ${applyLocalFallback}
       } else {
-        (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() => {
+        __mfTrackPendingShareLoad(initPromise.then(() => {
           exportModule = ${getSharedCacheReadExpression(cacheDescriptor, treeShakingConsumer)};
           if (exportModule !== undefined) {
             __mfApplyLazyShareExports(exportModule);
@@ -1829,7 +1829,7 @@ function generateDeferredHostProvidedExports(
     };
     let exportModule = ${getSharedCacheReadExpression(cacheDescriptor, treeShakingConsumer)};
     if (exportModule === undefined) {
-      (__mfModuleCache.pendingShareLoads ||= []).push(initPromise.then(() => {
+      __mfTrackPendingShareLoad(initPromise.then(() => {
         exportModule = ${getSharedCacheReadExpression(cacheDescriptor, treeShakingConsumer)};
         if (exportModule === undefined) {
           throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.");


### PR DESCRIPTION
## Summary

This change prevents a rejected lazy shared dependency promise from remaining in the generated runtime's global `pendingShareLoads` array and poisoning later `remoteEntry.get()` calls.

The generated runtime now tracks each pending shared-load promise and removes that exact promise when it settles. The original promise is returned unchanged, so callers that are already waiting on the `Promise.all()` barrier still receive the original rejection. Once the failed promise has settled and been removed, a later retry can proceed normally.

Both the default module cache and the `react-server` module cache use the same cleanup behavior.

## Problem

`pendingShareLoads` was append-only. When a lazy shared import failed, its rejected promise stayed in the cache. Subsequent `remoteEntry.get()` and plugin entry calls awaited the same array and repeatedly observed the historical rejection, even after the shared cache had been recovered or re-evaluated. As a result, the expose factory was never called on the retry.

The `import: false` host-provided path could leave the same stale rejection behind.

## Changes

- Add the internal generated-code helper `__mfTrackPendingShareLoad` in `virtualRuntimeInitStatus.ts`.
  - Lazily creates `pendingShareLoads` only on first registration.
  - Adds and returns the original promise.
  - Removes only the matching promise by identity after resolve or reject.
  - Uses `then(cleanup, cleanup)` without consuming the rejection.
  - Is emitted separately for the default and `react-server` module caches.
- Replace the two raw `pendingShareLoads.push(...)` calls in `virtualShared_preBuild.ts`:
  - lazy local shared imports;
  - `import: false` host-provided shared imports.
- Preserve the existing `Promise.all()` barrier semantics in `virtualRemoteEntry.ts` and `pluginAddEntry.ts`.
- Add unit and integration coverage for cleanup, retry behavior, overlapping promises, `import: false`, permanent lazy `remote.get()` recovery, and `react-server` cache isolation.

## Regression coverage

- A failed first shared import rejects the current `remote.get()` and does not call the expose factory.
- After the failed promise is cleaned up and the shared cache is restored or the generated module is re-evaluated, the next `remote.get()` succeeds and calls the factory.
- Settling one of multiple pending promises does not remove another promise.
- The default and `react-server` pending-load arrays remain independent.
- The `import: false` path receives the same cleanup and retry behavior.