### PR TITLE
fix: guard untyped SSR JSON and remove unused shared helpers

### DIFF
--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -408,8 +408,6 @@ export function isSharedPackageDependency(sharedKey: string, dependency: string)
 
 export function proxySharedModule(options: {
   shared?: NormalizedShared;
-  include?: string | string[];
-  exclude?: string | string[];
   federationOptions?: NormalizedModuleFederationOptions;
   getParsePromise?: () => Promise<unknown>;
 }): Plugin[] {

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -794,6 +794,44 @@ describe('ssrEntryLoaderPlugin — manifest SSR entry resolution', () => {
     const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
     expect(heads.length).toBeGreaterThan(0);
   });
+
+  it('ignores a JSON array posted as a manifest instead of treating it as an object', async () => {
+    const fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': {
+        ok: true,
+        json: [{ metaData: { ssrRemoteEntry: { name: 'trap.ssr.js' } } }],
+      },
+      'http://localhost:5001/remoteEntry.ssr.js': { ok: false },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+    await factory().loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
+    });
+    expectFetchNotCalled(fetch, 'http://localhost:5001/trap.ssr.js');
+    const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
+    expect(heads.length).toBeGreaterThan(0);
+  });
+
+  it('ignores ssrRemoteEntry.name when it is not a string', async () => {
+    const fetch = makeFetchMock({
+      'http://localhost:5001/mf-manifest.json': {
+        ok: true,
+        json: {
+          metaData: { ssrRemoteEntry: { name: { nested: true }, path: '', type: 'module' } },
+        },
+      },
+      'http://localhost:5001/remoteEntry.ssr.js': { ok: false },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+    const factory = await freshLoader();
+    await factory().loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
+    });
+    expect(fetch.mock.calls.some(([url]) => String(url).includes('[object Object]'))).toBe(false);
+    const heads = fetch.mock.calls.filter((c) => c[1]?.method === 'HEAD');
+    expect(heads.length).toBeGreaterThan(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1420,6 +1458,43 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
         },
       },
     ]);
