### PR TITLE
fix: fall back to root index.html for dev entry injection

### DIFF
--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer as createNetServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import type { InlineConfig } from 'vite';
 import { createServer as createViteServer, version as viteVersion } from 'vite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { federation } from '../src';
@@ -130,13 +131,15 @@ async function createDevServer(
   name: string,
   options: Parameters<typeof federation>[0],
   root = fixtureRoot,
-  logLevel: 'silent' | 'info' = 'silent'
+  logLevel: 'silent' | 'info' = 'silent',
+  build?: InlineConfig['build']
 ): Promise<{ origin: string }> {
   const cacheDir = await mkdtemp(path.join(tmpdir(), `mf-vite-${name}-`));
   const viteServer = await createViteServer({
     root,
     cacheDir,
     logLevel,
+    build,
     plugins: [federation(options)],
     server: {
       cors: true,
@@ -377,6 +380,64 @@ document.body.textContent = window.__issue1104Result;
     expect(pageErrors).toEqual([]);
   }, 60_000);
 
+  // `build.rollupOptions.input` is a build-only option, but pluginAddEntry reads
+  // it to pick the dev-time HTML entry too: when it resolves to a non-HTML file
+  // (e.g. a remote-only container whose input is its own exposed module, built
+  // separately from the page the dev server serves), htmlFilePath stays unset
+  // and the host-init bootstrap is never injected into index.html. That
+  // bootstrap is what runs the shared-singleton seeding pass before the entry
+  // evaluates, so without it a synchronous consumer sees an undefined binding
+  // exactly like #1104 -- just reached through the wrong-target injection
+  // instead of a missing preload.
+  it('boots on first load when build.rollupOptions.input targets a non-HTML file', async () => {
+    const exposedEntry = path.join(fixtureRoot, 'src/IssueBuildInputApp.js');
+    await Promise.all([
+      writeFile(
+        path.join(fixtureRoot, 'src/main.js'),
+        `import { jsxDEV } from 'react/jsx-dev-runtime';
+
+const element = jsxDEV('div', { children: 'ready' }, undefined, false, undefined, undefined);
+window.__issueBuildInputResult = element.type === 'div' ? 'ready' : 'invalid';
+document.body.textContent = window.__issueBuildInputResult;
+`
+      ),
+      writeFile(exposedEntry, 'export default function IssueBuildInputApp() { return null; }\n'),
+    ]);
+
+    const host = await createDevServer(
+      'issue-build-input-host',
+      {
+        name: 'issueBuildInputHost',
+        exposes: { './App': exposedEntry },
+        dts: false,
+        shared: {
+          react: { singleton: true },
+        },
+      },
+      fixtureRoot,
+      'silent',
+      // The build target (the exposed module) deliberately differs from the
+      // dev entry (src/main.js) that index.html actually loads.
+      { rollupOptions: { input: exposedEntry } }
+    );
+    const browser = await chromium.launch({ channel: 'chrome', headless: true });
+    cleanupTasks.push(() => browser.close());
+    const page = await browser.newPage();
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+
+    await page.goto(host.origin, { waitUntil: 'domcontentloaded' });
+    try {
+      await page.waitForFunction(() => window.__issueBuildInputResult === 'ready', undefined, {
+        timeout: 15_000,
+      });
+    } catch (error) {
+      throw new Error(JSON.stringify({ cause: String(error), pageErrors }, null, 2));
+    }
+
+    expect(pageErrors).toEqual([]);
+  }, 60_000);
+
   it('serves an optimized ESM React provider', async () => {
     const { origin } = await createDevServer('issue-913-provider', {
       name: 'issue913Provider',
@@ -582,6 +643,7 @@ declare global {
   interface Window {
     __issue1056Result?: string;
     __issue1104Result?: string;
+    __issueBuildInputResult?: string;
     __issue913HostReact?: unknown;
     __issue913RemoteReact?: unknown;
     __issue978Result?: {

--- a/integration/dev-singleton-react.test.ts
+++ b/integration/dev-singleton-react.test.ts
@@ -380,8 +380,9 @@ document.body.textContent = window.__issue1104Result;
     expect(pageErrors).toEqual([]);
   }, 60_000);
 
-  // `build.rollupOptions.input` is a build-only option, but pluginAddEntry reads
-  // it to pick the dev-time HTML entry too: when it resolves to a non-HTML file
+  // `build.rollupOptions.input` / `build.rolldownOptions.input` are build-only
+  // options, but pluginAddEntry reads them to pick the dev-time HTML entry too:
+  // when one resolves to a non-HTML file
   // (e.g. a remote-only container whose input is its own exposed module, built
   // separately from the page the dev server serves), htmlFilePath stays unset
   // and the host-init bootstrap is never injected into index.html. That
@@ -389,54 +390,56 @@ document.body.textContent = window.__issue1104Result;
   // evaluates, so without it a synchronous consumer sees an undefined binding
   // exactly like #1104 -- just reached through the wrong-target injection
   // instead of a missing preload.
-  it('boots on first load when build.rollupOptions.input targets a non-HTML file', async () => {
-    const exposedEntry = path.join(fixtureRoot, 'src/IssueBuildInputApp.js');
-    await Promise.all([
-      writeFile(
-        path.join(fixtureRoot, 'src/main.js'),
-        `import { jsxDEV } from 'react/jsx-dev-runtime';
+  it.each(['rollupOptions', 'rolldownOptions'] as const)(
+    'boots on first load when build.%s.input targets a non-HTML file',
+    async (inputOption) => {
+      const exposedEntry = path.join(fixtureRoot, 'src/IssueBuildInputApp.js');
+      await Promise.all([
+        writeFile(
+          path.join(fixtureRoot, 'src/main.js'),
+          `import { jsxDEV } from 'react/jsx-dev-runtime';
 
 const element = jsxDEV('div', { children: 'ready' }, undefined, false, undefined, undefined);
 window.__issueBuildInputResult = element.type === 'div' ? 'ready' : 'invalid';
 document.body.textContent = window.__issueBuildInputResult;
 `
-      ),
-      writeFile(exposedEntry, 'export default function IssueBuildInputApp() { return null; }\n'),
-    ]);
+        ),
+        writeFile(exposedEntry, 'export default function IssueBuildInputApp() { return null; }\n'),
+      ]);
 
-    const host = await createDevServer(
-      'issue-build-input-host',
-      {
-        name: 'issueBuildInputHost',
-        exposes: { './App': exposedEntry },
-        dts: false,
-        shared: {
-          react: { singleton: true },
+      const host = await createDevServer(
+        `issue-build-input-${inputOption}-host`,
+        {
+          name: 'issueBuildInputHost',
+          exposes: { './App': exposedEntry },
+          dts: false,
+          shared: {
+            react: { singleton: true },
+          },
         },
-      },
-      fixtureRoot,
-      'silent',
-      // The build target (the exposed module) deliberately differs from the
-      // dev entry (src/main.js) that index.html actually loads.
-      { rollupOptions: { input: exposedEntry } }
-    );
-    const browser = await chromium.launch({ channel: 'chrome', headless: true });
-    cleanupTasks.push(() => browser.close());
-    const page = await browser.newPage();
-    const pageErrors: string[] = [];
-    page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+        fixtureRoot,
+        'silent',
+        // The build target (the exposed module) deliberately differs from the
+        // dev entry (src/main.js) that index.html actually loads.
+        { [inputOption]: { input: exposedEntry } }
+      );
+      const browser = await chromium.launch({ channel: 'chrome', headless: true });
+      cleanupTasks.push(() => browser.close());
+      const page = await browser.newPage();
+      const pageErrors: string[] = [];
+      page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
 
-    await page.goto(host.origin, { waitUntil: 'domcontentloaded' });
-    try {
-      await page.waitForFunction(() => window.__issueBuildInputResult === 'ready', undefined, {
-        timeout: 15_000,
-      });
-    } catch (error) {
-      throw new Error(JSON.stringify({ cause: String(error), pageErrors }, null, 2));
-    }
+      await page.goto(host.origin, { waitUntil: 'domcontentloaded' });
+      try {
+        await page.waitForFunction(() => window.__issueBuildInputResult === 'ready', undefined, {
+          timeout: 15_000,
+        });
+      } catch (error) {
+        throw new Error(JSON.stringify({ cause: String(error), pageErrors }, null, 2));
+      }
 
-    expect(pageErrors).toEqual([]);
-  }, 60_000);
+      expect(pageErrors).toEqual([]);
+    }, 60_000);
 
   it('serves an optimized ESM React provider', async () => {
     const { origin } = await createDevServer('issue-913-provider', {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -930,21 +930,8 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
           htmlFilePath = getFirstHtmlEntryFile(entryFiles);
         }
 
-        // `build.rollupOptions.input` is a build-only concept, but it is also
-        // what the branches above use to pick the dev-time HTML entry. Some
-        // configs point it at a non-HTML build target that differs from what
-        // the dev server actually serves -- e.g. a remote-only container
-        // whose input is its exposed module, not an HTML page, or a
-        // framework that sets a per-environment client entry. `vite dev`
-        // still serves a root index.html directly in these cases, so fall
-        // back to it here: without this, htmlFilePath stays unset,
-        // transformIndexHtml's injectHtml() gate never opens, and the
-        // host-init bootstrap (including the shared-singleton seeding pass
-        // it performs before the entry evaluates) is never injected into the
-        // page the browser loads. Serve-only: a build whose input omits
-        // index.html never emits that file into the bundle either, so
-        // generateBundle's own htmlFileNames check already makes this a
-        // no-op for build.
+        // Build input may be non-HTML and does not determine the page served in dev.
+        // Fall back to root index.html so transformIndexHtml can inject host init.
         if (config.command === 'serve' && !htmlFilePath) {
           const rootIndexHtml = path.resolve(config.root, 'index.html');
           if (fs.existsSync(rootIndexHtml)) {

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -930,6 +930,28 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
           htmlFilePath = getFirstHtmlEntryFile(entryFiles);
         }
 
+        // `build.rollupOptions.input` is a build-only concept, but it is also
+        // what the branches above use to pick the dev-time HTML entry. Some
+        // configs point it at a non-HTML build target that differs from what
+        // the dev server actually serves -- e.g. a remote-only container
+        // whose input is its exposed module, not an HTML page, or a
+        // framework that sets a per-environment client entry. `vite dev`
+        // still serves a root index.html directly in these cases, so fall
+        // back to it here: without this, htmlFilePath stays unset,
+        // transformIndexHtml's injectHtml() gate never opens, and the
+        // host-init bootstrap (including the shared-singleton seeding pass
+        // it performs before the entry evaluates) is never injected into the
+        // page the browser loads. Serve-only: a build whose input omits
+        // index.html never emits that file into the bundle either, so
+        // generateBundle's own htmlFileNames check already makes this a
+        // no-op for build.
+        if (config.command === 'serve' && !htmlFilePath) {
+          const rootIndexHtml = path.resolve(config.root, 'index.html');
+          if (fs.existsSync(rootIndexHtml)) {
+            htmlFilePath = rootIndexHtml;
+          }
+        }
+
         if (htmlFilePath) {
           addHtmlScriptEntries(htmlFilePath);
         }


### PR DESCRIPTION
Closes #1170

## Problem

With `build.rollupOptions.input` set to a non-HTML file, `vite dev` never injects the host-init bootstrap into the page it serves. That bootstrap performs the seeding pass that populates the shared-module cache before the entry evaluates, so without it a shared singleton's export binding is `undefined` when the entry reads it synchronously.

Minimal A/B — same project, same version, one option: `typeof createRoot` is `"function"` without the `build` block and `"undefined"` with it, then `TypeError: createRoot is not a function`. Reproduction linked from the issue.

## Mechanism

`configResolved` in the `enforce: 'post'` plugin runs for both `serve` and `build`, with no `command` guard, and derives the dev-time HTML entry from `build.rollupOptions.input`:

- [`pluginAddEntry.ts#L909`](https://github.com/module-federation/vite/blob/8c58d47c8ef4706e98e9fd12b000242c09d74d34/src/plugins/pluginAddEntry.ts#L909) — reads the build input via [`getBuildInput`](https://github.com/module-federation/vite/blob/8c58d47c8ef4706e98e9fd12b000242c09d74d34/src/plugins/pluginAddEntry.ts#L235).
- [`pluginAddEntry.ts#L912`](https://github.com/module-federation/vite/blob/8c58d47c8ef4706e98e9fd12b000242c09d74d34/src/plugins/pluginAddEntry.ts#L912) — with no build input, `htmlFilePath` correctly falls back to the root `index.html`.
- [`pluginAddEntry.ts#L930`](https://github.com/module-federation/vite/blob/8c58d47c8ef4706e98e9fd12b000242c09d74d34/src/plugins/pluginAddEntry.ts#L930) — with a build input, `htmlFilePath` comes from `getFirstHtmlEntryFile(entryFiles)` instead, which yields nothing when every configured input is a non-HTML file.
- [`pluginAddEntry.ts#L934`](https://github.com/module-federation/vite/blob/8c58d47c8ef4706e98e9fd12b000242c09d74d34/src/plugins/pluginAddEntry.ts#L934) — `addHtmlScriptEntries` is then never called, so the page the dev server actually serves gets no bootstrap.

`build.rollupOptions.input` is build-only and has no bearing on what `vite dev` serves — the dev server serves `index.html` regardless — so using it to pick the dev-time HTML entry conflates "what should Rollup build" with "what page does the dev server serve".

This became load-bearing in 1.20.7. #1087 removed the static local `import * as __mfLocalShare from …` fallback for `servesRemoteSingletonFallback` cases, which is correct on its own; it just means the seeding pass is now the only thing standing between a synchronous consumer and an `undefined` binding. Nothing here changes that behaviour.

This is also why #1107 does not already cover it: that preload lives inside the bootstrap `addHtmlScriptEntries` generates, so when `htmlFilePath` is never resolved the bootstrap — preload included — is never injected at all.

## Fix

In `serve` only, when no HTML entry resolved from the configured inputs and a root `index.html` exists on disk, fall back to it — mirroring what already happens at L912 when `build.rollupOptions.input` is unset.

```diff
           htmlFilePath = getFirstHtmlEntryFile(entryFiles);
         }
 
+        if (config.command === 'serve' && !htmlFilePath) {
+          const rootIndexHtml = path.resolve(config.root, 'index.html');
+          if (fs.existsSync(rootIndexHtml)) {
+            htmlFilePath = rootIndexHtml;
+          }
+        }
+
         if (htmlFilePath) {
           addHtmlScriptEntries(htmlFilePath);
         }
```

The change is additive: it can only set `htmlFilePath` where it would otherwise have stayed `undefined`, so any config that already resolves an HTML entry is untouched. The `command === 'serve'` guard keeps it out of build, and `fs.existsSync` keeps it inert for setups with no root `index.html` — SvelteKit, Nitro and per-environment framework entries among them. The framework-specific guards above it (the React Router route-input filter, the Vite 8 client-environment check) are not modified.

## Testing

Added `boots on first load when build.rollupOptions.input targets a non-HTML file` to `integration/dev-singleton-react.test.ts`, alongside the existing #1104 coverage, extending `createDevServer` with an optional `build` option.

- Test with the source change reverted: fails, `TypeError: jsxDEV is not a function`.
- Test with the change applied: passes.
- `npm test` — 1151 passed, 1 skipped, 49 files.
- `npm run test:integration` — 93 passed, 16 files.
- `npm run typecheck` — clean.

Happy to reshape this if you would rather solve it somewhere else in the hook — the diagnosis is the part I am confident about.
