### PR TITLE
fix: fix shared export method detection

### DIFF
--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -183,6 +183,29 @@ describe('getInstalledPackageJson', () => {
     expect(entry).toBe(realpathSync(path.join(packageDir, 'dist/index.js')));
   });
 
+  it('ignores copied package metadata beside the resolved entry', () => {
+    const packageName = 'mf-test-copied-package-json';
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-copied-package-json-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', packageName);
+    const packageJson = JSON.stringify({
+      name: packageName,
+      exports: { import: './dist/index.js', require: './dist/index.cjs' },
+    });
+    mkdirSync(path.join(packageDir, 'dist'), { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(path.join(packageDir, 'package.json'), packageJson);
+    writeFileSync(path.join(packageDir, 'dist/package.json'), packageJson);
+    writeFileSync(path.join(packageDir, 'dist/index.js'), 'export const esmOnly = true;');
+    writeFileSync(path.join(packageDir, 'dist/index.cjs'), 'module.exports = {};');
+
+    expect(getInstalledPackageEntry(packageName, { cwd: hostDir })).toBe(
+      path.join(packageDir, 'dist/index.js')
+    );
+  });
+
   it('preserves legacy package subpaths when ESM condition resolution is requested', () => {
     const packageName = 'mf-test-legacy-subpath';
     const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-legacy-subpath-'));

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -479,6 +479,7 @@ function resolveInstalledPackageJson(
 
     let currentDir = path.dirname(resolvedPath);
     const rootDir = path.parse(currentDir).root;
+    let matchingPackage: InstalledPackageJson | undefined;
 
     while (true) {
       const packageJsonPath = path.join(currentDir, 'package.json');
@@ -487,11 +488,13 @@ function resolveInstalledPackageJson(
         try {
           const packageJson = JSON.parse(packageJsonContent) as Record<string, unknown>;
           if (packageJson.name === packageName) {
-            return {
+            const packageInfo = {
               path: packageJsonPath,
               dir: currentDir,
               packageJson,
             };
+            if (currentDir.endsWith(path.join('node_modules', packageName))) return packageInfo;
+            matchingPackage ??= packageInfo;
           }
         } catch (error) {
           if (!(error instanceof SyntaxError)) throw error;
@@ -500,6 +503,7 @@ function resolveInstalledPackageJson(
       if (currentDir === rootDir) break;
       currentDir = path.dirname(currentDir);
     }
+    return matchingPackage;
   } catch {
     let currentDir = cwd;
     const rootDir = path.parse(currentDir).root;

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -715,6 +715,9 @@ export const buttonBase = 1;`;
     }
     if (filePath.endsWith('node_modules/mock-package-export-method-call/index.js')) {
       return [
+        'class BaseCreator {',
+        '  export(userParams) { return userParams; }',
+        '}',
         'const key = globalThis.crypto.subtle;',
         'export function toJwk() {',
         "  return key.export({ format: 'jwk' });",

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -790,6 +790,10 @@ function getNamedExportsViaRegex(
     }
     if (source[previousCodeIndex] === '.') continue;
 
+    let nextCodeIndex = match.index + match[0].length;
+    while (/\s/.test(source[nextCodeIndex] || '')) nextCodeIndex++;
+    if (source[nextCodeIndex] === '(') continue;
+
     scanState.complete = false;
     break;
   }


### PR DESCRIPTION
Closes #1187

Correctly detects named exports despite export(...) methods and nested package metadata.