### PR TITLE
fix: end type arguments at a line break in semicolon-less code

### DIFF
--- a/src/utils/__tests__/typeArgumentScanner.test.ts
+++ b/src/utils/__tests__/typeArgumentScanner.test.ts
@@ -27,6 +27,14 @@ describe('findLikelyTypeArgumentEnd', () => {
     );
   });
 
+  it.each([
+    ["type Shape = Pick<Options, 'onClick'>\nconst later = 1", "<Options, 'onClick'>"],
+    ['let registry: Map<string, number>\nregistry = new Map()', '<string, number>'],
+    ['const registry = new WeakMap<object, any> // comment\nconst later = 1', '<object, any>'],
+  ])('ends the range at a line break in semicolon-less %s', (source, expected) => {
+    expect(findTypeArgumentRange(source)).toBe(expected);
+  });
+
   it('finds nested type arguments in a TypeScript angle-bracket assertion', () => {
     expect(findTypeArgumentRange('const registry = <Map<object, any>>new Map();')).toBe(
       '<Map<object, any>>'

--- a/src/utils/typeArgumentScanner.ts
+++ b/src/utils/typeArgumentScanner.ts
@@ -62,6 +62,9 @@ function hasLikelyTypeArgumentFollower(
   let next = end + 1;
   while (next < source.length && (!codePositions[next] || /\s/.test(source[next]))) next++;
   if (next >= source.length || /[([.!?=;,)\]}:|&]/.test(source[next])) return true;
+  // A line break after `>` ends the statement in semicolon-less code: `a < b, c >` followed by a
+  // new line cannot continue a declarator list, so the range can only be type arguments.
+  if (source.slice(end + 1, next).includes('\n')) return true;
 
   const followingToken = source
     .slice(next)

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -632,6 +632,9 @@ export const createThing = factory<Result, Options>()
 export const nestedRegistry: Map<string, WeakMap<object, any>> = new Map();
 export const identity = <T = string, U = number>(value: T) => value;
 export const assertedRegistry = <Map<object, any>>new Map(), secondaryRegistry = new Map()
+type Shape = Pick<Options, 'onClick'>
+let registry: Map<string, number>
+registry = new Map()
 export function pick<
   T extends string,
   R = T,


### PR DESCRIPTION
## Description

Fixes #1198. Follow-up to #1195.

When plain code follows a semicolon-less `export const`, `getAdditionalTopLevelDeclaratorNames` keeps lexing into it and asks `findLikelyTypeArgumentEnd` about every `<`. `hasLikelyTypeArgumentFollower` only accepted `(`, `=`, `.`, `as`, `satisfies` and a few punctuation characters after the closing `>`, so a `<…, …>` range that ends a line — `type Shape = Pick<Options, 'onClick'>`, `let registry: Map<string, number>` — was read as a comparison. The `,` inside then became a declarator separator: `'onClick'` fails the identifier check and the whole export list is dropped (`scanState.complete = false`), while `number` passes it and is emitted as a phantom export.

A line break after `>` is a safe terminator: in semicolon-less code `a < b, c >` followed by a new line cannot continue a declarator list, so the range can only be type arguments.

## Changes

- `typeArgumentScanner.ts`: treat a line break between the closing `>` and the next code token as a valid follower.
- `typeArgumentScanner.test.ts`: three semicolon-less line-break cases (string-literal type argument, annotated `let`, trailing line comment).
- `virtualShared_preBuild.test.ts`: the `generic-initializer` mock now has a `type` alias and an annotated `let` between two exported declarations; the existing expectation (exports stay live, no `export *` fallback) covers both symptoms.

## Verification

- `pnpm test`: all green except the pre-existing macOS `/private/var` realpath failure in `packageUtils.test.ts`, which fails identically on `main`.
- Repro repo https://github.com/marksnode/mf-vite-repro-scanner: on `main` (c030ee2) `broken-lib-ts-alias` bails and `broken-lib-ts-phantom` exports `number`; with this branch all four libs report CLEAN.
- Our monorepo (6 571 source files scanned with the extracted scanner): 3 → 0 bailing files of this class.