### PR TITLE
fix: skip shared dependency cycle rewrites

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -23,7 +23,7 @@ const {
   getTreeShakingSharedProviderImportIdMock,
   getTreeShakingSharedProviderNameMock,
 } = vi.hoisted(() => ({
-  hasPackageDependencyMock: vi.fn<(pkg: string) => boolean>(),
+  hasPackageDependencyMock: vi.fn<(pkg: string, cwd?: string) => boolean>(),
   existsSyncMock: vi.fn<(path: string) => boolean>(() => false),
   readFileSyncMock: vi.fn<(path: string) => string>(() => '{}'),
   addUsedSharesMock: vi.fn<(pkg: string) => void>(),
@@ -1072,6 +1072,63 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     expect(resolution).toBeUndefined();
     expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+  });
+
+  it('does not proxy a shared package import from one of its own dependencies during build', async () => {
+    // vue -> vue-core -> vue-helper -> vue is a package-level cycle. Proxying the
+    // back edge would evaluate the loadShare glue inside vue's own evaluation cycle.
+    hasPackageDependencyMock.mockReturnValue(false);
+    const manifests: Record<string, string> = {
+      '/repo/apps/remote/node_modules/vue/package.json': '{"dependencies":{"vue-core":"1"}}',
+      '/repo/apps/remote/node_modules/vue-core/package.json': '{"dependencies":{"vue-helper":"1"}}',
+      '/repo/apps/remote/node_modules/vue-helper/package.json': '{"dependencies":{"vue":"1"}}',
+      '/repo/apps/remote/node_modules/other-lib/package.json': '{"dependencies":{"vue":"1"}}',
+    };
+    existsSyncMock.mockImplementation((p: string) => p in manifests);
+    readFileSyncMock.mockImplementation((p: string) => manifests[p] ?? '{}');
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    const config: MockUserConfig = { resolve: { alias: [] } };
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      config,
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as any,
+      'vue',
+      '/repo/apps/remote/node_modules/vue-helper/index.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+
+    const unrelated = await callHook(
+      sharedResolvePlugin.resolveId,
+      {
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as any,
+      'vue',
+      '/repo/apps/remote/node_modules/other-lib/index.js',
+      { isEntry: false }
+    );
+
+    expect(unrelated).toBeDefined();
+    expect(writeLoadShareModuleMock).toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
   });
 
   it('does not proxy internal imports for wildcard shared package keys during build', async () => {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -261,6 +261,34 @@ export function excludeSharedSubDependencies(shared: NormalizedShared): void {
   }
 }
 
+const sharedDependencyCache = new Map<string, Set<string>>();
+
+/** Whether `dependency` is reachable through the shared package's manifest dependencies. */
+function isSharedPackageDependency(sharedKey: string, dependency: string) {
+  const sharedPackage = getPackageName(sharedKey);
+  let reachable = sharedDependencyCache.get(sharedPackage);
+  if (!reachable) {
+    reachable = new Set<string>();
+    const visited = new Set<string>();
+    const queue = [getInstalledPackageJson(sharedPackage, { packageName: sharedPackage })];
+    for (let installed = queue.shift(); installed; installed = queue.shift()) {
+      if (visited.has(installed.dir)) continue;
+      visited.add(installed.dir);
+      const manifest = installed.packageJson as Record<string, Record<string, string> | undefined>;
+      for (const dep of Object.keys({
+        ...manifest.dependencies,
+        ...manifest.peerDependencies,
+        ...manifest.optionalDependencies,
+      })) {
+        reachable.add(dep);
+        queue.push(getInstalledPackageJson(dep, { cwd: installed.dir, packageName: dep }));
+      }
+    }
+    sharedDependencyCache.set(sharedPackage, reachable);
+  }
+  return reachable.has(dependency);
+}
+
 export function proxySharedModule(options: {
   shared?: NormalizedShared;
   include?: string | string[];
@@ -401,6 +429,7 @@ export function proxySharedModule(options: {
         setTreeShakingBuildMode(command === 'build', federationOptions);
         resetTreeShakingExports(federationOptions);
         emittedTreeShakingProviders.clear();
+        sharedDependencyCache.clear();
         const isVinext = hasPackageDependency('vinext');
         const isAstro = hasPackageDependency('astro');
         const isRolldown = getIsRolldown(this);
@@ -551,7 +580,13 @@ export function proxySharedModule(options: {
         // A shared package's own files must keep ordinary internal module edges.
         // Compare package roots because `key` may be an explicit subpath or a
         // trailing-slash wildcard share key.
-        if (importer && getPackageNameFromNodeModulePath(importer) === getPackageName(key)) return;
+        const importerPackage = importer ? getPackageNameFromNodeModulePath(importer) : undefined;
+        if (importerPackage === getPackageName(key)) return;
+        // A dependency of the shared package that imports it back (a package-level
+        // cycle) keeps its ordinary edge too. Proxying it would place the loadShare
+        // glue inside the package's own evaluation cycle, where the glue's eager
+        // export reads run before the fallback body has initialized.
+        if (importerPackage && isSharedPackageDependency(key, importerPackage)) return;
         if (useDirectReactImport && key === 'react') return;
         if (isAssetLikeImport(source)) return;
         if (isBuildConfigImporter(importer)) return;


### PR DESCRIPTION
Closes #1181

A dependency of a shared package that imports the shared package back (e.g. demo-ui → demo-utils → demo-ui) was proxied through the loadShare glue. That puts the glue and its prebuild wrapper inside the package's own evaluation cycle. When an untracked subpath such as demo-ui/extra.js is walked first, rolldown cuts the cycle at the wrapper's fallback edge, the wrapper's eager export reads run before the package body, and the whole chunk dies with TypeError: Cannot read properties of undefined.

Extend the #1177 same-package rule: when the importer is a node_modules package listed in the shared package's package.json dependencies, keep the ordinary module edge instead of proxying it.
