### PR TITLE
fix: inject federation init into attributed head tags

### DIFF
--- a/src/utils/__tests__/htmlEntryUtils.test.ts
+++ b/src/utils/__tests__/htmlEntryUtils.test.ts
@@ -354,6 +354,22 @@ describe('injectEntryScript', () => {
       `<head><script type="module" src="/__mf__virtual/hostAutoInit.js"></script>`
     );
   });
+
+  it.each(['<head lang="en">', '<HEAD>', '<head data-capo>'])(
+    'injects into a non-exact head tag (%s)',
+    (headTag) => {
+      const html = `<html>${headTag}</head><body></body></html>`;
+      const result = injectEntryScript(html, INIT_SRC);
+      expect(result).toContain(
+        `${headTag}<script type="module" src="/__mf__virtual/hostAutoInit.js"></script>`
+      );
+    }
+  );
+
+  it('does not treat a header element as a head tag', () => {
+    const html = '<html><header></header><body></body></html>';
+    expect(injectEntryScript(html, INIT_SRC)).toBe(html);
+  });
 });
 
 describe('sanitizeDevEntryPath', () => {

--- a/src/utils/htmlEntryUtils.ts
+++ b/src/utils/htmlEntryUtils.ts
@@ -185,5 +185,9 @@ export function rewriteEntryScripts(
 
 export function injectEntryScript(html: string, initSrc: string): string {
   const src = sanitizeDevEntryPath(initSrc);
-  return html.replace('<head>', `<head><script type="module" src=${JSON.stringify(src)}></script>`);
+  const script = `<script type="module" src=${JSON.stringify(src)}></script>`;
+  // Match the first `<head>` even when it has attributes or differs in case.
+  // `\b` keeps `<header>` from being treated as a head tag. The original tag
+  // is preserved so exact `<head>` still becomes `<head><script…>`.
+  return html.replace(/<head\b[^>]*>/i, (openTag) => `${openTag}${script}`);
 }


### PR DESCRIPTION
## Summary

Fallback `injectEntryScript` only matched exact `<head>`. Tags like `<head lang="en">` or `<HEAD>` left federation init out of the HTML.

## Fix

Case-insensitive match of the first `<head…>` tag, keep the original tag text, inject the module script after it. `<header>` is not treated as a head tag.

## Test plan

- [x] Unit tests for attributed / uppercase head
- [x] Exact `<head>` still becomes `<head><script…>`
