### PR TITLE
fix: keep cycle edges from unshared workspace packages off the loadShare glue

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1171,6 +1171,98 @@ describe('pluginProxySharedModule_preBuild', () => {
     readFileSyncMock.mockReset().mockReturnValue('{}');
   });
 
+  it('does not proxy shared dependency cycle edges from unshared workspace packages', async () => {
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'react' ? '/repo/packages/react/index.js' : undefined
+    );
+    // vue -> bridge -> vue: `bridge` is a workspace package that is not shared, so it gets inlined into vue's
+    // fallback. Its import of vue is a cycle edge exactly like one from a node_modules dependency.
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/vue/package.json' ||
+        p === '/repo/packages/bridge/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('/vue/package.json')) return '{"dependencies":{"bridge":"workspace:*"}}';
+      if (p.endsWith('/bridge/package.json')) return '{"name":"bridge"}';
+      return '{}';
+    });
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
+  it('still proxies imports from unshared workspace packages outside the shared package cycle', async () => {
+    normalizeModuleFederationOptions({ name: 'host', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'react' ? '/repo/packages/react/index.js' : undefined
+    );
+    // `widgets` is a workspace package vue does not depend on: no cycle, the import is proxied as usual.
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/vue/package.json' ||
+        p === '/repo/packages/widgets/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('/vue/package.json')) return '{"dependencies":{"react":"1"}}';
+      if (p.endsWith('/widgets/package.json')) return '{"name":"widgets"}';
+      return '{}';
+    });
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/widgets/src/panel.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeDefined();
+    expect(writeLoadShareModuleMock).toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+  });
+
   it('keeps walking the dependency tree past an unresolvable optional peer when detecting cycles', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
     getInstalledPackageEntryMock.mockImplementation((pkg) =>

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -291,9 +291,47 @@ export function getSharedPackageFromFile(
     sharedPackageDirectoryCache.set(shared, cached);
   }
   const normalizedImporter = normalizePathForImport(importer);
-  return [...cached.entries].find(
+  const sharedPackage = [...cached.entries].find(
     ([dir]) => normalizedImporter === dir || normalizedImporter.startsWith(`${dir}/`)
   )?.[1];
+  // A workspace package that is not shared still takes part in package-level cycles: its files get inlined
+  // into the fallback of the share that depends on it, so its import of another share must be judged
+  // the same way as an import from inside `node_modules` (which resolves to a package name above).
+  return sharedPackage ?? getWorkspacePackageNameFromFile(normalizedImporter);
+}
+
+const workspacePackageNameCache = new Map<string, string | undefined>();
+
+/** Name from the nearest `package.json` above `file`, for files outside `node_modules`. */
+function getWorkspacePackageNameFromFile(file: string): string | undefined {
+  const filePath = file.split('?')[0];
+  if (!path.isAbsolute(filePath) || isNodeModulePath(filePath)) return;
+  const visited: string[] = [];
+  let dir = path.dirname(filePath);
+  let name: string | undefined;
+  while (true) {
+    if (workspacePackageNameCache.has(dir)) {
+      name = workspacePackageNameCache.get(dir);
+      break;
+    }
+    visited.push(dir);
+    const manifestPath = path.join(dir, 'package.json');
+    if (existsSync(manifestPath)) {
+      try {
+        const manifestName = (JSON.parse(readFileSync(manifestPath, 'utf-8')) as { name?: unknown })
+          .name;
+        name = typeof manifestName === 'string' ? manifestName : undefined;
+      } catch {
+        name = undefined;
+      }
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  for (const visitedDir of visited) workspacePackageNameCache.set(visitedDir, name);
+  return name;
 }
 
 const dependencyManifestCache = new Map<string, InstalledPackageJson | undefined>();
@@ -510,6 +548,7 @@ export function proxySharedModule(options: {
         emittedTreeShakingProviders.clear();
         sharedDependencyCache.clear();
         dependencyManifestCache.clear();
+        workspacePackageNameCache.clear();
         const isVinext = hasPackageDependency('vinext');
         const isAstro = hasPackageDependency('astro');
         const isRolldown = getIsRolldown(this);


### PR DESCRIPTION
## Description

Fixes #1209. Follow-up to #1194 / #1203.

The shared-cycle guard in `proxyPreBuildShared:resolve-shared-loadShare` asks `getSharedPackageFromFile(importer, shared)` which package the importing file belongs to and then checks `isSharedPackageDependency(key, importerPackage)`. That lookup knew only `node_modules` files (any package) and files of *shared* workspace packages. A workspace package that sits in the cycle but is not shared — inlined into the fallback of the share that depends on it — came back as `undefined`, the guard was skipped, and its import of the share was rewritten to `loadShare` glue inside the share's own evaluation cycle: the #1192 hazard, now behind an asymmetry (the same import from an unshared `node_modules` dependency is kept direct).

In a 315-share monorepo host this put the eager `lib-ad-ui-kit` wrapper at position 50 of a 61-module merged chunk and its fallback at position 87 → `__mfApplyEagerShareExports(undefined)` → `TypeError: Cannot read properties of undefined (reading 'ChatSeparatorDate')`. Sharing the whole workspace closure was the only workaround.

## Changes

- `pluginProxySharedModule_preBuild.ts`
  - `getSharedPackageFromFile`: when the importer is neither in `node_modules` nor inside a shared package, return the `name` of the nearest `package.json` above it (`getWorkspacePackageNameFromFile`, cached per directory, cleared with the other caches). `isSharedPackageDependency` then decides exactly as for `node_modules` importers.
- `pluginProxySharedModule_preBuild.test.ts`
  - `does not proxy shared dependency cycle edges from unshared workspace packages` — `vue → bridge → vue` with `bridge` an unshared workspace package: the import from `/repo/packages/bridge/src/title.js` is not proxied. Fails on `main`.
  - `still proxies imports from unshared workspace packages outside the shared package cycle` — a workspace package the share does not depend on is proxied as before.

## Verification

- Repro https://github.com/marksnode/mf-vite-repro-cycle-guard-skips-unshared-workspace-importer: `npm run check` goes from `through the aaa-ui loadShare GLUE` to `directly from the aaa-ui fallback`.
- Monorepo host (315 shares): with this fix on top of #1208 it boots without the "share the whole closure" workaround (28 fewer shares) and without `eager: true`.
- `pnpm test`: 1190 passed; the one failure (`packageUtils > ignores copied package metadata beside the resolved entry`) also fails on untouched `main` on macOS (`/var` vs `/private/var` tmpdir realpath).