### PR TITLE
fix: ignore members named export in object and type literals

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -552,6 +552,7 @@ vi.mock('fs', () => ({
       filePath.endsWith('/repo/packages/typed-destructuring.ts') ||
       filePath.endsWith('/repo/packages/decorated-export.ts') ||
       filePath.endsWith('/repo/packages/export-import-alias.ts') ||
+      filePath.endsWith('/repo/packages/export-property-key.ts') ||
       filePath.endsWith('/repo/packages/custom-shared-source/index.ts') ||
       filePath.endsWith('/repo/packages/cached-shared-source/index.ts') ||
       filePath.endsWith('/repo/packages/cached-shared-source/leaf.ts')
@@ -575,6 +576,14 @@ export default function createDefaultOnly() {}`;
 export interface Shape { value: string }
 export declare const declaredOnly: string;
 export default function createDefaultOnly() {}`;
+    }
+    if (filePath.endsWith('/repo/packages/export-property-key.ts')) {
+      return `export const messages = {
+  export: () => 'Export',
+  'import': () => 'Import',
+}
+type Options = { export?: boolean; import ?: boolean }
+export const visible = 2`;
     }
     if (filePath.endsWith('/repo/packages/default-only-export-lookalikes.js')) {
       return `// export*from"./comment.js";
@@ -1818,6 +1827,29 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(`export * from ${JSON.stringify(importPath)}`);
     expect(generatedCode).not.toContain('__mfApplySharedDefaultExport');
     expect(generatedCode).not.toContain('__mfSubscribeSharedCache(__mfModuleCache.share');
+  });
+
+  it('ignores members named export in object and type literals', () => {
+    const pkg = 'mock-package-with-reserved';
+    const mockShareItem: ShareItem = {
+      name: pkg,
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        import: '/repo/packages/export-property-key.ts',
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule(pkg, mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+
+    expectLiveSingletonProxy(generatedCode, pkg, ['messages', 'visible']);
+    expect(generatedCode).not.toContain('export * from "/repo/packages/export-property-key.ts"');
   });
 
   it('ignores unmatched export syntax in comments, strings, and regular expressions', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -806,6 +806,14 @@ function getNamedExportsViaRegex(
     while (/\s/.test(source[nextCodeIndex] || '')) nextCodeIndex++;
     if (source[nextCodeIndex] === '(') continue;
 
+    // A property named `export` in an object or type literal (`export:`, `export?:`) is not one either.
+    let memberIndex = nextCodeIndex;
+    if (source[memberIndex] === '?') {
+      memberIndex++;
+      while (/\s/.test(source[memberIndex] || '')) memberIndex++;
+    }
+    if (source[memberIndex] === ':') continue;
+
     scanState.complete = false;
     break;
   }


### PR DESCRIPTION
## Description

Fixes #1200. Independent from #1199 (both branch off `main`).

The final catch-all in `getNamedExportsViaRegex` walks every `\bexport\b` that no earlier regex claimed and fails closed unless the keyword is preceded by `.` or followed by `(`. A property named `export` — `{ export: () => 'Export' }` in an object literal, `{ export?: boolean }` in a type literal — is neither, so the module was treated as having an unrecognised export form and lost its whole export list (glue fell back to `export * from` the local copy, no live re-binding).

`export` is a reserved word, so a bare property key is the only place it can legally appear besides `obj.export` (already skipped); `export` followed by `:` or `?:` can never start an export declaration.

## Changes

- `virtualShared_preBuild.ts`: in the catch-all, also skip the keyword when the next code character is `:`, or `?` followed by `:`.
- `virtualShared_preBuild.test.ts`: new `export-property-key.ts` mock (object literal with `export:` and `'import':` members, type literal with `export?:` / `import ?:`) and a test asserting the live singleton proxy with `messages`, `visible` and no `export *` fallback. Red before the fix, green after.

## Verification

- `pnpm test`: all green except the pre-existing macOS `/private/var` realpath failure in `packageUtils.test.ts` (fails identically on `main`).
- Repro https://github.com/marksnode/mf-vite-repro-scanner (`broken-lib-ts-export-key`): SCANNER BAILED on `main` c030ee2 → CLEAN SCAN with this branch.
- Two i18n message tables in our monorepo (`{ export: () => 'Export' as const, … }`) scan cleanly with this branch.