### PR TITLE
fix: align SSR and wildcard shared-key matching

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -353,6 +353,35 @@ describe('pluginProxySharedModule_preBuild', () => {
       expect(findSharedKey('react-dom/client', shared)).toBe('react-dom');
     });
 
+    it('prefers the longest trailing-slash wildcard prefix', () => {
+      const wildcardShare = (name: string): NormalizedShared[string] => ({
+        name,
+        from: '',
+        version: '1.0.0',
+        scope: 'default',
+        shareConfig: {
+          singleton: false,
+          requiredVersion: '^1.0.0',
+          strictVersion: false,
+        },
+      });
+
+      // Shorter prefix inserted first so first-key-wins would pick `@scope/ui/`.
+      const shorterFirst: NormalizedShared = {
+        '@scope/ui/': wildcardShare('@scope/ui/'),
+        '@scope/ui/forms/': wildcardShare('@scope/ui/forms/'),
+      };
+      expect(findSharedKey('@scope/ui/forms/Button', shorterFirst)).toBe('@scope/ui/forms/');
+      expect(findSharedKey('@scope/ui/button', shorterFirst)).toBe('@scope/ui/');
+
+      const longerFirst: NormalizedShared = {
+        '@scope/ui/forms/': wildcardShare('@scope/ui/forms/'),
+        '@scope/ui/': wildcardShare('@scope/ui/'),
+      };
+      expect(findSharedKey('@scope/ui/forms/Button', longerFirst)).toBe('@scope/ui/forms/');
+      expect(findSharedKey('@scope/ui/button', longerFirst)).toBe('@scope/ui/');
+    });
+
     it('caches per source without changing misses', () => {
       const shared = makeShared();
 

--- a/src/plugins/pluginModuleParseEnd.ts
+++ b/src/plugins/pluginModuleParseEnd.ts
@@ -1,6 +1,8 @@
 /**
- * Dynamic shared modules, such as "react/" and "react-dom/", can only be parsed during the build process;
- * This plugin allows me to wait until all modules are built, and then expose them together.
+ * Dynamic shared modules, such as the "react/" namespace prefix, can only be
+ * parsed during the build process. Trailing-slash `react-dom/` keys collapse to
+ * the package root after #1158, so they are not a dynamic prefix.
+ * This plugin waits until all modules are built, then exposes them together.
  */
 import type { Plugin } from 'vite';
 import { mfWarn } from '../utils/logger';

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -13,12 +13,16 @@ import {
 } from '../utils/normalizeModuleFederationOptions';
 import {
   getCommonSharedSubpathFromNodeModulePath,
-  getCommonSharedSubpaths,
   getMatchingNodeModuleSubpath,
   isNodeModulePath,
   isAssetLikeImport,
   normalizeNodeModulePath,
 } from '../utils/pathNormalization';
+import {
+  findSharedKey,
+  invalidateSharedKeyMatcher,
+  matchesSharedSource,
+} from '../utils/sharedKeyMatcher';
 import {
   getIsRolldown,
   getInstalledPackageJson,
@@ -66,6 +70,8 @@ import {
   stripTreeShakingGraphQuery,
 } from '../virtualModules';
 
+export { findSharedKey, matchesSharedSource };
+
 function getPrebuildResolutionSource(pkgName: string, shareItem?: ShareItem): string {
   return getConcreteSharedImportSource(pkgName, shareItem) || pkgName;
 }
@@ -89,101 +95,6 @@ function isBuildConfigImporter(importer: string | undefined): boolean {
   return /(^|\/)(?:nuxt|vite|vitest|webpack|rollup|rspack)\.config\.[cm]?[jt]sx?$/.test(
     importer.replace(/\\/g, '/')
   );
-}
-
-export function matchesSharedSource(source: string, key: string): boolean {
-  const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
-  if (
-    keyBase === 'vue' &&
-    (source === 'vue/dist/vue.esm-bundler.js' || source === 'vue/dist/vue.runtime.esm-bundler.js')
-  ) {
-    return true;
-  }
-  if (key.endsWith('/')) return source === keyBase || source.startsWith(`${keyBase}/`);
-  if (getCommonSharedSubpaths(keyBase).includes(source)) return true;
-  return source === keyBase;
-}
-
-export function findSharedKey(
-  source: string,
-  shared: NormalizedShared | undefined
-): string | undefined {
-  return getSharedKeyMatcher(shared).find(source);
-}
-
-type SharedKeyMatcher = {
-  find(source: string): string | undefined;
-};
-
-const emptySharedKeyMatcher: SharedKeyMatcher = {
-  find: () => undefined,
-};
-
-const sharedKeyMatcherCache = new WeakMap<NormalizedShared, SharedKeyMatcher>();
-
-function getSharedKeyMatcher(shared: NormalizedShared | undefined): SharedKeyMatcher {
-  if (!shared) return emptySharedKeyMatcher;
-
-  const cached = sharedKeyMatcherCache.get(shared);
-  if (cached) return cached;
-
-  // Shared matching is on a hot resolve path. Precompute exact/subpath indexes
-  // once per normalized shared object, then cache repeated source lookups.
-  const keys = Object.keys(shared);
-  const exactKeys = new Set(keys);
-  const commonSubpathKeys = new Map<string, string>();
-  const wildcardKeys: Array<{ key: string; base: string }> = [];
-  let vueKey: string | undefined;
-
-  for (const key of keys) {
-    const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
-    const shareItem = shared[key];
-
-    if (!vueKey && keyBase === 'vue') vueKey = key;
-    if (key.endsWith('/')) wildcardKeys.push({ key, base: keyBase });
-
-    // `import: false` applies to the configured key only. Treating common
-    // subpaths as implicit shares creates unfulfillable runtime-only entries
-    // for hosts which provide the bare package but not every package export.
-    if (shareItem.shareConfig?.import !== false) {
-      for (const subpath of getCommonSharedSubpaths(keyBase)) {
-        if (!commonSubpathKeys.has(subpath)) commonSubpathKeys.set(subpath, key);
-      }
-    }
-  }
-
-  const sourceCache = new Map<string, string | undefined>();
-  const matcher: SharedKeyMatcher = {
-    find(source) {
-      if (sourceCache.has(source)) return sourceCache.get(source);
-
-      let result = exactKeys.has(source) ? source : undefined;
-
-      if (!result && vueKey) {
-        if (
-          source === 'vue/dist/vue.esm-bundler.js' ||
-          source === 'vue/dist/vue.runtime.esm-bundler.js'
-        ) {
-          result = vueKey;
-        }
-      }
-
-      if (!result) result = commonSubpathKeys.get(source);
-
-      if (!result) {
-        const wildcardKey = wildcardKeys.find(
-          ({ base }) => source === base || source.startsWith(`${base}/`)
-        );
-        result = wildcardKey?.key;
-      }
-
-      sourceCache.set(source, result);
-      return result;
-    },
-  };
-
-  sharedKeyMatcherCache.set(shared, matcher);
-  return matcher;
 }
 
 function findSharedKeyForSource(
@@ -257,7 +168,7 @@ export function excludeSharedSubDependencies(shared: NormalizedShared): void {
         sharedKeyByBase.delete(dep);
         // A matcher cached before this deletion would keep resolving the
         // removed key and hand callers an undefined shareItem.
-        sharedKeyMatcherCache.delete(shared);
+        invalidateSharedKeyMatcher(shared);
       }
     }
   }

--- a/src/utils/__tests__/pathNormalization.test.ts
+++ b/src/utils/__tests__/pathNormalization.test.ts
@@ -83,9 +83,22 @@ describe('pathNormalization', () => {
       getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/client.mjs', ['react-dom/client'])
     ).toBe('react-dom/client');
     expect(
+      getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/client.js#app', [
+        'react-dom/client',
+      ])
+    ).toBe('react-dom/client');
+    expect(
       getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/server/render.js', [
         'react-dom/server',
       ])
