### PR TITLE
fix: handle Cyclic Shared Package Initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import pluginProxyRemotes from './plugins/pluginProxyRemotes';
 import {
   excludeSharedSubDependencies,
   findSharedKey,
+  getSharedPackageFromFile,
+  isSharedPackageDependency,
   proxySharedModule,
 } from './plugins/pluginProxySharedModule_preBuild';
 import { pluginRemoteNamedExports } from './plugins/pluginRemoteNamedExports';
@@ -691,6 +693,14 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                 if (isSharedResolverInternalImporter(importer)) return;
                 const key = findSharedKey(source, shared);
                 if (!key) return;
+                const importerPackage = getSharedPackageFromFile(importer, shared, root);
+                const reactDomSelfReference = isReactDomSelfReference(source, importer);
+                if (
+                  !reactDomSelfReference &&
+                  (importerPackage === getPackageName(key) ||
+                    (importerPackage && isSharedPackageDependency(key, importerPackage)))
+                )
+                  return;
                 if (isAssetLikeImport(source)) return;
                 const shareItem = shared[key];
                 const isReactSingleton =
@@ -744,11 +754,13 @@ function createEarlyVirtualModulesPlugin(options: NormalizedModuleFederationOpti
                   if (isSharedResolverInternalImporter(args.importer)) return;
                   const key = findSharedKey(args.path, shared);
                   if (!key || isAssetLikeImport(args.path)) return;
+                  const importerPackage = getSharedPackageFromFile(args.importer, shared, root);
                   if (
-                    getPackageNameFromNodeModulePath(args.importer) === getPackageName(args.path) &&
+                    importerPackage === getPackageName(args.path) &&
                     !isReactDomSelfReference(args.path, args.importer)
                   )
                     return;
+                  if (importerPackage && isSharedPackageDependency(key, importerPackage)) return;
                   addUsedShares(args.path, options);
                   if (args.kind === 'import-statement' || args.kind === 'dynamic-import') {
                     const shareItem = shared[key];

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1131,6 +1131,46 @@ describe('pluginProxySharedModule_preBuild', () => {
     readFileSyncMock.mockReset().mockReturnValue('{}');
   });
 
+  it('does not proxy shared dependency cycle edges from workspace packages', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'react' ? '/repo/packages/react/index.js' : undefined
+    );
+    existsSyncMock.mockImplementation(
+      (p: string) => p === '/repo/apps/remote/node_modules/vue/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) =>
+      p.endsWith('/vue/package.json') ? '{"dependencies":{"react":"1"}}' : '{}'
+    );
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/react/internal.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
   it('does not proxy internal imports for wildcard shared package keys during build', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -262,9 +262,40 @@ export function excludeSharedSubDependencies(shared: NormalizedShared): void {
 }
 
 const sharedDependencyCache = new Map<string, Set<string>>();
+const sharedPackageDirectoryCache = new WeakMap<
+  NormalizedShared,
+  { cwd: string; entries: Map<string, string> }
+>();
+
+export function getSharedPackageFromFile(
+  importer: string | undefined,
+  shared: NormalizedShared,
+  cwd = getPackageDetectionCwd()
+): string | undefined {
+  if (!importer) return;
+  const nodeModulePackage = getPackageNameFromNodeModulePath(importer);
+  if (nodeModulePackage) return nodeModulePackage;
+  let cached = sharedPackageDirectoryCache.get(shared);
+  if (!cached || cached.cwd !== cwd) {
+    const entries = new Map<string, string>();
+    for (const key of Object.keys(shared)) {
+      const packageName = getPackageName(key);
+      const entry = getInstalledPackageEntry(packageName, { cwd });
+      if (entry && !isNodeModulePath(entry)) {
+        entries.set(path.dirname(normalizePathForImport(entry)), packageName);
+      }
+    }
+    cached = { cwd, entries };
+    sharedPackageDirectoryCache.set(shared, cached);
+  }
+  const normalizedImporter = normalizePathForImport(importer);
+  return [...cached.entries].find(
+    ([dir]) => normalizedImporter === dir || normalizedImporter.startsWith(`${dir}/`)
+  )?.[1];
+}
 
 /** Whether `dependency` is reachable through the shared package's manifest dependencies. */
-function isSharedPackageDependency(sharedKey: string, dependency: string) {
+export function isSharedPackageDependency(sharedKey: string, dependency: string) {
   const sharedPackage = getPackageName(sharedKey);
   let reachable = sharedDependencyCache.get(sharedPackage);
   if (!reachable) {
@@ -436,7 +467,6 @@ export function proxySharedModule(options: {
         _command = command;
         useRolldown = isRolldown;
         useDirectReactImport = isVinext || isAstro;
-
         if (command === 'serve') {
           excludeSharedSubDependencies(shared);
         }
@@ -580,7 +610,7 @@ export function proxySharedModule(options: {
         // A shared package's own files must keep ordinary internal module edges.
         // Compare package roots because `key` may be an explicit subpath or a
         // trailing-slash wildcard share key.
-        const importerPackage = importer ? getPackageNameFromNodeModulePath(importer) : undefined;
+        const importerPackage = getSharedPackageFromFile(importer, shared);
         if (importerPackage === getPackageName(key)) return;
         // A dependency of the shared package that imports it back (a package-level
         // cycle) keeps its ordinary edge too. Proxying it would place the loadShare


### PR DESCRIPTION
Closes #1192

Preserves normal imports across shared dependency cycles, preventing initialization errors in development and production.