### PR TITLE
fix: scope SSR init remotes and strip hash from SSR exposes filename

### DIFF
--- a/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
+++ b/src/plugins/__tests__/pluginSSRRemoteEntry.test.ts
@@ -519,6 +519,66 @@ describe('pluginSSRRemoteEntry', () => {
       expect(secondResponse.body).toBe(firstResponse.body);
       expect(generateRemoteEntrySSR).toHaveBeenCalledTimes(1);
     });
+
+    it('serves hashed-filename SSR exposes without a literal [hash] placeholder', () => {
+      const plugins = pluginSSRRemoteEntry(makeOptions({ filename: 'remoteEntry-[hash]' }));
+      const mainPlugin = plugins[1];
+      const handlers: { path: string }[] = [];
+
+      callHook(
+        mainPlugin.configResolved,
+        {} as Rollup.PluginContext,
+        { base: '/', root: '/mock/cwd' } as unknown as ResolvedConfig
+      );
+      callHook(
+        mainPlugin.configureServer,
+        {} as Rollup.PluginContext,
+        {
+          config: { root: '/mock/cwd' },
+          environments: {},
+          middlewares: {
+            use(
+              pathOrHandler: string | ((req: unknown, res: unknown) => unknown),
+              handler?: unknown
+            ) {
+              if (typeof pathOrHandler === 'string') {
+                handlers.push({ path: pathOrHandler });
+              }
+              void handler;
+            },
+          },
+        } as never
+      );
+
+      const exposesPath = handlers.find((entry) => entry.path.includes('exposes.js'))?.path;
+      expect(exposesPath).toBe('/__mf_ssr__/remoteEntry.exposes.js');
+      expect(exposesPath).not.toContain('[hash');
+    });
+
+    it('resolves hashed-filename SSR exposes without a literal [hash] placeholder', () => {
+      const plugins = pluginSSRRemoteEntry(makeOptions({ filename: 'remoteEntry-[hash]' }));
+      const mainPlugin = plugins[1];
+      const exposesId = 'virtual:mf-exposes-ssr:__mfe_internal__remote';
+
+      expect(
+        callHook(
+          mainPlugin.resolveId,
+          {} as Rollup.PluginContext,
+          '/__mf_ssr__/remoteEntry.exposes.js',
+          undefined,
+          { isEntry: false }
+        )
+      ).toBe(exposesId);
+      expect(
+        callHook(
+          mainPlugin.resolveId,
+          {} as Rollup.PluginContext,
+          '/__mf_ssr__/remoteEntry-[hash].exposes.js',
+          undefined,
+          { isEntry: false }
+        )
+      ).toBeUndefined();
+    });
   });
 
   describe('main plugin — configureServer runner endpoint', () => {

--- a/src/plugins/pluginSSRRemoteEntry.ts
+++ b/src/plugins/pluginSSRRemoteEntry.ts
@@ -11,6 +11,7 @@ import { generateExposesSSR, getVirtualExposesSSRId } from '../virtualModules/vi
 import {
   generateRemoteEntrySSR,
   getRemoteEntrySSRId,
+  getSsrExposesFileName,
   getSsrRemoteEntryFileName,
 } from '../virtualModules/virtualRemoteEntrySSR';
 
@@ -218,6 +219,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
   const virtualExposesSSRId = getVirtualExposesSSRId(options);
   let cachedSsrRemoteEntrySource: string | undefined;
   const ssrOutputFilename = getSsrRemoteEntryFileName(options.filename);
+  const ssrExposesFileName = getSsrExposesFileName(options.filename);
   let ssrOutputFiles = new Set<string>();
   let ssrOutputDir = '';
   let clientOutputDir = '';
@@ -478,7 +480,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         // Serve the SSR remote entry at a predictable URL.
         const ssrPath = `${base}/${ssrEntryFileName}`;
         server.middlewares.use(ssrPath, (_req, res) => {
-          const exposesUrl = `${base}/${options.filename.replace(/\.[^.]+$/, '')}.exposes.js`;
+          const exposesUrl = `${base}/${ssrExposesFileName}`;
           const code = getSsrRemoteEntrySource().replace(
             JSON.stringify(virtualExposesSSRId),
             JSON.stringify(exposesUrl)
@@ -488,7 +490,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
           res.end(code);
         });
 
-        const exposesPath = `${base}/${options.filename.replace(/\.[^.]+$/, '')}.exposes.js`;
+        const exposesPath = `${base}/${ssrExposesFileName}`;
         server.middlewares.use(exposesPath, (_req, res) => {
           res.setHeader('Content-Type', 'application/javascript');
           res.setHeader('Access-Control-Allow-Origin', '*');
@@ -506,7 +508,7 @@ export function pluginSSRRemoteEntry(options: NormalizedModuleFederationOptions)
         // imports this path and Vite resolves it here so load() can serve it.
         const ssrDevPath = `/__mf_ssr__/${getSsrRemoteEntryFileName(options.filename)}`;
         if (id === ssrDevPath) return remoteEntrySSRId;
-        const exposesDevPath = `/__mf_ssr__/${options.filename.replace(/\.[^.]+$/, '')}.exposes.js`;
+        const exposesDevPath = `/__mf_ssr__/${ssrExposesFileName}`;
         if (id === exposesDevPath) return virtualExposesSSRId;
       },
 

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -4,6 +4,7 @@ import { addUsedShares, getUsedShares } from '../virtualRemoteEntry';
 import {
   generateRemoteEntrySSR,
   getRemoteEntrySSRId,
+  getSsrExposesFileName,
   getSsrRemoteEntryFileName,
 } from '../virtualRemoteEntrySSR';
 import { MODULE_CACHE_SHARE_SCOPE_KEY } from '../virtualRuntimeInitStatus';
@@ -93,6 +94,23 @@ describe('virtualRemoteEntrySSR', () => {
     it('never leaves a literal [hash] in the SSR filename', () => {
       expect(getSsrRemoteEntryFileName('remoteEntry-[hash].js')).not.toContain('[hash');
       expect(getSsrRemoteEntryFileName('mf-[hash:8]')).not.toContain('[hash');
+    });
+  });
+
+  describe('getSsrExposesFileName', () => {
+    it('maps remoteEntry.js to remoteEntry.exposes.js', () => {
+      expect(getSsrExposesFileName('remoteEntry.js')).toBe('remoteEntry.exposes.js');
+    });
+
+    it('strips [hash] placeholders to a stable exposes companion', () => {
+      expect(getSsrExposesFileName('remoteEntry-[hash]')).toBe('remoteEntry.exposes.js');
+      expect(getSsrExposesFileName('remoteEntry-[hash].js')).toBe('remoteEntry.exposes.js');
+      expect(getSsrExposesFileName('remote-entry-[hash:8].js')).toBe('remote-entry.exposes.js');
+    });
+
+    it('never leaves a literal [hash] in the exposes filename', () => {
+      expect(getSsrExposesFileName('remoteEntry-[hash].js')).not.toContain('[hash');
+      expect(getSsrExposesFileName('mf-[hash:8]')).not.toContain('[hash');
     });
   });
 

--- a/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
+++ b/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
@@ -277,12 +277,10 @@ describe('virtualRuntimeInitStatus', () => {
   });
 
   it('maps configured remotes through the scoped runtime alias', async () => {
-    const { getRuntimeRemoteAlias, getSsrRuntimeRemotes } = await import(
-      '../virtualRuntimeInitStatus'
-    );
-    const { normalizeModuleFederationOptions } = await import(
-      '../../utils/normalizeModuleFederationOptions'
-    );
+    const { getRuntimeRemoteAlias, getSsrRuntimeRemotes } =
+      await import('../virtualRuntimeInitStatus');
+    const { normalizeModuleFederationOptions } =
+      await import('../../utils/normalizeModuleFederationOptions');
 
     const options = normalizeModuleFederationOptions({
       name: 'ssr-host',

--- a/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
+++ b/src/virtualModules/__tests__/virtualRuntimeInitStatus.test.ts
@@ -275,4 +275,32 @@ describe('virtualRuntimeInitStatus', () => {
     expect(code).toContain('"name":"remote"');
     expect(code).toContain('"entry":"http://localhost:4174/remoteEntry.js"');
   });
+
+  it('maps configured remotes through the scoped runtime alias', async () => {
+    const { getRuntimeRemoteAlias, getSsrRuntimeRemotes } = await import(
+      '../virtualRuntimeInitStatus'
+    );
+    const { normalizeModuleFederationOptions } = await import(
+      '../../utils/normalizeModuleFederationOptions'
+    );
+
+    const options = normalizeModuleFederationOptions({
+      name: 'ssr-host',
+      remotes: {
+        remote: {
+          type: 'module',
+          name: 'remote',
+          entry: 'http://localhost:4174/remoteEntry.js',
+        },
+      },
+    });
+
+    expect(getSsrRuntimeRemotes(options.remotes, options)).toEqual([
+      {
+        name: getRuntimeRemoteAlias('remote', options),
+        entry: 'http://localhost:4174/remoteEntry.js',
+        type: 'module',
+      },
+    ]);
+  });
 });

--- a/src/virtualModules/__tests__/virtualSharedInstanceIsolation.test.ts
+++ b/src/virtualModules/__tests__/virtualSharedInstanceIsolation.test.ts
@@ -16,7 +16,13 @@ import {
   writePreBuildLibPath,
 } from '../virtualShared_preBuild';
 import { generateRemoteEntry } from '../virtualRemoteEntry';
-import { getRuntimeInitStatusImportId, writeRuntimeInitStatus } from '../virtualRuntimeInitStatus';
+import { generateRemotes } from '../virtualRemotes';
+import { initVirtualModules } from '../index';
+import {
+  getRuntimeInitStatusImportId,
+  getRuntimeRemoteAlias,
+  writeRuntimeInitStatus,
+} from '../virtualRuntimeInitStatus';
 import { recordTreeShakingExports, setTreeShakingBuildMode } from '../../utils/treeShaking';
 import { getFederationScopeKey } from '../virtualModuleScope';
 
@@ -169,6 +175,32 @@ describe('shared virtual module instance isolation', () => {
     expect(codeB).not.toContain(`import(${JSON.stringify(runtimeInitB)})`);
     expect(codeB).toContain('https://b.invalid/ssr.js');
     expect(codeB).not.toContain('https://a.invalid/ssr.js');
+  });
+
+  it('registers SSR remotes under the same scoped names generateRemotes loadRemote uses', () => {
+    const options = normalizeModuleFederationOptions({
+      name: 'ssr-host',
+      remotes: {
+        remote: {
+          type: 'module',
+          name: 'remote',
+          entry: 'http://localhost:4174/remoteEntry.js',
+          entryGlobalName: 'remote',
+          shareScope: 'default',
+        },
+      },
+    });
+
+    initVirtualModules('serve', undefined, true, options);
+    const initCode = VirtualModule.findById(getRuntimeInitStatusImportId(options))?.code ?? '';
+    const remoteCode = generateRemotes('remote/App', 'serve', true, 'server', options);
+    const aliased = getRuntimeRemoteAlias('remote', options);
+
+    expect(remoteCode).toContain(`runtime.loadRemote(${JSON.stringify(`${aliased}/App`)})`);
+    expect(remoteCode).toContain(`"name":${JSON.stringify(aliased)}`);
+    expect(initCode).toContain(`"name":${JSON.stringify(aliased)}`);
+    expect(initCode).not.toMatch(/"name":"remote"/);
+    expect(remoteCode).not.toMatch(/"name":"remote"/);
   });
 
   it('does not combine tree-shaking providers across federation instances', () => {

--- a/src/virtualModules/index.ts
+++ b/src/virtualModules/index.ts
@@ -3,7 +3,7 @@ import {
   writeHostAutoInit,
   writeLocalSharedImportMap,
 } from './virtualRemoteEntry';
-import { writeRuntimeInitStatus } from './virtualRuntimeInitStatus';
+import { getSsrRuntimeRemotes, writeRuntimeInitStatus } from './virtualRuntimeInitStatus';
 import type { NormalizedModuleFederationOptions } from '../utils/normalizeModuleFederationOptions';
 
 export {
@@ -86,12 +86,6 @@ export function initVirtualModules(
     enableSsrInit,
     getHostAutoInitPath(options),
     options,
-    options
-      ? Object.entries(options.remotes).map(([name, item]) => ({
-          name,
-          entry: item.entry,
-          type: item.type ?? 'module',
-        }))
-      : undefined
+    options ? getSsrRuntimeRemotes(options.remotes, options) : undefined
   );
 }

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -15,20 +15,30 @@ export function getRemoteEntrySSRId(
   return `${REMOTE_ENTRY_SSR_ID}:${getVirtualModuleScopeKey(options)}`;
 }
 
-export function getSsrRemoteEntryFileName(browserFilename: string): string {
-  // Strip literal `[hash]` / `[hash:N]` placeholders so the SSR companion stays
-  // stable (`remoteEntry-[hash].js` → `remoteEntry.ssr.js`). Do not try to mirror
+function stripSsrFilenameHashPlaceholder(filename: string): string {
+  // Strip literal `[hash]` / `[hash:N]` placeholders so SSR companions stay
+  // stable (`remoteEntry-[hash].js` → `remoteEntry.js`). Do not try to mirror
   // the browser content hash in the SSR filename.
-  let filename = browserFilename;
-  if (filename.includes('[hash')) {
-    filename = filename.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
-    if (!/\.[^.]+$/.test(filename)) {
-      filename = `${filename}.js`;
-    }
+  if (!filename.includes('[hash')) return filename;
+  filename = filename.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
+  if (!/\.[^.]+$/.test(filename)) {
+    filename = `${filename}.js`;
   }
+  return filename;
+}
+
+export function getSsrRemoteEntryFileName(browserFilename: string): string {
+  const filename = stripSsrFilenameHashPlaceholder(browserFilename);
   const ext = filename.match(/\.[^.]+$/)?.[0] || '.js';
   const base = filename.slice(0, filename.length - ext.length);
   return `${base}.ssr${ext}`;
+}
+
+export function getSsrExposesFileName(browserFilename: string): string {
+  const filename = stripSsrFilenameHashPlaceholder(browserFilename);
+  const ext = filename.match(/\.[^.]+$/)?.[0];
+  const base = ext ? filename.slice(0, filename.length - ext.length) : filename;
+  return `${base}.exposes.js`;
 }
 
 /** Singleton map for SSR loadShare: expand `pkg/` via usedShares; never serialize the prefix. */

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -13,6 +13,7 @@ import {
   getRuntimeRemoteCachePrefix,
   getRuntimeInitStatusImportId,
   getRuntimeModuleCacheBootstrapCode,
+  getSsrRuntimeRemotes,
   MODULE_CACHE_SHARE_SCOPE_KEY,
 } from './virtualRuntimeInitStatus';
 
@@ -433,11 +434,7 @@ export function generateRemotes(
       ? `runtime.registerRemotes([${JSON.stringify(remoteRegistration)}]);`
       : '';
   const hostAutoInitPath = getHostAutoInitPath(options);
-  const ssrRemotes = Object.entries(resolvedOptions.remotes).map(([name, item]) => ({
-    name: getRuntimeRemoteAlias(name, options),
-    entry: item.entry,
-    type: item.type ?? 'module',
-  }));
+  const ssrRemotes = getSsrRuntimeRemotes(resolvedOptions.remotes, options);
   const browserHostInitCode = `import(${JSON.stringify(hostAutoInitPath)})
         .then((mod) => mod.hostInitPromise)
         .then(initResolve, initReject);`;

--- a/src/virtualModules/virtualRuntimeInitStatus.ts
+++ b/src/virtualModules/virtualRuntimeInitStatus.ts
@@ -45,6 +45,17 @@ export function getRuntimeRemoteAlias(alias: string, options?: NormalizedModuleF
   return `${getFederationScopeKey(options)}__${alias}`;
 }
 
+export function getSsrRuntimeRemotes(
+  remotes: NormalizedModuleFederationOptions['remotes'],
+  options?: NormalizedModuleFederationOptions
+) {
+  return Object.entries(remotes).map(([name, item]) => ({
+    name: getRuntimeRemoteAlias(name, options),
+    entry: item.entry,
+    type: item.type ?? 'module',
+  }));
+}
+
 export function getRuntimeInitGlobalKey(ownerImportId?: string) {
   return `__mf_init__${ownerImportId ?? virtualRuntimeInitStatus.getImportId()}__`;
 }


### PR DESCRIPTION
## Summary

`initVirtualModules` registered bare remote names while `generateRemotes` used scoped runtime aliases — first writer of runtime init could leave `loadRemote("…__remote/App")` without a matching runtime entry.

Default hashed `filename` (`remoteEntry-[hash]`) also left a literal `[hash]` in SSR `.exposes.js` URLs (entry was already stripped in #1157).

## Fix

Both paths use `getSsrRuntimeRemotes` / `getRuntimeRemoteAlias`. `getSsrExposesFileName` strips `[hash]` / `[hash:N]` like the SSR entry.

## Test plan

- [x] Isolation test for scoped remotes in SSR init
- [x] Hashed exposes middleware / filename unit tests
