### PR TITLE
fix: harden module import scanner

### DIFF
--- a/integration/fixtures/nested-remote-transitive/component.svelte
+++ b/integration/fixtures/nested-remote-transitive/component.svelte
@@ -1,0 +1,18 @@
+<script context="module">
+  import 'remoteA/module-setup';
+</script>
+
+<script lang="ts">
+  import { helper } from 'remoteA/shared/helpers';
+  export let label: string = helper;
+</script>
+
+<!-- import { fake } from 'remoteB/html-comment' -->
+<p>{label} import 'remoteB/template-only'</p>
+
+<style>
+  /* import 'remoteB/style-comment' */
+  p::before {
+    content: "import 'remoteB/css-string'";
+  }
+</style>

--- a/integration/fixtures/nested-remote-transitive/component.vue
+++ b/integration/fixtures/nested-remote-transitive/component.vue
@@ -1,0 +1,20 @@
+<template>
+  <p>import 'remoteB/template-only'</p>
+  <!-- import { fake } from 'remoteB/html-comment' -->
+</template>
+
+<script>
+import 'remoteA/module-setup';
+</script>
+
+<script setup lang="ts">
+import { helper } from 'remoteA/shared/helpers';
+defineProps<{ helper: typeof helper }>();
+</script>
+
+<style scoped>
+/* import 'remoteB/style-comment' */
+p::before {
+  content: "import 'remoteB/css-string'";
+}
+</style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ import {
   isAssetLikeImport,
   isViteOptimizableEntry,
 } from './utils/pathNormalization';
