### PR TITLE
fix: complete solid-js and zustand common shared subpaths

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2627,12 +2627,18 @@ describe('vite:module-federation-early-init', () => {
 
     const vanillaImportId = getLoadShareModulePath('zustand/vanilla', false);
     const reactImportId = getLoadShareModulePath('zustand/react', false);
+    const middlewareImportId = getLoadShareModulePath('zustand/middleware', false);
+    const shallowImportId = getLoadShareModulePath('zustand/shallow', false);
     const optimizeDeps = [...config.optimizeDeps.include, ...config.optimizeDeps.exclude];
 
     expect(VirtualModule.findById(vanillaImportId)?.code).toBeTruthy();
     expect(VirtualModule.findById(reactImportId)?.code).toBeTruthy();
+    expect(VirtualModule.findById(middlewareImportId)?.code).toBeTruthy();
+    expect(VirtualModule.findById(shallowImportId)?.code).toBeTruthy();
     expect(optimizeDeps).toContain('zustand/vanilla');
     expect(optimizeDeps).toContain('zustand/react');
+    expect(optimizeDeps).toContain('zustand/middleware');
+    expect(optimizeDeps).toContain('zustand/shallow');
   });
 
   it('includes shared react in dev optimizeDeps when react-redux is installed', () => {

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -433,6 +433,77 @@ describe('pluginProxySharedModule_preBuild', () => {
       expect(findSharedKey('react-dom/server.browser', shared)).toBeUndefined();
     });
 
+    it('auto-maps solid-js jsx runtimes and zustand middleware/shallow for a local provider', () => {
+      const shared: NormalizedShared = {
+        'solid-js': {
+          name: 'solid-js',
+          from: '',
+          version: '1.9.0',
+          scope: 'default',
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^1.9.0',
+            strictVersion: false,
+          },
+        },
+        zustand: {
+          name: 'zustand',
+          from: '',
+          version: '5.0.0',
+          scope: 'default',
+          shareConfig: {
+            singleton: true,
+            requiredVersion: '^5.0.0',
+            strictVersion: false,
+          },
+        },
+      };
+
+      expect(findSharedKey('solid-js/jsx-runtime', shared)).toBe('solid-js');
+      expect(findSharedKey('solid-js/jsx-dev-runtime', shared)).toBe('solid-js');
+      expect(findSharedKey('solid-js/web', shared)).toBe('solid-js');
+      expect(findSharedKey('zustand/middleware', shared)).toBe('zustand');
+      expect(findSharedKey('zustand/shallow', shared)).toBe('zustand');
+      expect(findSharedKey('zustand/vanilla', shared)).toBe('zustand');
+      expect(findSharedKey('zustand/context', shared)).toBeUndefined();
+    });
+
+    it('does not auto-map solid-js or zustand common subpaths when the package uses import:false', () => {
+      const shared: NormalizedShared = {
+        'solid-js': {
+          name: 'solid-js',
+          from: '',
+          version: '1.9.0',
+          scope: 'default',
+          shareConfig: {
+            singleton: true,
+            import: false,
+            requiredVersion: '^1.9.0',
+            strictVersion: false,
+          },
+        },
+        zustand: {
+          name: 'zustand',
+          from: '',
+          version: '5.0.0',
+          scope: 'default',
+          shareConfig: {
+            singleton: true,
+            import: false,
+            requiredVersion: '^5.0.0',
+            strictVersion: false,
+          },
+        },
+      };
+
+      expect(findSharedKey('solid-js', shared)).toBe('solid-js');
+      expect(findSharedKey('solid-js/jsx-runtime', shared)).toBeUndefined();
+      expect(findSharedKey('solid-js/jsx-dev-runtime', shared)).toBeUndefined();
+      expect(findSharedKey('zustand', shared)).toBe('zustand');
+      expect(findSharedKey('zustand/middleware', shared)).toBeUndefined();
+      expect(findSharedKey('zustand/shallow', shared)).toBeUndefined();
+    });
+
     it('keeps explicit react-dom server shares available', () => {
       const shared = makeShared();
       shared['react-dom/server'] = {

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -744,6 +744,37 @@ describe('normalizeModuleFederationOption', () => {
       expect(shared['@scope/ui/']).toBeDefined();
     });
 
+    it('collapses solid-js/ and zustand/ to the package root', () => {
+      const shared = normalizeModuleFederationOptions({
+        ...minimalOptions,
+        shared: {
+          'solid-js/': {
+            singleton: true,
+          },
+          'zustand/': {
+            singleton: true,
+            import: false,
+          },
+        },
+      }).shared;
+
+      expect(shared['solid-js']).toMatchObject({
+        name: 'solid-js',
+        shareConfig: {
+          singleton: true,
+        },
+      });
+      expect(shared['solid-js/']).toBeUndefined();
+      expect(shared.zustand).toMatchObject({
+        name: 'zustand',
+        shareConfig: {
+          import: false,
+          singleton: true,
+        },
+      });
+      expect(shared['zustand/']).toBeUndefined();
+    });
+
     it('preserves consumer-only react/ with import: false as a namespace prefix', () => {
       const shared = normalizeModuleFederationOptions({
         ...minimalOptions,

--- a/src/utils/__tests__/pathNormalization.test.ts
+++ b/src/utils/__tests__/pathNormalization.test.ts
@@ -91,6 +91,36 @@ describe('pathNormalization', () => {
     ).toBeUndefined();
   });
 
+  it('lists solid-js jsx runtimes and zustand middleware/shallow as common subpaths', () => {
+    expect(getCommonSharedSubpaths('solid-js')).toEqual([
+      'solid-js/web',
+      'solid-js/store',
+      'solid-js/html',
+      'solid-js/h',
+      'solid-js/jsx-runtime',
+      'solid-js/jsx-dev-runtime',
+    ]);
+    expect(getCommonSharedSubpaths('zustand')).toEqual([
+      'zustand/vanilla',
+      'zustand/react',
+      'zustand/middleware',
+      'zustand/shallow',
+    ]);
+    expect(getCommonSharedSubpaths('zustand')).not.toContain('zustand/context');
+    expect(
+      getCommonSharedSubpathFromNodeModulePath(
+        '/repo/node_modules/solid-js/jsx-runtime.js',
+        'solid-js'
+      )
+    ).toBe('solid-js/jsx-runtime');
+    expect(
+      getCommonSharedSubpathFromNodeModulePath(
+        '/repo/node_modules/zustand/middleware.js',
+        'zustand'
+      )
+    ).toBe('zustand/middleware');
+  });
+
   it.each([
     'styles.css',
     'styles.scss?inline',

--- a/src/utils/pathNormalization.ts
+++ b/src/utils/pathNormalization.ts
@@ -6,8 +6,16 @@ export const COMMON_SHARED_SUBPATHS: Record<string, string[]> = {
   // entries into the client share set. SSR imports them as normal modules, or
   // users add an explicit shared key.
   'react-dom': ['react-dom/client', 'react-dom/profiling'],
-  'solid-js': ['solid-js/web', 'solid-js/store', 'solid-js/html', 'solid-js/h'],
-  zustand: ['zustand/vanilla', 'zustand/react'],
+  'solid-js': [
+    'solid-js/web',
+    'solid-js/store',
+    'solid-js/html',
+    'solid-js/h',
+    'solid-js/jsx-runtime',
+    'solid-js/jsx-dev-runtime',
+  ],
+  // First-party entry points only. zustand/context is not a v5 export.
+  zustand: ['zustand/vanilla', 'zustand/react', 'zustand/middleware', 'zustand/shallow'],
 };
 
 const VITE_DEFAULT_ASSET_TYPES = [


### PR DESCRIPTION
## Summary

`COMMON_SHARED_SUBPATHS` for `solid-js` / `zustand` was incomplete. Apps that share the package root still got separate copies of `solid-js/jsx-runtime` or `zustand/middleware` / `shallow`.

## Fix

Add `solid-js/jsx-runtime`, `solid-js/jsx-dev-runtime`, `zustand/middleware`, and `zustand/shallow`. Collapse policy for `solid-js/` and `zustand/` is unchanged. `import: false` still skips auto-map. Does not reopen `react/` prefix policy.

## Test plan

- [x] Auto-map tests for new subpaths
- [x] import:false does not auto-map