+  });
+
+  it('does not throw when the runner endpoint returns a JSON primitive', async () => {
+    const sharedFetchResults: unknown[] = [];
+    const factory = await freshLoaderWithRunner((runnerOptions) => ({
+      import: vi.fn(async () => {
+        sharedFetchResults.push(
+          await runnerOptions.transport.invoke({
+            type: 'custom',
+            event: 'vite:invoke',
+            data: { name: 'fetchModule', data: ['react'] },
+          })
+        );
+        return { init: vi.fn(), get: vi.fn() };
+      }),
+    }));
+    const fetch = makeFetchMock({
+      'http://localhost:4175/mf-manifest.json': {
+        ok: true,
+        json: {
+          metaData: {
+            ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '__mf_ssr__/', type: 'module' },
+          },
+        },
+      },
+      'http://localhost:4175/__mf_runner__': {
+        ok: true,
+        json: null,
+      },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+
+    await factory().loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:4175/remoteEntry.js' },
+    });
+
+    expect(sharedFetchResults).toEqual([{ error: { message: 'Invalid runner response' } }]);
   });
 
   it('returns null when ModuleRunner import throws (no silent fallback)', async () => {

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -175,9 +175,7 @@ async function getOrCreateRunner(
                 fetchTimeoutMs
               );
               const text = await readResponseTextBounded(res, fetchMaxBytes, runnerEndpoint);
-              const result = JSON.parse(text) as
-                | { result: unknown }
-                | { error: { message: string } };
+              const result = parseRunnerInvokeResult(JSON.parse(text));
               // Let the remote transform configured shares and resolve local-only
               // dependencies first. This preserves remote-owned React islands.
               if ('error' in result && payload.data.name === 'fetchModule') {
@@ -227,6 +225,47 @@ interface ManifestMetaData {
 
 interface Manifest {
   metaData?: ManifestMetaData;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseManifestEntry(
+  value: unknown
+): { name: string; path: string; type: string } | undefined {
+  if (!isPlainObject(value) || typeof value.name !== 'string' || value.name.length === 0) {
+    return undefined;
+  }
+  return {
+    name: value.name,
+    path: typeof value.path === 'string' ? value.path : '',
+    type: typeof value.type === 'string' ? value.type : 'module',
+  };
+}
+
+/** Network JSON is untyped until parsed. Keep the original object for version hashing. */
+function parseManifest(data: unknown): Manifest | null {
+  if (!isPlainObject(data)) return null;
+  return data as Manifest;
+}
+
+function parseRunnerInvokeResult(
+  data: unknown
+): { result: unknown } | { error: { message: string } } {
+  if (!isPlainObject(data)) {
+    return { error: { message: 'Invalid runner response' } };
+  }
+  if ('error' in data) {
+    const error = data.error;
+    const message =
+      isPlainObject(error) && typeof error.message === 'string'
+        ? error.message
+        : 'Unknown runner error';
+    return { error: { message } };
+  }
+  if ('result' in data) return { result: data.result };
+  return { result: data };
 }
 
 /**
@@ -317,7 +356,7 @@ async function fetchManifest(
     const res = await fetchWithTimeout(manifestUrl, {}, fetchTimeoutMs);
     if (!res.ok) return null;
     const text = await readResponseTextBounded(res, fetchMaxBytes, manifestUrl);
-    return JSON.parse(text) as Manifest;
+    return parseManifest(JSON.parse(text));
   } catch (error) {
     // Size-limit failures must fail closed; other discovery errors stay soft.
     if (isSsrFetchBodyTooLargeError(error)) throw error;
@@ -385,15 +424,15 @@ function resolveEntryAssetUrl(entry: { name: string; path?: string }, manifestUr
 }
 
 function resolveSSREntryUrl(manifest: Manifest, manifestUrl: string): SsrEntryCandidate | null {
-  const meta = manifest?.metaData;
-  if (!meta?.ssrRemoteEntry?.name) return null;
+  const entry = parseManifestEntry(manifest.metaData?.ssrRemoteEntry);
+  if (!entry) return null;
 
   const base = manifestUrl.replace(/\/[^/]+$/, '/');
-  const entryPath = (meta.ssrRemoteEntry.path || '') + meta.ssrRemoteEntry.name;
+  const entryPath = entry.path + entry.name;
   const url = new URL(entryPath, base).href;
   return {
     url,
-    type: meta.ssrRemoteEntry.type || 'module',
+    type: entry.type,
     versionKey: computeManifestVersionKey(manifest),
   };
 }
@@ -424,8 +463,8 @@ function resolveAssetBaseUrl(
   manifest: Manifest | null,
   manifestUrl: string
 ): string {
-  const remoteEntry = manifest?.metaData?.remoteEntry;
-  if (remoteEntry?.name) return resolveEntryAssetUrl(remoteEntry, manifestUrl);
+  const remoteEntry = parseManifestEntry(manifest?.metaData?.remoteEntry);
+  if (remoteEntry) return resolveEntryAssetUrl(remoteEntry, manifestUrl);
   if (!isManifestEntry(entryUrl)) return entryUrl;
   return new URL('remoteEntry.js', manifestUrl.replace(/\/[^/]+$/, '/')).href;
 }

--- a/src/virtualModules/virtualRemotes.ts
+++ b/src/virtualModules/virtualRemotes.ts
@@ -198,11 +198,6 @@ export function getRemoteRegistration(
   };
 }
 
-export function getRemoteFromId(id: string, remotes: Record<string, RemoteObjectConfig>) {
-  const remoteAlias = getRemoteAliasFromId(id, remotes);
-  return remoteAlias ? remotes[remoteAlias] : undefined;
-}
-
 export function getRuntimeRemoteId(
   id: string,
   remotes: Record<string, RemoteObjectConfig>,

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1570,16 +1570,6 @@ export function getPreBuildLibImportId(
   const importId = preBuildCacheMap[pkg].getImportId();
   return importId;
 }
-export function getPreBuildLibPath(
-  pkg: string,
-  options?: NormalizedModuleFederationOptions
-): string {
-  const { preBuildCacheMap } = getSharedVirtualModuleState(options);
-  if (!preBuildCacheMap[pkg]) {
-    preBuildCacheMap[pkg] = createScopedSharedVirtualModule(pkg, PREBUILD_TAG, options);
-  }
-  return preBuildCacheMap[pkg].getImportId();
-}
 export function getPreBuildShareItem(
   pkg: string,
   options?: NormalizedModuleFederationOptions


### PR DESCRIPTION
## Summary

SSR manifest and ModuleRunner invoke responses were trusted via `JSON.parse(…) as …`, so arrays / primitives / non-string `name` could become bad URLs or throw on `'error' in null`.

Also removes unused `getPreBuildLibPath` (duplicate of `getPreBuildLibImportId`), unused `getRemoteFromId`, and unused `include`/`exclude` on `proxySharedModule`.

## Fix

Parse as `unknown` with plain-object / field guards. Delete the unused helpers and options.

## Test plan

- [x] SSR entry loader tests for malformed JSON
- [x] Typecheck / vitest