-import { findModuleImportDescriptors } from './utils/htmlEntryUtils';
+import { findModuleImportDescriptors, getScannableModuleSource } from './utils/htmlEntryUtils';
 import VirtualModule, { createViteEncodedIdPrefixRegExp } from './utils/VirtualModule';
 import {
   getHostAutoInitPath,
@@ -552,7 +552,7 @@ function registerEntryImports(
     const { file, preloadRemotes } = pending.pop()!;
     if (visited.get(file) || (visited.has(file) && !preloadRemotes)) continue;
     visited.set(file, preloadRemotes);
-    const code = readFileSync(file, 'utf8');
+    const code = getScannableModuleSource(file, readFileSync(file, 'utf8'));
     for (const { source: request, kind, typeOnly } of findModuleImportDescriptors(code)) {
       const isStatic = kind === 'static' && !typeOnly;
       const remoteKey =

--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -179,6 +179,47 @@ describe('pluginProxyRemoteEntry', () => {
     expect(resolvedSources).not.toContain('@graphql-typed-document-node/core');
   });
 
+  it.each(['component.vue', 'component.svelte'])(
+    'only scans script blocks of %s for remote dependencies',
+    async (component) => {
+      const expose = resolve(`integration/fixtures/nested-remote-transitive/${component}`);
+      const plugin = pluginProxyRemoteEntry({
+        options: getDefaultMockOptions({
+          exposes: { './component': { import: expose } as any },
+          remotes: {
+            remoteA: {
+              name: 'remoteA',
+              entry: 'http://localhost:3001/remoteEntry.js',
+              type: 'module',
+            },
+            remoteB: {
+              name: 'remoteB',
+              entry: 'http://localhost:3002/remoteEntry.js',
+              type: 'module',
+            },
+          },
+        }),
+        remoteEntryId: 'virtual:mf-remote-entry',
+        virtualExposesId: 'virtual:mf-exposes',
+      });
+      const context = {
+        resolve: async (source: string) => (source === expose ? { id: expose } : undefined),
+      } as any;
+
+      callHook(
+        plugin.config,
+        {} as ConfigPluginContext,
+        {},
+        { command: 'serve', mode: 'development' }
+      );
+      const generated = await callHook(plugin.load, context, 'virtual:mf-exposes');
+
+      expect(generated).toContain('__loadRemote__remoteA_mf_1_shared_mf_1_helpers');
+      expect(generated).toContain('__loadRemote__remoteA_mf_1_module_mf_2_setup');
+      expect(generated).not.toContain('__loadRemote__remoteB');
+    }
+  );
+
   it('uses an inlined data-URL origin for dev host init in SSR/module-runner contexts, protocol relative fallback origin otherwise', async () => {
     normalizeModuleFederationOptions({ name: 'test' });
     const plugin = pluginProxyRemoteEntry({

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import { normalizePathForImport } from '../utils/buildPaths';
-import { findModuleImportDescriptors } from '../utils/htmlEntryUtils';
+import { findModuleImportDescriptors, getScannableModuleSource } from '../utils/htmlEntryUtils';
 import {
   addCssAssetsToAllExports,
   collectCssAssets,
@@ -105,7 +105,7 @@ export default function ({
 
     let code: string;
     try {
-      code = readFileSync(id, 'utf8');
+      code = getScannableModuleSource(id, readFileSync(id, 'utf8'));
     } catch {
       return [];
     }

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -264,6 +264,17 @@ describe('getScannableModuleSource', () => {
     }
   );
 
+  it('closes a script block at an end tag carrying whitespace or attributes', () => {
+    expect(
+      findModuleImportSources(
+        getScannableModuleSource(
+          '/src/App.svelte',
+          `<script>import 'remote/a';</script\t\n bar>\n<p>import 'remote/template'</p>\n<script>import 'remote/b';</script >`
+        )
+      )
+    ).toEqual(['remote/a', 'remote/b']);
+  });
+
   it('returns nothing for a component without script blocks', () => {
     expect(getScannableModuleSource('/src/App.vue', `<template><p>import 'x'</p></template>`)).toBe(
       ''

--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   findModuleImportDescriptors,
   findModuleImportSources,
+  getScannableModuleSource,
   injectEntryScript,
   rewriteEntryScripts,
   sanitizeDevEntryPath,
@@ -98,6 +99,139 @@ describe('findModuleImportDescriptors', () => {
     ]);
   });
 
+  it('does not let comments change the classification of an import', () => {
+    expect(
+      findModuleImportDescriptors(`
+        import type /* comment */, { value } from 'remote/runtime';
+        import { type/* comment */Foo } from 'remote/type';
+        import { value } from /* comment */ 'remote/comment-before-source';
+      `)
+    ).toEqual([
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/runtime',
+        typeOnly: false,
+      },
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/type',
+        typeOnly: true,
+      },
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/comment-before-source',
+        typeOnly: false,
+      },
+    ]);
+  });
+
+  it('does not span multiple statements when classifying re-exports', () => {
+    expect(
+      findModuleImportDescriptors(`
+        export type Local = string;
+        export { value } from 'remote/value';
+        import Legacy = require('remote/legacy');
+        import { other } from 'remote/other';
+        export * from 'remote/star';
+        export * as ns from 'remote/namespace';
+        export type * from 'remote/type-star';
+      `)
+    ).toEqual([
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/value',
+        typeOnly: false,
+      },
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/other',
+        typeOnly: false,
+      },
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/star',
+        typeOnly: false,
+      },
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/namespace',
+        typeOnly: false,
+      },
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/type-star',
+        typeOnly: true,
+      },
+      {
+        kind: 'dynamic',
+        syntax: 'require',
+        source: 'remote/legacy',
+        typeOnly: false,
+      },
+    ]);
+  });
+
+  it('does not invent imports from `from` inside strings or trailing comments', () => {
+    expect(
+      findModuleImportDescriptors(`
+        export const text = " from 'fake-package'";
+        export const value = 1; // from 'fake-package'
+        export const escaped = 'it\\'s'; import { real } from 'remote/real';
+      `)
+    ).toEqual([
+      {
+        kind: 'static',
+        syntax: 'import',
+        source: 'remote/real',
+        typeOnly: false,
+      },
+    ]);
+  });
+
+  it('finds dynamic imports with options or comments before the source', () => {
+    expect(
+      findModuleImportDescriptors(`
+        import('remote/json', { with: { type: 'json' } });
+        import /* comment */ ('remote/commented');
+      `)
+    ).toEqual([
+      {
+        kind: 'dynamic',
+        syntax: 'import',
+        source: 'remote/json',
+        typeOnly: false,
+      },
+      {
+        kind: 'dynamic',
+        syntax: 'import',
+        source: 'remote/commented',
+        typeOnly: false,
+      },
+    ]);
+  });
+
+  it('finds imports in minified code without whitespace', () => {
+    expect(
+      findModuleImportDescriptors(
+        `import{a}from"remote/a";import*as b from"remote/b";export{c}from"remote/c";export*from"remote/d";import"remote/e";import("remote/f")`
+      ).map(({ source }) => source)
+    ).toEqual(['remote/a', 'remote/b', 'remote/c', 'remote/d', 'remote/f', 'remote/e']);
+  });
+
+  it('ignores member accesses named import or require', () => {
+    expect(
+      findModuleImportDescriptors(`loader.import('remote/member'); ctx.require('remote/member');`)
+    ).toEqual([]);
+  });
+
   it('ignores import-looking text in comments and strings', () => {
     expect(
       findModuleImportDescriptors(`
@@ -107,6 +241,33 @@ describe('findModuleImportDescriptors', () => {
         import 'remote/real';
       `)
     ).toEqual([{ kind: 'static', syntax: 'import', source: 'remote/real', typeOnly: false }]);
+  });
+});
+
+describe('getScannableModuleSource', () => {
+  it('returns plain modules unchanged', () => {
+    const code = `import 'remote/plain';`;
+    expect(getScannableModuleSource('/src/entry.ts', code)).toBe(code);
+  });
+
+  it.each(['/src/App.vue', '/src/App.svelte', '/src/App.vue?vue&type=script'])(
+    'only scans script blocks of %s',
+    (id) => {
+      const source = getScannableModuleSource(
+        id,
+        `<template><p>import 'remote/template'</p><!-- import 'remote/html-comment' --></template>
+<script setup lang="ts">import { a } from 'remote/setup';</script>
+<script>import 'remote/plain';</script>
+<style>/* import 'remote/style' */ .x { content: "import 'remote/css'" }</style>`
+      );
+      expect(findModuleImportSources(source)).toEqual(['remote/setup', 'remote/plain']);
+    }
+  );
+
+  it('returns nothing for a component without script blocks', () => {
+    expect(getScannableModuleSource('/src/App.vue', `<template><p>import 'x'</p></template>`)).toBe(
+      ''
+    );
   });
 });
 

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -138,7 +138,7 @@ export function findModuleImportDescriptors(code: string): ModuleImportDescripto
 export function getScannableModuleSource(id: string, code: string): string {
   if (!/\.(?:vue|svelte)(?:\?|$)/.test(id)) return code;
   const blocks: string[] = [];
-  for (const match of code.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script\s*>/gi)) {
+  for (const match of code.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script(?:\s[^>]*)?>/gi)) {
     blocks.push(match[1]);
   }
   return blocks.join('\n');

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -7,15 +7,65 @@ export interface ModuleImportDescriptor {
   typeOnly: boolean;
 }
 
-function isTypeOnlyClause(clause: string): boolean {
-  const normalized = clause.trim();
-  const declarationTypeOnly = normalized.match(/^type\b([\s\S]*)$/)?.[1].trim();
-  if (declarationTypeOnly !== undefined) {
-    return declarationTypeOnly.length > 0 && !declarationTypeOnly.startsWith(',');
-  }
+const IDENTIFIER = String.raw`[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*`;
+const NAMED_SPECIFIERS = String.raw`\{[^{}]*\}`;
+const NAMESPACE_SPECIFIER = String.raw`\*\s*as\s+${IDENTIFIER}`;
+const IMPORT_CLAUSE = String.raw`(?:(?<importType>type)\s+)?(?<importClause>${NAMESPACE_SPECIFIER}|${NAMED_SPECIFIERS}|${IDENTIFIER}(?:\s*,\s*(?:${NAMESPACE_SPECIFIER}|${NAMED_SPECIFIERS}))?)`;
+const EXPORT_CLAUSE = String.raw`(?:(?<exportType>type)\s+)?(?<exportClause>\*(?:\s*as\s+(?:${IDENTIFIER}|"[^"]*"|'[^']*'))?|${NAMED_SPECIFIERS})`;
+const SPECIFIER = String.raw`(?<quote>["'])(?<source>[^"'\r\n]*)\k<quote>`;
+// `import`/`require` preceded by `.`, `$`, or a word char is a member access or
+// part of a longer identifier, not the keyword.
+const KEYWORD_BOUNDARY = String.raw`(?<![.$\w])`;
 
-  const namedSpecifiers = normalized.match(/^\{([\s\S]*)\}$/)?.[1];
-  if (!namedSpecifiers) return false;
+// Whitespace after the keyword is optional when a `{` or `*` follows (minified code).
+const KEYWORD_GAP = String.raw`(?:\s+|(?=[{*]))`;
+
+const STATIC_PATTERN = new RegExp(
+  String.raw`${KEYWORD_BOUNDARY}(?:import${KEYWORD_GAP}${IMPORT_CLAUSE}|export${KEYWORD_GAP}${EXPORT_CLAUSE})\s*from\s*${SPECIFIER}`,
+  'gud'
+);
+const DYNAMIC_PATTERN = new RegExp(
+  String.raw`${KEYWORD_BOUNDARY}import\s*\(\s*${SPECIFIER}`,
+  'gud'
+);
+const REQUIRE_PATTERN = new RegExp(
+  String.raw`${KEYWORD_BOUNDARY}require\s*\(\s*${SPECIFIER}\s*\)`,
+  'gud'
+);
+const SIDE_EFFECT_PATTERN = new RegExp(String.raw`${KEYWORD_BOUNDARY}import\s*${SPECIFIER}`, 'gud');
+
+/**
+ * Returns `code` with every non-code region blanked out to spaces so that
+ * regexes can run against real syntax only. String literals keep their
+ * delimiters (with a blank interior) so import specifiers stay locatable;
+ * comments, template literals, and regular expressions vanish entirely.
+ * The result has the same length as `code`, so match indices map back 1:1.
+ */
+function blankNonCode(code: string): string {
+  const codePositions = createCodePositionMap(code);
+  const chars = code.split('');
+  let index = 0;
+  while (index < code.length) {
+    if (codePositions[index]) {
+      index++;
+      continue;
+    }
+    const start = index;
+    while (index < code.length && !codePositions[index]) index++;
+    const quote = code[start];
+    const isString =
+      (quote === '"' || quote === "'") && index - start >= 2 && code[index - 1] === quote;
+    for (let position = start; position < index; position++) {
+      const keep = isString && (position === start || position === index - 1);
+      chars[position] = keep ? quote : code[position] === '\n' ? '\n' : ' ';
+    }
+  }
+  return chars.join('');
+}
+
+function isTypeOnlyNamedClause(clause: string): boolean {
+  const namedSpecifiers = clause.trim().match(/^\{([\s\S]*)\}$/)?.[1];
+  if (namedSpecifiers === undefined) return false;
 
   const specifiers = namedSpecifiers
     .split(',')
@@ -30,49 +80,68 @@ function isTypeOnlyClause(clause: string): boolean {
   );
 }
 
+function readSource(code: string, match: RegExpMatchArray): string | undefined {
+  const range = match.indices?.groups?.source;
+  if (!range) return undefined;
+  const source = code.slice(range[0], range[1]);
+  return source.length > 0 ? source : undefined;
+}
+
 /**
  * Finds module imports while ignoring comments, strings, and regular expressions.
  * The descriptor keeps enough information for callers to distinguish runtime
  * static imports from type-only imports without introducing a parser dependency.
+ *
+ * Matching runs against a blanked copy of the code (see `blankNonCode`), so an
+ * `import` inside a comment or string can never match, comments inside a
+ * statement never change its classification, and a clause can never span
+ * multiple statements.
  */
 export function findModuleImportDescriptors(code: string): ModuleImportDescriptor[] {
-  const codePositions = createCodePositionMap(code);
+  const blanked = blankNonCode(code);
   const descriptors: ModuleImportDescriptor[] = [];
-  const staticFromPattern = /\b(?:import|export)\s+([\s\S]*?)\s+from\s*(["'])([^"']+)\2/g;
-  const dynamicPattern = /\bimport\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*)?(["'])([^"']+)\1\s*\)/g;
-  const requirePattern = /\brequire\s*\(\s*(["'])([^"']+)\1\s*\)/g;
-  const sideEffectPattern = /\bimport\s*(["'])([^"']+)\1/g;
 
-  let match: RegExpExecArray | null;
-  while ((match = staticFromPattern.exec(code))) {
-    if (!codePositions[match.index!]) {
-      staticFromPattern.lastIndex = match.index! + 1;
-      continue;
-    }
-    descriptors.push({
-      kind: 'static',
-      syntax: 'import',
-      source: match[3],
-      typeOnly: isTypeOnlyClause(match[1]),
-    });
+  for (const match of blanked.matchAll(STATIC_PATTERN)) {
+    const source = readSource(code, match);
+    if (!source) continue;
+    const groups = match.groups!;
+    const typeOnly =
+      groups.importType !== undefined ||
+      groups.exportType !== undefined ||
+      isTypeOnlyNamedClause(groups.importClause ?? groups.exportClause ?? '');
+    descriptors.push({ kind: 'static', syntax: 'import', source, typeOnly });
   }
 
-  for (const match of code.matchAll(dynamicPattern)) {
-    if (!codePositions[match.index!]) continue;
-    descriptors.push({ kind: 'dynamic', syntax: 'import', source: match[2], typeOnly: false });
+  for (const match of blanked.matchAll(DYNAMIC_PATTERN)) {
+    const source = readSource(code, match);
+    if (source) descriptors.push({ kind: 'dynamic', syntax: 'import', source, typeOnly: false });
   }
 
-  for (const match of code.matchAll(requirePattern)) {
-    if (!codePositions[match.index!]) continue;
-    descriptors.push({ kind: 'dynamic', syntax: 'require', source: match[2], typeOnly: false });
+  for (const match of blanked.matchAll(REQUIRE_PATTERN)) {
+    const source = readSource(code, match);
+    if (source) descriptors.push({ kind: 'dynamic', syntax: 'require', source, typeOnly: false });
   }
 
-  for (const match of code.matchAll(sideEffectPattern)) {
-    if (!codePositions[match.index!]) continue;
-    descriptors.push({ kind: 'static', syntax: 'import', source: match[2], typeOnly: false });
+  for (const match of blanked.matchAll(SIDE_EFFECT_PATTERN)) {
+    const source = readSource(code, match);
+    if (source) descriptors.push({ kind: 'static', syntax: 'import', source, typeOnly: false });
   }
 
   return descriptors;
+}
+
+/**
+ * Returns the JavaScript/TypeScript portion of a module for import scanning.
+ * Vue and Svelte single-file components only contribute their `<script>`
+ * blocks so template markup and styles are never misread as code.
+ */
+export function getScannableModuleSource(id: string, code: string): string {
+  if (!/\.(?:vue|svelte)(?:\?|$)/.test(id)) return code;
+  const blocks: string[] = [];
+  for (const match of code.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script\s*>/gi)) {
+    blocks.push(match[1]);
+  }
+  return blocks.join('\n');
 }
 
 export function findModuleImportSources(code: string): string[] {


### PR DESCRIPTION
Follow-up to #1186. 

findModuleImportDescriptors now runs against a blanked copy of the source (comments, strings, regexes, templates removed) and matches import/export clauses with a real grammar instead of [\s\S]*?. Fixes the cases reported in the review: comments flipping type-only classification, clauses spanning statements, fake imports from strings/comments, missed dynamic imports with options or comments, and obj.import(...) false positives. .vue/.svelte files now contribute only their <script> blocks to import scanning.