### PR TITLE
chore(husky): migrate hooks to v9 setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx oxfmt --check src
 pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib/**/*"
   ],
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "fmt": "oxfmt src",
     "fmt.check": "oxfmt --check src",
     "dev": "tsdown --watch",


### PR DESCRIPTION
## Summary

- Updated the Husky prepare script for v9.
- Removed deprecated hook wrapper lines.

## References

- [Husky v9.0.1 migration guide](https://github.com/typicode/husky/releases/tag/v9.0.1)


<img width="365" height="79" alt="husky" src="https://github.com/user-attachments/assets/befba8ce-fab5-4386-846f-3a0e08a8b387" />
