### PR TITLE
fix: prevent shared package self-import rewrites

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1042,6 +1042,76 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(resolution).toBeUndefined();
   });
 
+  it('does not proxy internal imports from the same shared package during build', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      config,
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as any,
+      '/repo/apps/remote/node_modules/vue/src/internal.js',
+      '/repo/apps/remote/node_modules/vue/src/index.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+  });
+
+  it('does not proxy internal imports for wildcard shared package keys during build', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+
+    const shared: NormalizedShared = {
+      'transitive/': {
+        ...makeShared().transitive,
+        name: 'transitive/',
+      },
+    };
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      config,
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as any,
+      '/repo/apps/remote/node_modules/transitive/src/internal.js',
+      '/repo/apps/remote/node_modules/transitive/src/index.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+  });
+
   it('materializes repeated loadShare resolutions once per shared source', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -548,6 +548,10 @@ export function proxySharedModule(options: {
 
         const key = findSharedKeyForSource(source, shared);
         if (!key) return;
+        // A shared package's own files must keep ordinary internal module edges.
+        // Compare package roots because `key` may be an explicit subpath or a
+        // trailing-slash wildcard share key.
+        if (importer && getPackageNameFromNodeModulePath(importer) === getPackageName(key)) return;
         if (useDirectReactImport && key === 'react') return;
         if (isAssetLikeImport(source)) return;
         if (isBuildConfigImporter(importer)) return;


### PR DESCRIPTION
## Summary

Fixes #1175

- Prevent the build resolver from proxying a shared package's own internal imports through `loadShare`.
- Compare package roots so explicit subpath and trailing-slash wildcard share keys are handled correctly.
- Add regression coverage for regular and wildcard shared keys.

## Validation

- `pnpm test` — 49 test files passed; 1,156 tests passed, 1 skipped
- `pnpm typecheck`
- `pnpm fmt.check`
- `pnpm build`
- Issue reproduction build passes without `MISSING_EXPORT`.