### PR TITLE
fix: fix Deferred Singleton Initialization Ordering

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -428,6 +428,19 @@ vi.mock('../../utils/packageUtils', () => ({
         },
       };
     }
+    if (pkg === 'runtime-consumer') {
+      return {
+        path: '/repo/apps/remote/node_modules/runtime-consumer/package.json',
+        dir: '/repo/apps/remote/node_modules/runtime-consumer',
+        packageJson: {
+          name: 'runtime-consumer',
+          dependencies: {
+            '@module-federation/enhanced': '^2.9.0',
+            react: '^19.0.0',
+          },
+        },
+      };
+    }
   }),
   getPackageName: (packageString: string) => {
     const match = packageString.match(/^(?:@[^/]+\/)?[^/]+/);
@@ -3476,6 +3489,37 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).not.toContain('import * as __mfLocalShare');
     expect(generatedCode).toContain('initPromise.then');
     expect(generatedCode).toContain('import("mock-import-id").then((mod) => {');
+    expect(generatedCode).not.toContain('await ');
+  });
+
+  it('uses eager fallback for peer-consumed singletons in remote builds', () => {
+    normalizeModuleFederationOptions({
+      name: 'remote',
+      exposes: { './App': './src/App.jsx' },
+      shared: {
+        react: { singleton: true },
+        'runtime-consumer': { singleton: true },
+      },
+    });
+    const pkg = 'react';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '19.2.4',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^19.2.4',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    expect(generatedCode).toContain('import * as __mfLocalShare from "mock-import-id";');
+    expect(generatedCode).toContain('__mfApplySharedDefaultExport(exportModule);');
+    expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).not.toContain('await ');
   });
 

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1032,13 +1032,15 @@ function getDependencyNames(packageJson: Record<string, unknown> | undefined) {
 
 function isSharedSingletonConsumedByPeer(
   pkg: string,
-  options: NormalizedModuleFederationOptions = getNormalizeModuleFederationOptions()
+  options: NormalizedModuleFederationOptions = getNormalizeModuleFederationOptions(),
+  requireFederationRuntimeDependency = false
 ) {
   const shared = options?.shared || {};
   // Subpath shares (for example `preact/hooks`) execute against their package
   // root during module evaluation. Keep the root singleton eager so that the
   // subpath cannot observe an as-yet-uninitialised lazy namespace.
   if (
+    !requireFederationRuntimeDependency &&
     Object.entries(shared).some(
       ([key, item]) =>
         key !== pkg && key.startsWith(`${pkg}/`) && item.shareConfig.singleton === true
@@ -1064,15 +1066,28 @@ function isSharedSingletonConsumedByPeer(
   // cache, leaving the consumer's top-level read of `pkg`'s bindings undefined.
   // This covers both cyclic graphs and acyclic ones where a package is shared
   // together with one of its subpath exports (see issue #823).
-  const reachesPkg = (current: string, seen: Set<string>): boolean => {
+  const reachesPkg = (
+    current: string,
+    seen: Set<string>,
+    hasFederationRuntimeDependency = false
+  ): boolean => {
     const packageJson = getSharedDependencyGraphPackageJson(current);
-    for (const dependency of getDependencyNames(packageJson)) {
+    const dependencies = getDependencyNames(packageJson);
+    const usesFederationRuntime = dependencies.some(
+      (dependency) =>
+        dependency === '@module-federation/enhanced' ||
+        dependency === '@module-federation/runtime' ||
+        dependency === '@module-federation/runtime-core'
+    );
+    const runtimeIsReachable = hasFederationRuntimeDependency || usesFederationRuntime;
+    for (const dependency of dependencies) {
       const sharedDependency = sharedKeyByPackageName.get(dependency);
       if (!sharedDependency) continue;
-      if (sharedDependency === pkg) return true;
+      if (sharedDependency === pkg)
+        return !requireFederationRuntimeDependency || runtimeIsReachable;
       if (seen.has(sharedDependency)) continue;
       seen.add(sharedDependency);
-      if (reachesPkg(sharedDependency, seen)) return true;
+      if (reachesPkg(sharedDependency, seen, runtimeIsReachable)) return true;
     }
     return false;
   };
@@ -2023,7 +2038,8 @@ export function writeLoadShareModule(
         shareItem.shareConfig.singleton === true) ||
       (command === 'build' &&
         isRemoteOnlyContainer(resolvedOptions) &&
-        (shareItem.shareConfig.singleton === true || isDefaultShareScope)));
+        (shareItem.shareConfig.singleton === true || isDefaultShareScope) &&
+        !isSharedSingletonConsumedByPeer(pkg, resolvedOptions, true)));
   const servesRemoteSingletonFallback =
     command !== 'build' &&
     isRemoteOnlyContainer(resolvedOptions) &&


### PR DESCRIPTION
Close #1196

Preserves deferred fallbacks while eagerly initializing runtime-linked singleton dependencies.
 