### PR TITLE
fix: skip satisfy-checking import:false stubs

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -4120,6 +4120,25 @@ describe('virtualRemoteEntry', () => {
     ).toBeUndefined();
   });
 
+  it("does not satisfy-check the container's own import:false stub", async () => {
+    const selectProvider = await getExternalSharedProviderSelector();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ownStub = {
+      from: 'host',
+      version: '0.0.0',
+      shareConfig: { singleton: true, import: false, requiredVersion: '^1.0.0' },
+    };
+
+    try {
+      expect(
+        selectProvider({ '0.0.0': ownStub }, 'demo-lib', ownStub, 'loaded-first')
+      ).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('compares external and local singleton providers with version-first', async () => {
     const selectExternalProvider = await getExternalSharedProviderSelector();
     const hostGet = vi.fn();

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -587,8 +587,16 @@ export const sharedProviderSelectionHelperCode = `const __mfOriginalProviderKey 
             strategy
           ) => {
             if (!versions || !share) return undefined;
+            // import:false stubs provide nothing, so they are never a selectable
+            // provider and must not be satisfy-checked. Skip the runtime entirely
+            // when nothing remains: it treats an empty map as version "0" and
+            // warns that it fails even a "*" requirement.
+            const candidates = Object.fromEntries(
+              Object.entries(versions).filter(([, provider]) => provider?.shareConfig?.import !== false)
+            );
+            if (Object.keys(candidates).length === 0) return undefined;
             const scopes = Array.isArray(share.scope) ? share.scope : [share.scope || "default"];
-            const selectionVersions = __mfCreateProviderSelectionVersions(versions, strategy);
+            const selectionVersions = __mfCreateProviderSelectionVersions(candidates, strategy);
             const shareScopeMap = {};
             for (const scope of scopes) {
               shareScopeMap[scope || "default"] = { [pkg]: selectionVersions };


### PR DESCRIPTION
Closes #1183

Excludes import: false placeholders from shared provider selection before calling runtime getRegisteredShare, and returns early when no candidates remain. Stops the runtime from treating an empty version map as version 0 and warning on every container init.