### PR TITLE
fix: serialize method shorthand and skip native functions in runtime options

### DIFF
--- a/src/utils/__tests__/serializeRuntimeOptions.test.ts
+++ b/src/utils/__tests__/serializeRuntimeOptions.test.ts
@@ -102,7 +102,7 @@ describe('generateRuntimePluginOption - safe JS literal', () => {
         return 1;
       },
     });
-    expect(code).toMatch(/"onError":\s*function\s+onError\s*\(/);
+    expect(code).toMatch(/"onError":\s*function\s*\(/);
     const evaluated = new Function(`return (${code});`)() as { onError: () => number };
     expect(evaluated.onError()).toBe(1);
   });
@@ -114,5 +114,27 @@ describe('generateRuntimePluginOption - safe JS literal', () => {
     expect(code).toBe('{"parse": undefined}');
     expect(() => new Function(`return (${code});`)()).not.toThrow();
     expect(new Function(`return (${code});`)().parse).toBeUndefined();
+  });
+
+  it('serializes reserved-word method names without emitting invalid function names', () => {
+    const code = serializeRuntimeOptions({
+      default() {
+        return 1;
+      },
+    });
+    const evaluated = new Function(`return (${code});`)() as { default: () => number };
+    expect(evaluated.default()).toBe(1);
+  });
+
+  it('skips computed method names instead of emitting invalid JavaScript', () => {
+    const hook = 'onError';
+    const options = {
+      [hook]() {
+        return 1;
+      },
+    };
+    const code = serializeRuntimeOptions(options);
+    expect(code).toBe('{"onError": undefined}');
+    expect(() => new Function(`return (${code});`)()).not.toThrow();
   });
 });

--- a/src/utils/__tests__/serializeRuntimeOptions.test.ts
+++ b/src/utils/__tests__/serializeRuntimeOptions.test.ts
@@ -95,4 +95,24 @@ describe('generateRuntimePluginOption - safe JS literal', () => {
 
     expect(serializeRuntimeOptions({ circular })).toBe('{"circular": {"self": "__circular__"}}');
   });
+
+  it('serializes method-shorthand functions as evaluable object-literal values', () => {
+    const code = serializeRuntimeOptions({
+      onError() {
+        return 1;
+      },
+    });
+    expect(code).toMatch(/"onError":\s*function\s+onError\s*\(/);
+    const evaluated = new Function(`return (${code});`)() as { onError: () => number };
+    expect(evaluated.onError()).toBe(1);
+  });
+
+  it('does not emit native-function source that cannot be parsed', () => {
+    const code = serializeRuntimeOptions({ parse: JSON.parse });
+    // Native functions stringify as `function parse() { [native code] }`, which
+    // is not valid JS. Skip them with `undefined` so the object literal loads.
+    expect(code).toBe('{"parse": undefined}');
+    expect(() => new Function(`return (${code});`)()).not.toThrow();
+    expect(new Function(`return (${code});`)().parse).toBeUndefined();
+  });
 });

--- a/src/utils/serializeRuntimeOptions.ts
+++ b/src/utils/serializeRuntimeOptions.ts
@@ -55,7 +55,7 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
     }
 
     // Handle Function (returns the function's source code)
-    if (type === 'function') return val.toString();
+    if (type === 'function') return functionToExpression(val);
 
     // 2. Handle special built-in objects
     if (val instanceof Date) return `new Date(${toSafeJsLiteral(val.toISOString())})`;
@@ -115,4 +115,54 @@ export function serializeRuntimeOptions(options: Record<string, unknown>): strin
   }
 
   return `{${topLevelProps.join(', ')}}`;
