### PR TITLE
fix: reset alias regex lastIndex before shared-key matches

### DIFF
--- a/src/plugins/__tests__/pluginCheckAliasConflicts.test.ts
+++ b/src/plugins/__tests__/pluginCheckAliasConflicts.test.ts
@@ -183,6 +183,33 @@ describe('pluginCheckAliasConflicts', () => {
     );
   });
 
+  it('does not skip later shared keys when a global alias regex advances lastIndex', () => {
+    const plugin = checkAliasConflicts({
+      shared: {
+        react: createSharedItem('react', '18.0.0'),
+        'react-dom': createSharedItem('react-dom', '18.0.0'),
+      },
+    });
+
+    runConfigResolved(plugin, {
+      resolve: {
+        alias: [
+          {
+            find: /react/g,
+            replacement: '/path/to/project/vendor/react',
+          },
+        ],
+      },
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Shared module "react" is aliased')
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Shared module "react-dom" is aliased')
+    );
+  });
+
   it('should not warn for trailing slash shared modules pointing at same node_modules package', () => {
     const plugin = checkAliasConflicts({
       shared: {

--- a/src/plugins/pluginCheckAliasConflicts.ts
+++ b/src/plugins/pluginCheckAliasConflicts.ts
@@ -26,7 +26,12 @@ export function checkAliasConflicts(options: { shared?: NormalizedShared }): Plu
           return findPattern === sharedKey || sharedKey.startsWith(findPattern + '/');
         }
         if (findPattern instanceof RegExp) {
-          return findPattern.test(sharedKey);
+          // Global/sticky regexes advance lastIndex on .test; reset so later
+          // shared keys (e.g. `react-dom` after `react`) are not skipped.
+          findPattern.lastIndex = 0;
+          const matched = findPattern.test(sharedKey);
+          findPattern.lastIndex = 0;
+          return matched;
         }
 
         return false;


### PR DESCRIPTION
## Summary

Global `RegExp` objects in alias-conflict / shared-key checks kept `lastIndex`, so a later key like `react-dom` could be skipped after `/react/g` matched `react`.

## Fix

Reset `lastIndex` around `.test` so each key is matched from the start.

## Test plan

- [x] Unit test: `/react/g` still matches `react-dom` afterward
