### PR TITLE
fix: keep runtime-registered shared providers

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1025,6 +1025,52 @@ describe('virtualRemoteEntry', () => {
     expect(generatedCode).not.toContain('.catch(remoteEntry.init)');
   });
 
+  it('keeps shares registered on the runtime before initShareScopeMap', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        remotes: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+
+    expect(code).toContain('const __mfKeepRegisteredShares = (scopeName, scope) => {');
+    expect(code).toContain('Object.entries(initRes.shareScopeMap?.[scopeName] || {})');
+    expect(code).toContain('if (!provider || provider.get === usedShared[pkg]?.get) continue;');
+    expect(code).toContain('if (target[version] === undefined) target[version] = provider;');
+    expect(code).toContain(
+      'const __mfGetRuntimeShareScope = (scopeName, hostScope) => {\n      __mfKeepRegisteredShares(scopeName, hostScope);'
+    );
+    expect(code.indexOf('const initRes = runtimeInit({')).toBeLessThan(
+      code.indexOf(
+        "initRes.initShareScopeMap(\n      'default',\n      __mfGetRuntimeShareScope('default', shared)"
+      )
+    );
+  });
+
+  it('skips host init loadShare for import:false shares without a foreign provider', async () => {
+    const mod = await import('../virtualRemoteEntry');
+
+    const hostInit = mod.generateHostAutoInitCode('"virtual:remoteEntry"', 'build');
+
+    expect(hostInit).toContain('share.shareConfig?.import === false &&');
+    expect(hostInit).toContain(
+      'Object.values(runtime.shareScopeMap?.[scopeName]?.[pkg] || {}).some('
+    );
+    expect(hostInit).toContain('(provider) => provider?.shareConfig?.import !== false');
+    expect(hostInit.indexOf('share.shareConfig?.import === false &&')).toBeLessThan(
+      hostInit.indexOf('await runtime.loadShare(pkg, {')
+    );
+  });
+
   it('initializes all configured provider share scopes in remoteEntry', async () => {
     const mod = await import('../virtualRemoteEntry');
 
@@ -1265,56 +1311,6 @@ describe('virtualRemoteEntry', () => {
     expect(code).toContain('const factory = await initRes.loadShare(pkg');
     expect(code).not.toContain('import exposesMap from');
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
-  });
-
-  it('preserves runtime-registered shares when initializing the host scope', async () => {
-    const mod = await import('../virtualRemoteEntry');
-    const code = mod.generateRemoteEntry(
-      {
-        internalName: '__mfe_internal__host',
-        name: 'host',
-        filename: 'remoteEntry.js',
-        remotes: {},
-        runtimePlugins: [],
-        shareScope: 'default',
-        shareStrategy: 'version-first',
-      } as any,
-      'virtual:exposes',
-      'build'
-    );
-    const helperStart = code.indexOf('const __mfRuntimeShareScopes =');
-    const helperEnd = code.indexOf('const __mfRestoreForeignSharedProviders =', helperStart);
-    const getRuntimeShareScope = new Function(
-      'initRes',
-      'scopeRoot',
-      'isWebpackProvider',
-      `${code.slice(helperStart, helperEnd)}; return __mfGetRuntimeShareScope;`
-    )(
-      {
-        shareScopeMap: {
-          default: {
-            'runtime-shared': {
-              '2.0.0': { from: 'runtime-plugin' },
-            },
-            'host-shared': {
-              '1.0.0': { from: 'runtime-plugin' },
-            },
-          },
-        },
-      },
-      undefined,
-      () => false
-    ) as (scopeName: string, hostScope: Record<string, unknown>) => Record<string, any>;
-
-    const hostScope = {
-      'host-shared': {
-        '1.0.0': { from: 'host' },
-      },
-    };
-    const runtimeScope = getRuntimeShareScope('default', hostScope);
-
-    expect(runtimeScope['runtime-shared']['2.0.0']).toMatchObject({ from: 'runtime-plugin' });
-    expect(runtimeScope['host-shared']['1.0.0']).toMatchObject({ from: 'host' });
   });
 
   it('loads the local shared map dynamically when a local eager share is configured', async () => {
@@ -3064,8 +3060,11 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('expectedFrom');
     expect(code).not.toContain('__mfModuleCache.share[usedCacheKey] = normalized;');
     expect(code.match(/runtimeResolveShareHook/g)).toHaveLength(2);
-    expect(code).toContain('if (__mfMatchesSharedProvider(provider, share)) return;');
-    expect(code.indexOf('if (__mfMatchesSharedProvider(provider, share)) return;')).toBeLessThan(
+    expect(code).toContain(
+      'const __mfIsOwnStub = (candidate) => candidate === share || candidate?.shareConfig?.import === false;'
+    );
+    expect(code).toContain('if (__mfIsOwnStub(provider)) return;');
+    expect(code.indexOf('if (__mfIsOwnStub(provider)) return;')).toBeLessThan(
       code.indexOf(
         'const loadedShare = await __mfLoadPinnedRuntimeShare(',
         code.indexOf('const __mfResolveImportFalseShared')

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1267,6 +1267,56 @@ describe('virtualRemoteEntry', () => {
     expect(code).not.toContain('import {usedShared, usedRemotes} from');
   });
 
+  it('preserves runtime-registered shares when initializing the host scope', async () => {
+    const mod = await import('../virtualRemoteEntry');
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        remotes: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+    const helperStart = code.indexOf('const __mfRuntimeShareScopes =');
+    const helperEnd = code.indexOf('const __mfRestoreForeignSharedProviders =', helperStart);
+    const getRuntimeShareScope = new Function(
+      'initRes',
+      'scopeRoot',
+      'isWebpackProvider',
+      `${code.slice(helperStart, helperEnd)}; return __mfGetRuntimeShareScope;`
+    )(
+      {
+        shareScopeMap: {
+          default: {
+            'runtime-shared': {
+              '2.0.0': { from: 'runtime-plugin' },
+            },
+            'host-shared': {
+              '1.0.0': { from: 'runtime-plugin' },
+            },
+          },
+        },
+      },
+      undefined,
+      () => false
+    ) as (scopeName: string, hostScope: Record<string, unknown>) => Record<string, any>;
+
+    const hostScope = {
+      'host-shared': {
+        '1.0.0': { from: 'host' },
+      },
+    };
+    const runtimeScope = getRuntimeShareScope('default', hostScope);
+
+    expect(runtimeScope['runtime-shared']['2.0.0']).toMatchObject({ from: 'runtime-plugin' });
+    expect(runtimeScope['host-shared']['1.0.0']).toMatchObject({ from: 'host' });
+  });
+
   it('loads the local shared map dynamically when a local eager share is configured', async () => {
     const mod = await import('../virtualRemoteEntry');
     const eagerShare = {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1243,18 +1243,25 @@ export function generateRemoteEntry(
       }
       return runtimeScope;
     };
+    // runtimeInit() lets runtime plugins register providers (public
+    // registerShared) before initShareScopeMap() replaces the runtime's own
+    // scope map. Carry those registrations over; the runtime's own copies of
+    // usedShared keep registering lazily through loadShare().
+    const __mfKeepRegisteredShares = (scopeName, scope) => {
+      for (const [pkg, versions] of Object.entries(initRes.shareScopeMap?.[scopeName] || {})) {
+        for (const [version, provider] of Object.entries(versions || {})) {
+          if (!provider || provider.get === usedShared[pkg]?.get) continue;
+          const target = scope[pkg] ||= {};
+          if (target[version] === undefined) target[version] = provider;
+        }
+      }
+    };
     const __mfGetRuntimeShareScope = (scopeName, hostScope) => {
+      __mfKeepRegisteredShares(scopeName, hostScope);
       const isWebpackScope = !scopeRoot && Object.values(hostScope || {}).some((versions) =>
         Object.values(versions || {}).some(isWebpackProvider)
       );
       const runtimeScope = isWebpackScope ? __mfCloneShareScope(hostScope) : hostScope;
-      const registeredScope = initRes.shareScopeMap?.[scopeName];
-      for (const [pkg, versions] of Object.entries(registeredScope || {})) {
-        const runtimeVersions = runtimeScope[pkg] ||= Object.create(null);
-        for (const [version, provider] of Object.entries(versions || {})) {
-          if (runtimeVersions[version] === undefined) runtimeVersions[version] = provider;
-        }
-      }
       __mfRuntimeShareScopes[scopeName] = {
         host: hostScope,
         runtime: runtimeScope,
@@ -1957,7 +1964,11 @@ export function generateRemoteEntry(
       ) || share;
       const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
       if (!providerEntry) return;
-      if (__mfMatchesSharedProvider(provider, share)) return;
+      // A provider registered on this instance through the public registerShared
+      // API carries this container's own name, so tell the own stub apart by its
+      // import:false config rather than by provenance.
+      const __mfIsOwnStub = (candidate) => candidate === share || candidate?.shareConfig?.import === false;
+      if (__mfIsOwnStub(provider)) return;
       const { version } = providerEntry;
       const currentProvider = versionMap?.[version];
       const loadedShare = await __mfLoadPinnedRuntimeShare(
@@ -1967,13 +1978,13 @@ export function generateRemoteEntry(
         version,
         currentProvider,
         provider,
-        providerEntry.registered && !__mfMatchesSharedProvider(provider, share)
+        providerEntry.registered
       );
       const providerSelection = loadedShare?.selection;
       const actualProvider = loadedShare?.provider;
       const resolved = loadedShare?.resolved;
       if (!providerSelection) return;
-      if (__mfMatchesSharedProvider(actualProvider, share)) return;
+      if (__mfIsOwnStub(actualProvider)) return;
       if (resolved === undefined) return;
       const latestCachedShare = share.treeShaking
         ? __mfReadTreeShakingSharedSelection(__mfModuleCache.share, cacheDescriptor, mfName)
@@ -2138,6 +2149,16 @@ export function generateHostAutoInitCode(
                 __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) ${
                   _command === 'serve' ? '!== undefined' : `=== ${cacheOwner}`
                 }
+              ) return;
+              // An import:false share has nothing to load until a foreign provider
+              // registers: its own stub getter throws by construction.
+              if (
+                share.shareConfig?.import === false &&
+                !(Array.isArray(share.scope) ? share.scope : [share.scope || 'default']).some((scopeName) =>
+                  Object.values(runtime.shareScopeMap?.[scopeName]?.[pkg] || {}).some(
+                    (provider) => provider?.shareConfig?.import !== false
+                  )
+                )
               ) return;
               await runtime.loadShare(pkg, {
                 customShareInfo: { shareConfig: share.shareConfig }

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1248,6 +1248,13 @@ export function generateRemoteEntry(
         Object.values(versions || {}).some(isWebpackProvider)
       );
       const runtimeScope = isWebpackScope ? __mfCloneShareScope(hostScope) : hostScope;
+      const registeredScope = initRes.shareScopeMap?.[scopeName];
+      for (const [pkg, versions] of Object.entries(registeredScope || {})) {
+        const runtimeVersions = runtimeScope[pkg] ||= Object.create(null);
+        for (const [version, provider] of Object.entries(versions || {})) {
+          if (runtimeVersions[version] === undefined) runtimeVersions[version] = provider;
+        }
+      }
       __mfRuntimeShareScopes[scopeName] = {
         host: hostScope,
         runtime: runtimeScope,


### PR DESCRIPTION
Closes #1176 

Preserve providers registered via public registerShared across container init and skip loading the own import: false stub.