### PR TITLE
fix: respect eager shared fallback initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,18 @@ federation({
 
 `runtime-infer` is useful for local development and falls back to the full dependency when the required exports are not available. `server-calc` is recommended for deployments because it can use aggregated export metadata from all consumers.
 
+Use `eager: true` when a shared dependency must provide exports during module evaluation. For example, icon libraries may call `jsx()` at module scope before deferred singleton initialization completes. Configure the remote's React share as follows; discovered React subpaths such as `react/jsx-runtime` inherit this setting:
+
+```ts
+federation({
+  shared: {
+    react: { singleton: true, eager: true },
+  },
+});
+```
+
+This bundles the local fallback into the initial entry, so enable it only when synchronous evaluation requires it.
+
 Do not combine `eager: true` with `treeShaking`; eager shared dependencies are bundled into the initial entry and cannot use the on-demand tree-shaking path. Choose eager loading for small dependencies, or tree shaking for larger dependencies such as component libraries.
 
 With `server-calc`, the Vite build records the exports used by each application in its generated Module Federation metadata. A deployment service must then collect that metadata for all applications that share the same dependency and version, merge their `usedExports` lists, and use the resulting union to create one optimized secondary shared artifact. For example, if one application uses `Button` and another uses `Input`, the secondary artifact must contain both exports.

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -2515,6 +2515,33 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('useState');
   });
 
+  it('generates eager inherited subpath exports synchronously for remote builds', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: { './App': './src/App.jsx' },
+    });
+    const pkg = 'react/jsx-runtime';
+    const mockShareItem: ShareItem = {
+      name: 'react',
+      from: '',
+      version: '17.0.2',
+      shareConfig: {
+        singleton: true,
+        eager: true,
+        strictVersion: false,
+        requiredVersion: '^17.0.2',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', true);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expect(generatedCode).toContain('import * as __mfLocalShare from "mock-import-id";');
+    expect(generatedCode).not.toContain('initPromise.then');
+  });
+
   it('reads React compiler runtime internals from the compatible React cache key', () => {
     const pkg = 'react/compiler-runtime';
     const mockShareItem: ShareItem = {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -2000,6 +2000,7 @@ export function writeLoadShareModule(
     (Array.isArray(shareItem.scope) && shareItem.scope[0] === 'default');
   const usesDeferredSingletonFallback =
     hasCompleteExportCoverage &&
+    shareItem.shareConfig.eager !== true &&
     (isWorkspacePackage ||
       (command !== 'build' &&
         isRemoteOnlyContainer(resolvedOptions) &&


### PR DESCRIPTION
Closes #1179

Prevents eager shared modules from using deferred fallback exports, ensuring module-scope consumers receive initialized bindings synchronously. Adds regression coverage and React JSX-runtime guidance.