+}
+
+const NATIVE_FUNCTION_SOURCE = /\{\s*\[native code\]\s*\}\s*$/;
+
+/**
+ * Turns `Function#toString()` output into a JS expression that is valid as an
+ * object-literal value.
+ *
+ * Method shorthand (`onError() { … }`) is not a valid expression after a `:`,
+ * so it is rewritten as a function expression. Native functions have no
+ * reconstructable source (`function parse() { [native code] }`) and serialize
+ * as `undefined` so the generated object stays loadable.
+ */
+function functionToExpression(fn: Function): string {
+  let source: string;
+  try {
+    source = Function.prototype.toString.call(fn).trim();
+  } catch {
+    return 'undefined';
+  }
+
+  if (NATIVE_FUNCTION_SOURCE.test(source) || /^(async\s+)?(?:get|set)\s+/.test(source)) {
+    return 'undefined';
+  }
+
+  // FunctionExpression, AsyncFunction, Generator, ClassExpression, or ArrowFunction.
+  if (
+    /^(async\s+)?function\b/.test(source) ||
+    /^(async\s*)?\(/.test(source) ||
+    /^class\b/.test(source) ||
+    /^(async\s+)?[$_\p{ID_Start}][$\p{ID_Continue}]*\s*=>/u.test(source)
+  ) {
+    return source;
+  }
+
+  // Method / generator-method shorthand from an object literal.
+  if (/^async\s*\*/.test(source)) {
+    return source.replace(/^async\s*\*\s*/, 'async function* ');
+  }
+  if (source.startsWith('*')) {
+    return source.replace(/^\*\s*/, 'function* ');
+  }
+  if (/^async\s+[$_\p{ID_Start}\[]/u.test(source)) {
+    return source.replace(/^async\s+/, 'async function ');
+  }
+  if (/^[$_\p{ID_Start}\[]/u.test(source)) {
+    return `function ${source}`;
+  }
+
+  return 'undefined';
 }

--- a/src/utils/serializeRuntimeOptions.ts
+++ b/src/utils/serializeRuntimeOptions.ts
@@ -147,22 +147,34 @@ function functionToExpression(fn: Function): string {
     /^class\b/.test(source) ||
     /^(async\s+)?[$_\p{ID_Start}][$\p{ID_Continue}]*\s*=>/u.test(source)
   ) {
-    return source;
+    return isParsableExpression(source) ? source : 'undefined';
   }
 
-  // Method / generator-method shorthand from an object literal.
-  if (/^async\s*\*/.test(source)) {
-    return source.replace(/^async\s*\*\s*/, 'async function* ');
-  }
-  if (source.startsWith('*')) {
-    return source.replace(/^\*\s*/, 'function* ');
-  }
-  if (/^async\s+[$_\p{ID_Start}\[]/u.test(source)) {
-    return source.replace(/^async\s+/, 'async function ');
-  }
-  if (/^[$_\p{ID_Start}\[]/u.test(source)) {
-    return `function ${source}`;
+  // Method shorthand. Drop the method name: object methods may use reserved
+  // words, while function declarations may not (`default() {}` is valid but
+  // `function default() {}` is not). Computed names cannot be reconstructed
+  // safely from Function#toString, so they fall through to `undefined`.
+  const methodPatterns: Array<[RegExp, string]> = [
+    [/^async\s*\*\s*[$_\p{ID_Start}][$\p{ID_Continue}]*\s*(\([\s\S]*)$/u, 'async function* '],
+    [/^\*\s*[$_\p{ID_Start}][$\p{ID_Continue}]*\s*(\([\s\S]*)$/u, 'function* '],
+    [/^async\s+[$_\p{ID_Start}][$\p{ID_Continue}]*\s*(\([\s\S]*)$/u, 'async function '],
+    [/^[$_\p{ID_Start}][$\p{ID_Continue}]*\s*(\([\s\S]*)$/u, 'function '],
+  ];
+  for (const [pattern, prefix] of methodPatterns) {
+    const match = source.match(pattern);
+    if (!match) continue;
+    const expression = `${prefix}${match[1]}`;
+    return isParsableExpression(expression) ? expression : 'undefined';
   }
 
   return 'undefined';
+}
+
+function isParsableExpression(source: string): boolean {
+  try {
+    new Function(`return (${source});`);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

`serializeRuntimeOptions` emitted unloadable JS for method shorthand (`onError() { … }` → invalid object literal) and for native functions (`function parse() { [native code] }`).

## Fix

Rewrite method shorthand as a function expression. Native / non-reconstructable functions serialize as `undefined` instead of breaking the generated module.

## Test plan

- [x] Unit tests for method shorthand and native functions
- [x] Existing arrow/`function` forms still serialize
