### PR TITLE
fix: ignore type-only imports in expose preflight

### DIFF
--- a/integration/fixtures/nested-remote-transitive/type-only-import.ts
+++ b/integration/fixtures/nested-remote-transitive/type-only-import.ts
@@ -1,0 +1,4 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { helper } from 'remoteA/shared/helpers';
+
+export const document = helper as unknown as TypedDocumentNode;

--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -143,6 +143,42 @@ describe('pluginProxyRemoteEntry', () => {
     expect(generated).not.toContain('__loadRemote__remoteB_mf_1_heavy');
   });
 
+  it('does not resolve type-only imports while collecting remote dependencies', async () => {
+    const expose = resolve('integration/fixtures/nested-remote-transitive/type-only-import.ts');
+    const resolvedSources: string[] = [];
+    const plugin = pluginProxyRemoteEntry({
+      options: getDefaultMockOptions({
+        exposes: { './document': { import: expose } as any },
+        remotes: {
+          remoteA: {
+            name: 'remoteA',
+            entry: 'http://localhost:3001/remoteEntry.js',
+            type: 'module',
+          },
+        },
+      }),
+      remoteEntryId: 'virtual:mf-remote-entry',
+      virtualExposesId: 'virtual:mf-exposes',
+    });
+    const context = {
+      resolve: async (source: string) => {
+        resolvedSources.push(source);
+        return source === expose ? { id: expose } : undefined;
+      },
+    } as any;
+
+    callHook(
+      plugin.config,
+      {} as ConfigPluginContext,
+      {},
+      { command: 'serve', mode: 'development' }
+    );
+    const generated = await callHook(plugin.load, context, 'virtual:mf-exposes');
+
+    expect(generated).toContain('__loadRemote__remoteA_mf_1_shared_mf_1_helpers');
+    expect(resolvedSources).not.toContain('@graphql-typed-document-node/core');
+  });
+
   it('uses an inlined data-URL origin for dev host init in SSR/module-runner contexts, protocol relative fallback origin otherwise', async () => {
     normalizeModuleFederationOptions({ name: 'test' });
     const plugin = pluginProxyRemoteEntry({

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import { normalizePathForImport } from '../utils/buildPaths';
+import { findModuleImportDescriptors } from '../utils/htmlEntryUtils';
 import {
   addCssAssetsToAllExports,
   collectCssAssets,
@@ -76,15 +77,11 @@ export default function ({
 
   function collectImportSources(code: string): Array<{ source: string; dynamic: boolean }> {
     const sources = new Map<string, boolean>();
-    const importRe =
-      /(?:^|[;\n\r])\s*import\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']|import\(\s*["']([^"']+)["']\s*\)/g;
 
-    for (const match of code.matchAll(importRe)) {
-      const source = match[1] || match[2];
-      if (source) {
-        const dynamic = !match[1];
-        sources.set(source, (sources.get(source) ?? true) && dynamic);
-      }
+    for (const { source, kind, syntax, typeOnly } of findModuleImportDescriptors(code)) {
+      if (syntax !== 'import' || typeOnly) continue;
+      const dynamic = kind === 'dynamic';
+      sources.set(source, (sources.get(source) ?? true) && dynamic);
     }
 
     return Array.from(sources, ([source, dynamic]) => ({ source, dynamic })).sort((a, b) =>

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -53,6 +53,12 @@ describe('findModuleImportSources', () => {
 });
 
 describe('findModuleImportDescriptors', () => {
+  it('treats an imported runtime binding named type as a value import', () => {
+    expect(findModuleImportDescriptors(`import { type as value } from 'remote/value';`)).toEqual([
+      { kind: 'static', syntax: 'import', source: 'remote/value', typeOnly: false },
+    ]);
+  });
+
   it('separates runtime imports from type-only imports', () => {
     expect(
       findModuleImportDescriptors(`

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -59,10 +59,21 @@ describe('findModuleImportDescriptors', () => {
     ]);
   });
 
+  it.each([`import type from 'remote/value';`, `import type, { value } from 'remote/value';`])(
+    'treats a default runtime binding named type as a value import',
+    (source) => {
+      expect(findModuleImportDescriptors(source)).toEqual([
+        { kind: 'static', syntax: 'import', source: 'remote/value', typeOnly: false },
+      ]);
+    }
+  );
+
   it('separates runtime imports from type-only imports', () => {
     expect(
       findModuleImportDescriptors(`
+        import type DefaultType from 'remote/default-type';
         import type { RemoteType } from 'remote/type';
+        import type * as RemoteTypes from 'remote/namespace-type';
         export type { ExportedType } from 'remote/export-type';
         export { type NamedType } from 'remote/named-type';
         import { value } from 'remote/value';
@@ -70,7 +81,9 @@ describe('findModuleImportDescriptors', () => {
         const lazy = import('remote/lazy');
       `)
     ).toEqual([
+      { kind: 'static', syntax: 'import', source: 'remote/default-type', typeOnly: true },
       { kind: 'static', syntax: 'import', source: 'remote/type', typeOnly: true },
+      { kind: 'static', syntax: 'import', source: 'remote/namespace-type', typeOnly: true },
       { kind: 'static', syntax: 'import', source: 'remote/export-type', typeOnly: true },
       { kind: 'static', syntax: 'import', source: 'remote/named-type', typeOnly: true },
       { kind: 'static', syntax: 'import', source: 'remote/value', typeOnly: false },

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -21,7 +21,10 @@ function isTypeOnlyClause(clause: string): boolean {
   // `type` alone (or `type as X`) imports a runtime binding literally named
   // `type`, not a type-only specifier — the `type` modifier always needs a
   // following identifier (`type Foo`).
-  return specifiers.length > 0 && specifiers.every((specifier) => /^type\s+\S/.test(specifier));
+  return (
+    specifiers.length > 0 &&
+    specifiers.every((specifier) => /^type\s+(?!as(?:\s|$))\S/.test(specifier))
+  );
 }
 
 /**

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -9,7 +9,10 @@ export interface ModuleImportDescriptor {
 
 function isTypeOnlyClause(clause: string): boolean {
   const normalized = clause.trim();
-  if (/^type\b/.test(normalized)) return true;
+  const declarationTypeOnly = normalized.match(/^type\b([\s\S]*)$/)?.[1].trim();
+  if (declarationTypeOnly !== undefined) {
+    return declarationTypeOnly.length > 0 && !declarationTypeOnly.startsWith(',');
+  }
 
   const namedSpecifiers = normalized.match(/^\{([\s\S]*)\}$/)?.[1];
   if (!namedSpecifiers) return false;


### PR DESCRIPTION
## Summary

- reuse the existing module import descriptor scanner when traversing exposed modules
- ignore type-only imports before asking Vite to resolve runtime dependencies
- preserve the existing static-versus-dynamic import behavior
- add regression coverage for a type-only dependency alongside a static remote import

## Problem

`pluginProxyRemoteEntry` traverses the raw source of exposed TypeScript modules before Vite transforms them. Its local regular expression currently treats `import type` declarations as runtime imports and passes their package specifiers to `ctx.resolve()`.

For packages that intentionally provide types without a runtime entry, this can make both development and production builds fail even though the import would normally be erased by the TypeScript transform.

The repository already has `findModuleImportDescriptors`, which distinguishes type-only imports and avoids matching import-like text in comments and strings. Reusing it here keeps the expose preflight traversal aligned with the other import-analysis paths.

## Tests

- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build`
- targeted formatting check for the changed files