+    ).toBe('react-dom/server');
+
+    // A dotted sibling earlier in the path must not hide a later exact module.
+    expect(
+      getMatchingNodeModuleSubpath(
+        '/repo/node_modules/react-dom/server.browser.js/vendor/node_modules/react-dom/server.js',
+        ['react-dom/server']
+      )
     ).toBe('react-dom/server');
   });
 

--- a/src/utils/__tests__/pathNormalization.test.ts
+++ b/src/utils/__tests__/pathNormalization.test.ts
@@ -61,6 +61,34 @@ describe('pathNormalization', () => {
     ).toBe('react-dom/server.browser');
   });
 
+  it('does not treat a dotted sibling file as a shorter candidate (extension boundary)', () => {
+    // `server.browser.js` must not match shared key `react-dom/server` just because
+    // the path contains `/node_modules/react-dom/server.`. The `.` after the
+    // candidate has to be a module-file extension, not another filename segment.
+    expect(
+      getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/server.browser.js', [
+        'react-dom/server',
+      ])
+    ).toBeUndefined();
+    expect(
+      getMatchingNodeModuleSubpath('C:\\repo\\node_modules\\react-dom\\server.browser.js?v=1', [
+        'react-dom/server',
+      ])
+    ).toBeUndefined();
+
+    expect(
+      getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/server.js', ['react-dom/server'])
+    ).toBe('react-dom/server');
+    expect(
+      getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/client.mjs', ['react-dom/client'])
+    ).toBe('react-dom/client');
+    expect(
+      getMatchingNodeModuleSubpath('/repo/node_modules/react-dom/server/render.js', [
+        'react-dom/server',
+      ])
+    ).toBe('react-dom/server');
+  });
+
   it('detects common shared subpaths from node_modules paths', () => {
     expect(
       getCommonSharedSubpathFromNodeModulePath(

--- a/src/utils/__tests__/ssrVmStrategy.test.ts
+++ b/src/utils/__tests__/ssrVmStrategy.test.ts
@@ -12,6 +12,9 @@
  * vi.resetModules() + dynamic import for a fresh instance.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { findSharedKey } from '../../plugins/pluginProxySharedModule_preBuild';
+import { findVmSharedKey } from '../ssrVmStrategy';
+import type { NormalizedShared } from '../normalizeModuleFederationOptions';
 
 const hasVmModules = await (async () => {
   const vm = (await import('vm')) as { SourceTextModule?: unknown };
@@ -71,6 +74,64 @@ describe('ssrVmStrategy — availability', () => {
       ...baseOptions,
     });
     expect(result).toBeNull();
+  });
+});
+
+function makeRuntimeShare(scope: string | string[] = 'default', shareConfig?: { import?: false }) {
+  return shareConfig ? { scope, shareConfig } : { scope };
+}
+
+describe('ssrVmStrategy — findVmSharedKey (browser matcher twin)', () => {
+  it('does not auto-map COMMON_SHARED_SUBPATHS when the parent uses import:false', () => {
+    // Twin of pluginProxySharedModule_preBuild findSharedKey's import:false case.
+    // Browser skips jsx-runtime after #1148; SSR findVmSharedKey must match.
+    const shared: NormalizedShared = {
+      react: {
+        name: 'react',
+        from: '',
+        version: '19.2.4',
+        scope: 'default',
+        shareConfig: {
+          singleton: true,
+          import: false,
+          requiredVersion: '^19.2.4',
+          strictVersion: false,
+        },
+      },
+    };
+
+    expect(findSharedKey('react', shared)).toBe('react');
+    expect(findSharedKey('react/jsx-runtime', shared)).toBeUndefined();
+    expect(findVmSharedKey('react', shared)).toBe('react');
+    expect(findVmSharedKey('react/jsx-runtime', shared)).toBeUndefined();
+
+    const withExplicit = {
+      ...shared,
+      'react/jsx-runtime': { ...shared.react, name: 'react/jsx-runtime' },
+    };
+    expect(findSharedKey('react/jsx-runtime', withExplicit)).toBe('react/jsx-runtime');
+    expect(findVmSharedKey('react/jsx-runtime', withExplicit)).toBe('react/jsx-runtime');
+  });
+
+  it('still auto-maps common subpaths when the parent is a local provider', () => {
+    const shared = { react: makeRuntimeShare('default') };
+    expect(findVmSharedKey('react/jsx-runtime', shared)).toBe('react');
+  });
+
+  it('prefers the longest trailing-slash wildcard prefix', () => {
+    const shorterFirst = {
+      '@scope/ui/': makeRuntimeShare('default'),
+      '@scope/ui/forms/': makeRuntimeShare('default'),
+    };
+    expect(findVmSharedKey('@scope/ui/forms/Button', shorterFirst)).toBe('@scope/ui/forms/');
+    expect(findVmSharedKey('@scope/ui/button', shorterFirst)).toBe('@scope/ui/');
+
+    const longerFirst = {
+      '@scope/ui/forms/': makeRuntimeShare('default'),
+      '@scope/ui/': makeRuntimeShare('default'),
+    };
+    expect(findVmSharedKey('@scope/ui/forms/Button', longerFirst)).toBe('@scope/ui/forms/');
+    expect(findVmSharedKey('@scope/ui/button', longerFirst)).toBe('@scope/ui/');
   });
 });
 
@@ -220,6 +281,75 @@ describe.skipIf(!hasVmModules)('ssrVmStrategy — module graph evaluation', () =
 
     expect(namespace.value).toBe('negotiated');
     expect(loadShare).toHaveBeenCalledWith('@scope/ui/button');
+  });
+
+  it('does not negotiate common shared subpaths when the parent uses import:false', async () => {
+    const fallbackFile = await createFallbackSharedModule('mf-vm-import-false-subpath-');
+
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { value } from "react/jsx-runtime"; export { value };',
+      },
+    }) as unknown as typeof globalThis.fetch;
+
+    const loadShare = vi.fn(async () => () => ({ value: 'negotiated' }));
+    (globalThis as Record<string, unknown>).__FEDERATION__ = {
+      __INSTANCES__: [
+        {
+          options: {
+            shared: { react: { scope: 'default', shareConfig: { import: false } } },
+          },
+          loadShare,
+        },
+      ],
+    };
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions, resolvedShared: { 'react/jsx-runtime': fallbackFile } }
+    )) as { value: string };
+
+    expect(namespace.value).toBe('fallback');
+    expect(loadShare).not.toHaveBeenCalled();
+  });
+
+  it('prefers the longest trailing-slash wildcard when scopes differ', async () => {
+    const fallbackFile = await createFallbackSharedModule('mf-vm-wildcard-longest-');
+
+    global.fetch = makeFetchMock({
+      'http://localhost:5001/remoteEntry.ssr.js': {
+        ok: true,
+        text: 'import { value } from "@scope/ui/forms/Button"; export { value };',
+      },
+    }) as unknown as typeof globalThis.fetch;
+
+    const loadShare = vi.fn(async () => () => ({ value: 'forms-wildcard' }));
+    (globalThis as Record<string, unknown>).__FEDERATION__ = {
+      __INSTANCES__: [
+        {
+          options: {
+            // Shorter prefix first: first-key-wins would select `@scope/ui/`
+            // (scope "other") and skip this instance instead of matching forms/.
+            shared: {
+              '@scope/ui/': { scope: 'other' },
+              '@scope/ui/forms/': { scope: 'default' },
+            },
+          },
+          loadShare,
+        },
+      ],
+    };
+    const strategy = await freshStrategy();
+
+    const namespace = (await strategy.loadViaVmStrategy(
+      'http://localhost:5001/remoteEntry.ssr.js',
+      { ...baseOptions, resolvedShared: { '@scope/ui/forms/Button': fallbackFile } }
+    )) as { value: string };
+
+    expect(namespace.value).toBe('forms-wildcard');
+    expect(loadShare).toHaveBeenCalledWith('@scope/ui/forms/Button');
   });
 
   it('does not treat arbitrary package subpaths as parent shared modules', async () => {

--- a/src/utils/pathNormalization.ts
+++ b/src/utils/pathNormalization.ts
@@ -94,6 +94,18 @@ export function filterId(id: unknown): id is string {
   return typeof id === 'string' && !id.includes('\0');
 }
 
+// A path-segment or real module-file extension after `/node_modules/${candidate}`.
+// Naive `candidate.` matching treated `server.browser.js` as `react-dom/server`.
+const NODE_MODULE_FILE_EXT_RE = /^\.[cm]?[jt]sx?$/i;
+
+function matchesNodeModuleCandidate(normalized: string, candidate: string): boolean {
+  const marker = `/node_modules/${candidate}`;
+  const index = normalized.indexOf(marker);
+  if (index === -1) return false;
+  const after = normalized.slice(index + marker.length);
+  return after === '' || after.startsWith('/') || NODE_MODULE_FILE_EXT_RE.test(after);
+}
+
 export function getMatchingNodeModuleSubpath(
   source: string,
   candidates: Iterable<string>
@@ -101,11 +113,7 @@ export function getMatchingNodeModuleSubpath(
   const normalized = normalizeNodeModulePath(source);
   return [...candidates]
     .sort((a, b) => b.length - a.length)
-    .find(
-      (candidate) =>
-        normalized.includes(`/node_modules/${candidate}/`) ||
-        normalized.includes(`/node_modules/${candidate}.`)
-    );
+    .find((candidate) => matchesNodeModuleCandidate(normalized, candidate));
 }
 
 export function getCommonSharedSubpaths(sharedKey: string): string[] {

--- a/src/utils/pathNormalization.ts
+++ b/src/utils/pathNormalization.ts
@@ -100,10 +100,19 @@ const NODE_MODULE_FILE_EXT_RE = /^\.[cm]?[jt]sx?$/i;
 
 function matchesNodeModuleCandidate(normalized: string, candidate: string): boolean {
   const marker = `/node_modules/${candidate}`;
-  const index = normalized.indexOf(marker);
-  if (index === -1) return false;
-  const after = normalized.slice(index + marker.length);
-  return after === '' || after.startsWith('/') || NODE_MODULE_FILE_EXT_RE.test(after);
+  let from = 0;
+  while (from < normalized.length) {
+    const index = normalized.indexOf(marker, from);
+    if (index === -1) return false;
+    const after = normalized.slice(index + marker.length);
+    const boundary = after.search(/[?#]/);
+    const afterPath = boundary === -1 ? after : after.slice(0, boundary);
+    if (afterPath === '' || afterPath.startsWith('/') || NODE_MODULE_FILE_EXT_RE.test(afterPath)) {
+      return true;
+    }
+    from = index + 1;
+  }
+  return false;
 }
 
 export function getMatchingNodeModuleSubpath(

--- a/src/utils/sharedKeyMatcher.ts
+++ b/src/utils/sharedKeyMatcher.ts
@@ -1,0 +1,118 @@
+import { getCommonSharedSubpaths } from './pathNormalization';
+
+/**
+ * Minimal shared-record shape used by both the browser matcher and SSR
+ * `findVmSharedKey`. Runtime federation instances store `shareConfig.import`.
+ */
+export type SharedKeyLookup = Record<string, { shareConfig?: { import?: unknown } } | undefined>;
+
+export function matchesSharedSource(source: string, key: string): boolean {
+  const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
+  if (
+    keyBase === 'vue' &&
+    (source === 'vue/dist/vue.esm-bundler.js' || source === 'vue/dist/vue.runtime.esm-bundler.js')
+  ) {
+    return true;
+  }
+  if (key.endsWith('/')) return source === keyBase || source.startsWith(`${keyBase}/`);
+  if (getCommonSharedSubpaths(keyBase).includes(source)) return true;
+  return source === keyBase;
+}
+
+type SharedKeyMatcher = {
+  find(source: string): string | undefined;
+};
+
+const emptySharedKeyMatcher: SharedKeyMatcher = {
+  find: () => undefined,
+};
+
+const sharedKeyMatcherCache = new WeakMap<object, SharedKeyMatcher>();
+
+export function invalidateSharedKeyMatcher(shared: object): void {
+  sharedKeyMatcherCache.delete(shared);
+}
+
+export function findSharedKey(
+  source: string,
+  shared: SharedKeyLookup | undefined
+): string | undefined {
+  return getSharedKeyMatcher(shared).find(source);
+}
+
+function pickLongestWildcardKey(
+  wildcardKeys: Array<{ key: string; base: string }>,
+  source: string
+): string | undefined {
+  let best: { key: string; base: string } | undefined;
+  for (const wildcard of wildcardKeys) {
+    if (source !== wildcard.base && !source.startsWith(`${wildcard.base}/`)) continue;
+    if (
+      !best ||
+      wildcard.base.length > best.base.length ||
+      (wildcard.base.length === best.base.length && wildcard.key.length > best.key.length)
+    ) {
+      best = wildcard;
+    }
+  }
+  return best?.key;
+}
+
+function getSharedKeyMatcher(shared: SharedKeyLookup | undefined): SharedKeyMatcher {
+  if (!shared) return emptySharedKeyMatcher;
+
+  const cached = sharedKeyMatcherCache.get(shared);
+  if (cached) return cached;
+
+  // Shared matching is on a hot resolve path. Precompute exact/subpath indexes
+  // once per shared object, then cache repeated source lookups.
+  const keys = Object.keys(shared);
+  const exactKeys = new Set(keys);
+  const commonSubpathKeys = new Map<string, string>();
+  const wildcardKeys: Array<{ key: string; base: string }> = [];
+  let vueKey: string | undefined;
+
+  for (const key of keys) {
+    const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
+    const shareItem = shared[key];
+
+    if (!vueKey && keyBase === 'vue') vueKey = key;
+    if (key.endsWith('/')) wildcardKeys.push({ key, base: keyBase });
+
+    // `import: false` applies to the configured key only. Treating common
+    // subpaths as implicit shares creates unfulfillable runtime-only entries
+    // for hosts which provide the bare package but not every package export.
+    if (shareItem?.shareConfig?.import !== false) {
+      for (const subpath of getCommonSharedSubpaths(keyBase)) {
+        if (!commonSubpathKeys.has(subpath)) commonSubpathKeys.set(subpath, key);
+      }
+    }
+  }
+
+  const sourceCache = new Map<string, string | undefined>();
+  const matcher: SharedKeyMatcher = {
+    find(source) {
+      if (sourceCache.has(source)) return sourceCache.get(source);
+
+      let result = exactKeys.has(source) ? source : undefined;
+
+      if (!result && vueKey) {
+        if (
+          source === 'vue/dist/vue.esm-bundler.js' ||
+          source === 'vue/dist/vue.runtime.esm-bundler.js'
+        ) {
+          result = vueKey;
+        }
+      }
+
+      if (!result) result = commonSubpathKeys.get(source);
+      if (!result) result = pickLongestWildcardKey(wildcardKeys, source);
+
+      sourceCache.set(source, result);
+      return result;
+    },
+  };
+
+  sharedKeyMatcherCache.set(shared, matcher);
+  return matcher;
+}

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -101,7 +101,7 @@ interface FederationInstanceLike {
   loadShare?: (name: string) => Promise<false | (() => unknown | undefined) | undefined>;
 }
 
-function findVmSharedKey(
+export function findVmSharedKey(
   specifier: string,
   shared: Record<string, { scope?: string | string[] } | undefined> | undefined
 ): string | undefined {

--- a/src/utils/ssrVmStrategy.ts
+++ b/src/utils/ssrVmStrategy.ts
@@ -25,7 +25,7 @@ import {
   fetchWithTimeout,
   readResponseTextBounded,
 } from './fetchWithTimeout';
-import { getCommonSharedSubpaths } from './pathNormalization';
+import { findSharedKey, type SharedKeyLookup } from './sharedKeyMatcher';
 
 interface VmStrategyOptions {
   resolvedShared: Record<string, string>;
@@ -96,42 +96,19 @@ export async function isVmStrategyAvailable(): Promise<boolean> {
 
 interface FederationInstanceLike {
   options?: {
-    shared?: Record<string, { scope?: string | string[] } | undefined>;
+    shared?: Record<
+      string,
+      { scope?: string | string[]; shareConfig?: { import?: unknown } } | undefined
+    >;
   };
   loadShare?: (name: string) => Promise<false | (() => unknown | undefined) | undefined>;
 }
 
 export function findVmSharedKey(
   specifier: string,
-  shared: Record<string, { scope?: string | string[] } | undefined> | undefined
+  shared: SharedKeyLookup | undefined
 ): string | undefined {
-  if (!shared) return;
-
-  const keys = Object.keys(shared);
-  if (Object.prototype.hasOwnProperty.call(shared, specifier)) return specifier;
-
-  const vueKey = keys.find((key) =>
-    key.endsWith('/') ? key.slice(0, -1) === 'vue' : key === 'vue'
-  );
-  if (
-    vueKey &&
-    (specifier === 'vue/dist/vue.esm-bundler.js' ||
-      specifier === 'vue/dist/vue.runtime.esm-bundler.js')
-  ) {
-    return vueKey;
-  }
-
-  const commonSubpathKey = keys.find((key) => {
-    const keyBase = key.endsWith('/') ? key.slice(0, -1) : key;
-    return getCommonSharedSubpaths(keyBase).includes(specifier);
-  });
-  if (commonSubpathKey) return commonSubpathKey;
-
-  return keys.find((key) => {
-    if (!key.endsWith('/')) return false;
-    const keyBase = key.slice(0, -1);
-    return specifier === keyBase || specifier.startsWith(`${keyBase}/`);
-  });
+  return findSharedKey(specifier, shared);
 }
 
 function getFederationInstances(): FederationInstanceLike[] {


### PR DESCRIPTION
## Summary

Three matcher bugs left after #1148 / #1158:

1. SSR `findVmSharedKey` still auto-mapped `COMMON_SHARED_SUBPATHS` for `import: false` parents; the browser matcher did not.
2. Trailing-slash wildcards used first-key-wins instead of longest prefix (`@scope/ui/` swallowed `@scope/ui/forms/`).
3. `getMatchingNodeModuleSubpath` treated `react-dom/server.browser.js` as `react-dom/server` via a naive `.` prefix.

Also drops a stale `pluginModuleParseEnd` comment that still treated `react-dom/` as a dynamic prefix after #1158.

## Fix

Shared `sharedKeyMatcher` used by browser and SSR. Longest wildcard prefix. Path matcher requires a real module extension or path boundary.

## Test plan

- [x] FAIL→PASS tests for import:false SSR, longest wildcard, server.browser path
- [x] Typecheck / vitest on touched files
