### PR TITLE
fix: format IPv6 Vite server.host in HTTP/WS origins

### DIFF
--- a/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
+++ b/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
@@ -269,8 +269,8 @@ describe('pluginDevRemoteHmr', () => {
   });
 
   it.each([
-    ['::', 'ws://localhost:4173/__mf_hmr?token=dev-token'],
-    ['::1', 'ws://[::1]:4173/__mf_hmr?token=dev-token'],
+    ['::', 'ws://localhost:4173/?token=dev-token'],
+    ['::1', 'ws://[::1]:4173/?token=dev-token'],
   ] as const)('advertises a valid HMR WebSocket URL when server.host is %s', (host, wsUrl) => {
     const { server, middlewares } = createServer({
       config: {

--- a/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
+++ b/src/plugins/__tests__/pluginDevRemoteHmr.test.ts
@@ -268,6 +268,48 @@ describe('pluginDevRemoteHmr', () => {
     expect(server.watcher.off).toHaveBeenCalledTimes(3);
   });
 
+  it.each([
+    ['::', 'ws://localhost:4173/__mf_hmr?token=dev-token'],
+    ['::1', 'ws://[::1]:4173/__mf_hmr?token=dev-token'],
+  ] as const)('advertises a valid HMR WebSocket URL when server.host is %s', (host, wsUrl) => {
+    const { server, middlewares } = createServer({
+      config: {
+        server: {
+          host,
+          port: 4173,
+        },
+      },
+    });
+
+    const plugin = pluginDevRemoteHmr(
+      normalizeModuleFederationOptions({
+        name: 'remote-app',
+        dev: { remoteHmr: true },
+        exposes: { './Button': { import: './src/Button.tsx' } },
+        remotes: {},
+        virtualModuleDir: '__mf__virtual',
+      })
+    );
+
+    runConfigureServer(plugin, server);
+
+    const res = {
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    };
+    middlewares[0](
+      { url: '/__mf_hmr' } as IncomingMessage,
+      res as unknown as ServerResponse<IncomingMessage>,
+      vi.fn()
+    );
+
+    expect(JSON.parse(res.end.mock.calls[0][0])).toEqual({
+      remote: 'remote-app',
+      event: 'mf:remote-update',
+      wsUrl,
+    });
+  });
+
   describe('react-refresh proxy middleware', () => {
     function makeRemotePlugin(opts: {
       exposes?: Record<string, string | { import: string }>;

--- a/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginProxyRemoteEntry.test.ts
@@ -261,6 +261,50 @@ describe('pluginProxyRemoteEntry', () => {
     );
   });
 
+  it.each([
+    ['::', '//localhost:4173'],
+    ['::1', '//[::1]:4173'],
+  ] as const)(
+    'uses a valid protocol-relative fallback origin when server.host is %s',
+    async (host, expectedOrigin) => {
+      normalizeModuleFederationOptions({ name: 'test' });
+      const plugin = pluginProxyRemoteEntry({
+        options: getDefaultMockOptions({ filename: 'remoteEntry.js' }),
+        remoteEntryId: 'virtual:mf-remote-entry',
+        virtualExposesId: 'virtual:mf-exposes',
+      });
+
+      callHook(
+        plugin.config,
+        {} as ConfigPluginContext,
+        {},
+        { command: 'serve', mode: 'development' }
+      );
+      callHook(
+        plugin.configResolved,
+        {} as MinimalPluginContextWithoutEnvironment,
+        {
+          root: '/repo',
+          base: '/',
+          server: { host, port: 4173 },
+        } as unknown as ResolvedConfig
+      );
+
+      const result = (await callHook(
+        plugin.transform,
+        {} as Rollup.TransformPluginContext,
+        '',
+        getHostAutoInitPath()
+      )) as {
+        code: string;
+      };
+
+      expect(result.code).toContain(
+        `const origin = typeof window !== 'undefined' && (true) ? window.origin : ${JSON.stringify(expectedOrigin)}`
+      );
+    }
+  );
+
   it('uses a dev-safe filename for hash-pattern host init remote entry imports', async () => {
     normalizeModuleFederationOptions({ name: 'test' });
     const plugin = pluginProxyRemoteEntry({

--- a/src/plugins/hmr/fullReload.ts
+++ b/src/plugins/hmr/fullReload.ts
@@ -1,4 +1,5 @@
 import type { ViteDevServer } from 'vite';
+import { formatDevServerHostForOrigin } from '../../utils/devServerHost';
 import { mfWarn } from '../../utils/logger';
 import type { NormalizedModuleFederationOptions } from '../../utils/normalizeModuleFederationOptions';
 import { shouldIgnoreFile } from '../pluginDevRemoteHmr';
@@ -45,12 +46,9 @@ function getRemoteHmrWsUrl(server: ViteDevServer) {
       : server.config.server.https
         ? 'wss'
         : 'ws';
-  const hostname =
-    hmr && typeof hmr === 'object' && hmr.host
-      ? hmr.host
-      : typeof server.config.server.host === 'string' && server.config.server.host !== '0.0.0.0'
-        ? server.config.server.host
-        : 'localhost';
+  const hostname = formatDevServerHostForOrigin(
+    hmr && typeof hmr === 'object' && hmr.host ? hmr.host : server.config.server.host
+  );
   const port =
     hmr && typeof hmr === 'object' && (hmr.clientPort || hmr.port)
       ? hmr.clientPort || hmr.port
@@ -61,12 +59,7 @@ function getRemoteHmrWsUrl(server: ViteDevServer) {
 
 function getLocalFallbackOrigin(server: ViteDevServer) {
   const protocol = server.config.server.https ? 'https' : 'http';
-  const host =
-    typeof server.config.server.host === 'string' &&
-    server.config.server.host !== '0.0.0.0' &&
-    server.config.server.host !== '::'
-      ? server.config.server.host
-      : 'localhost';
+  const host = formatDevServerHostForOrigin(server.config.server.host);
   const port = server.config.server.port || 5173;
   return `${protocol}://${host}:${port}`;
 }

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -14,6 +14,7 @@ import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap'
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 import { hasPackageDependency } from '../utils/packageUtils';
 import { getReactIslandExposes } from '../utils/reactIsland';
+import { formatDevServerHostForOrigin } from '../utils/devServerHost';
 import { ensureTrailingSlash, filterId, resolvePublicPath } from '../utils/pathNormalization';
 import {
   generateExposes,
@@ -244,10 +245,7 @@ export default function ({
         }
         if (isHostAutoInitId(id)) {
           if (_command === 'serve') {
-            const host =
-              typeof viteConfig.server?.host === 'string' && viteConfig.server.host !== '0.0.0.0'
-                ? viteConfig.server.host
-                : 'localhost';
+            const host = formatDevServerHostForOrigin(viteConfig.server?.host);
             const resolvedPublicPath = resolvePublicPath(
               options,
               viteConfig.base,

--- a/src/utils/__tests__/devServerHost.test.ts
+++ b/src/utils/__tests__/devServerHost.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatDevServerHostForOrigin } from '../devServerHost';
+
+describe('formatDevServerHostForOrigin', () => {
+  it.each([
+    [undefined, 'localhost'],
+    [true, 'localhost'],
+    ['0.0.0.0', 'localhost'],
+    ['::', 'localhost'],
+    ['localhost', 'localhost'],
+    ['127.0.0.1', '127.0.0.1'],
+    ['::1', '[::1]'],
+    ['2001:db8::1', '[2001:db8::1]'],
+    ['[::1]', '[::1]'],
+    ['example.local', 'example.local'],
+  ])('formats %j as %j', (host, expected) => {
+    expect(formatDevServerHostForOrigin(host)).toBe(expected);
+  });
+});

--- a/src/utils/devServerHost.ts
+++ b/src/utils/devServerHost.ts
@@ -1,0 +1,20 @@
+import { isIPv6 } from 'node:net';
+
+const UNSPECIFIED_HOSTS = new Set(['0.0.0.0', '::']);
+
+/**
+ * Hostname for client-facing HTTP/WS origins built from Vite `server.host`.
+ *
+ * Unspecified bind addresses (`0.0.0.0`, `::`) map to `localhost`, matching
+ * Vite's own printed local URL. IPv6 addresses are wrapped in brackets so
+ * `http://[::1]:5173` / `ws://[::1]:5173` parse as valid URLs.
+ */
+export function formatDevServerHostForOrigin(host: unknown): string {
+  if (typeof host !== 'string' || UNSPECIFIED_HOSTS.has(host)) {
+    return 'localhost';
+  }
+  if (host.startsWith('[') && host.endsWith(']')) {
+    return host;
+  }
+  return isIPv6(host) ? `[${host}]` : host;
+}


### PR DESCRIPTION
## Summary

`server.host` of `::` / `::1` produced invalid HMR WS and remote-entry origins (`ws://:::4173/…`, missing brackets).

## Fix

Shared `formatDevServerHostForOrigin`: map `::` / `0.0.0.0` to `localhost`; bracket other IPv6 hosts. Used in HMR `fullReload` and `pluginProxyRemoteEntry`.

## Test plan

- [x] Unit tests for host formatting
- [x] Plugin tests for WS/HTTP origins with IPv6
