### PR TITLE
fix: keep walking shared dependency cycles past unresolvable dependencies

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1171,6 +1171,53 @@ describe('pluginProxySharedModule_preBuild', () => {
     readFileSyncMock.mockReset().mockReturnValue('{}');
   });
 
+  it('keeps walking the dependency tree past an unresolvable optional peer when detecting cycles', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'react' ? '/repo/packages/react/index.js' : undefined
+    );
+    // vue -> (react-native: optional peer, not installed) -> forms -> react: the cycle closes through forms
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/vue/package.json' ||
+        p === '/repo/apps/remote/node_modules/forms/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('/vue/package.json')) {
+        return '{"peerDependencies":{"react-native":"*","forms":"1"},"peerDependenciesMeta":{"react-native":{"optional":true}}}';
+      }
+      if (p.endsWith('/forms/package.json')) return '{"dependencies":{"react":"1"}}';
+      return '{}';
+    });
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/react/internal.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
   it('does not proxy internal imports for wildcard shared package keys during build', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -321,7 +321,10 @@ function getDependencyManifest(dep: string, fromDir: string): InstalledPackageJs
         found = {
           path: packageJsonPath,
           dir,
-          packageJson: JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as Record<string, unknown>,
+          packageJson: JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as Record<
+            string,
+            unknown
+          >,
         };
       } catch {
         // Unreadable manifest: fall through to the resolver below.

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync, realpathSync } from 'fs';
 import { createRequire } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL } from 'url';
@@ -21,6 +22,7 @@ import {
 import {
   getIsRolldown,
   getInstalledPackageJson,
+  type InstalledPackageJson,
   getInstalledPackageEntry,
   getPackageDetectionCwd,
   getPackageName,
@@ -294,6 +296,47 @@ export function getSharedPackageFromFile(
   )?.[1];
 }
 
+const dependencyManifestCache = new Map<string, InstalledPackageJson | undefined>();
+
+/**
+ * The manifest of `dep` as seen from `fromDir`: a plain `node_modules` walk-up first, because the
+ * cycle walk below visits every package in the tree and `getInstalledPackageJson`'s resolver is
+ * far too expensive for that many lookups; it stays the fallback for layouts the walk-up misses.
+ */
+function getDependencyManifest(dep: string, fromDir: string): InstalledPackageJson | undefined {
+  const cacheKey = `${fromDir}\0${dep}`;
+  if (dependencyManifestCache.has(cacheKey)) return dependencyManifestCache.get(cacheKey);
+  let found: InstalledPackageJson | undefined;
+  let currentDir = fromDir;
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'node_modules', dep, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      try {
+        let dir = path.dirname(packageJsonPath);
+        try {
+          dir = realpathSync(dir);
+        } catch {
+          // Keep the symlink path when it cannot be resolved.
+        }
+        found = {
+          path: packageJsonPath,
+          dir,
+          packageJson: JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as Record<string, unknown>,
+        };
+      } catch {
+        // Unreadable manifest: fall through to the resolver below.
+      }
+      break;
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+  found ??= getInstalledPackageJson(dep, { cwd: fromDir, packageName: dep });
+  dependencyManifestCache.set(cacheKey, found);
+  return found;
+}
+
 /** Whether `dependency` is reachable through the shared package's manifest dependencies. */
 export function isSharedPackageDependency(sharedKey: string, dependency: string) {
   const sharedPackage = getPackageName(sharedKey);
@@ -302,8 +345,10 @@ export function isSharedPackageDependency(sharedKey: string, dependency: string)
     reachable = new Set<string>();
     const visited = new Set<string>();
     const queue = [getInstalledPackageJson(sharedPackage, { packageName: sharedPackage })];
-    for (let installed = queue.shift(); installed; installed = queue.shift()) {
-      if (visited.has(installed.dir)) continue;
+    // An unresolvable dependency (an uninstalled optional peer, say) must not end the walk early.
+    while (queue.length) {
+      const installed = queue.shift();
+      if (!installed || visited.has(installed.dir)) continue;
       visited.add(installed.dir);
       const manifest = installed.packageJson as Record<string, Record<string, string> | undefined>;
       for (const dep of Object.keys({
@@ -312,7 +357,7 @@ export function isSharedPackageDependency(sharedKey: string, dependency: string)
         ...manifest.optionalDependencies,
       })) {
         reachable.add(dep);
-        queue.push(getInstalledPackageJson(dep, { cwd: installed.dir, packageName: dep }));
+        queue.push(getDependencyManifest(dep, installed.dir));
       }
     }
     sharedDependencyCache.set(sharedPackage, reachable);
@@ -461,6 +506,7 @@ export function proxySharedModule(options: {
         resetTreeShakingExports(federationOptions);
         emittedTreeShakingProviders.clear();
         sharedDependencyCache.clear();
+        dependencyManifestCache.clear();
         const isVinext = hasPackageDependency('vinext');
         const isAstro = hasPackageDependency('astro');
         const isRolldown = getIsRolldown(this);


### PR DESCRIPTION
## Description

Fixes #1202. Follow-up to #1192 / #1194.

`isSharedPackageDependency` decides whether an import between two shared packages is a cycle edge (left alone) or gets rewritten to `loadShare` glue. Its reachability walk was

```ts
for (let installed = queue.shift(); installed; installed = queue.shift()) {
```

so the first queued dependency without a resolvable `package.json` — in practice an optional / uninstalled `peerDependency` somewhere in the tree (`use-context-selector → react-native`, `@swc/core → @swc/helpers`, …) — ended the walk with the rest of the queue unexpanded. Cycle edges behind that point were rewritten to glue, the glue chunks imported each other through the fallbacks, rolldown merged them and the glue landed above its own fallback again (the #1192 failure).

## Changes

- `pluginProxySharedModule_preBuild.ts`: skip an unresolvable entry and keep walking (`while (queue.length) { … if (!installed || visited.has(installed.dir)) continue; … }`).
- `pluginProxySharedModule_preBuild.test.ts`: `vue → (react-native: optional peer, not installed) → forms → react`; the edge from the `react` workspace package to `vue` must not be proxied. Red before the fix, green after.

## Verification

- `pnpm test`: green except the pre-existing macOS `/private/var` realpath failure in `packageUtils.test.ts` (same on `main`).
- Repro https://github.com/marksnode/mf-vite-repro-share-cycle-missing-peer: on `main` (f5b16d4) the merged chunk is `GLUE(cases) -> FALLBACK(lib-utils) -> GLUE(utils) -> …` and the page dies with `Cannot read properties of undefined (reading 'caseTitle')`; with this branch it is `FALLBACK(…) x4 -> GLUE(ui)` and the page prints its results.
- Our monorepo (288 shared workspace packages): the walk was cut short for 226 of them and 323 cycle edges flipped to glue; with this branch none are cut short.