### PR TITLE
fix: declare exportModule once for eager workspace singletons

### DIFF
--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'fs';
+import { parseAst } from 'vite';
 import { normalizePathForImport } from '../../utils/buildPaths';
 import { getSharedExportConditions } from '../../utils/sharedExportConditions';
 import {
@@ -3743,6 +3744,9 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain('const __mfApplyEagerShareExports = (mod) => {');
     expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
     expect(generatedCode).not.toContain('initPromise.then');
+    // The eager export block declares `exportModule` itself; the module body must not declare it again.
+    expect(generatedCode.match(/\blet exportModule\b/g)).toHaveLength(1);
+    expect(() => parseAst(generatedCode)).not.toThrow();
   });
 
   it('does not treat parent package.json name mismatches as workspace package matches', () => {

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -2215,9 +2215,14 @@ export function writeLoadShareModule(
         ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});`
         : '';
 
-  const moduleBody =
-    usesDeferredSingletonFallback || usesDeferredTreeShakingFallback
-      ? `
+  // These export blocks declare `exportModule` themselves; the plain body must not declare it a second time.
+  const exportLineDeclaresModule =
+    usesDeferredSingletonFallback ||
+    usesDeferredTreeShakingFallback ||
+    usesEagerWorkspaceFallback ||
+    usesEntryInjectedRemoteFallback;
+  const moduleBody = exportLineDeclaresModule
+    ? `
     ${prebuildImportLine}
     ${devDynamicImportLine}
     ${importLine}

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -2230,7 +2230,7 @@ export function writeLoadShareModule(
     ${normalizeLocalShareModuleCode}
     ${exportLine}
   `
-      : `
+    : `
     ${prebuildImportLine}
     ${devDynamicImportLine}
     ${importLine}


### PR DESCRIPTION
## Description

Fixes #1204.

A workspace singleton with `shareConfig.eager: true` failed to build with `[PARSE_ERROR] Identifier \`exportModule\` has already been declared`. `generateEagerWorkspaceSingletonExports` (and the entry-injected remote fallback, which shares the generator) already declares `exportModule` in the export block, but `moduleBody` only left out its own declaration for the two deferred variants. Without `eager` a workspace singleton is also `usesDeferredSingletonFallback`, which hid the duplicate; `eager: true` clears that flag and both declarations end up in one module.

## Changes

- `virtualShared_preBuild.ts`: `exportLineDeclaresModule = usesDeferredSingletonFallback || usesDeferredTreeShakingFallback || usesEagerWorkspaceFallback || usesEntryInjectedRemoteFallback` decides which module body is emitted.
- `virtualShared_preBuild.test.ts`: the existing “emits eager local exports for an explicitly eager leaf workspace singleton” test now also asserts a single `let exportModule` and that the generated module parses (`parseAst`). Red before the fix, green after.

## Verification

- `pnpm test`: green except the pre-existing macOS `/private/var` realpath failure in `packageUtils.test.ts` (same on `main`).
- Repro https://github.com/marksnode/mf-vite-repro-eager-workspace-singleton: build fails on `main` (f5b16d4), succeeds with this branch, and `vite preview` prints `Button(): [button]` from a module-scope read.
- Our host with 213 eager workspace singletons: build 19.7 s, boots; the module-scope route table that previously captured `undefined` (React #130) now gets the synchronously bound export.