### PR TITLE
fix: harden cyclic share resolution

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1317,6 +1317,43 @@ describe('pluginProxySharedModule_preBuild', () => {
     readFileSyncMock.mockReset().mockReturnValue('{}');
   });
 
+  it('walks past a nameless package.json when identifying an unshared workspace package', async () => {
+    normalizeModuleFederationOptions({ name: 'host', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    const manifests: Record<string, string> = {
+      '/repo/apps/remote/node_modules/vue/package.json':
+        '{"dependencies":{"bridge":"workspace:*"}}',
+      '/repo/packages/bridge/src/package.json': '{"type":"module"}',
+      '/repo/packages/bridge/package.json': '{"name":"bridge"}',
+    };
+    existsSyncMock.mockImplementation((p: string) => p in manifests);
+    readFileSyncMock.mockImplementation((p: string) => manifests[p] ?? '{}');
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+  });
+
   it('still proxies imports from unshared workspace packages outside the shared package cycle', async () => {
     normalizeModuleFederationOptions({ name: 'host', shared: {} });
     hasPackageDependencyMock.mockReturnValue(false);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -231,7 +231,13 @@ function getWorkspacePackageNameFromFile(file: string): string | undefined {
       try {
         const manifestName = (JSON.parse(readFileSync(manifestPath, 'utf-8')) as { name?: unknown })
           .name;
-        name = typeof manifestName === 'string' ? manifestName : undefined;
+        if (typeof manifestName !== 'string') {
+          const parent = path.dirname(dir);
+          if (parent === dir) break;
+          dir = parent;
+          continue;
+        }
+        name = manifestName;
       } catch {
         name = undefined;
       }

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -420,6 +420,26 @@ vi.mock('../../utils/packageUtils', () => {
       return match ? match[0] : packageString;
     },
     getInstalledPackageJson: (pkg: string) => {
+      if (pkg === '@repro/aaa-host-only') {
+        return {
+          path: '/repo/packages/aaa-host-only/package.json',
+          dir: '/repo/packages/aaa-host-only',
+          packageJson: {
+            name: '@repro/aaa-host-only',
+            dependencies: { '@repro/zzz-consumer': 'workspace:*' },
+          },
+        };
+      }
+      if (pkg === '@repro/zzz-consumer') {
+        return {
+          path: '/repo/packages/zzz-consumer/package.json',
+          dir: '/repo/packages/zzz-consumer',
+          packageJson: {
+            name: '@repro/zzz-consumer',
+            dependencies: { '@repro/aaa-host-only': 'workspace:*' },
+          },
+        };
+      }
       if (pkg === '@repro/react-consumer') {
         return {
           path: '/repo/packages/react-consumer/package.json',
@@ -2400,6 +2420,84 @@ describe('virtualRemoteEntry', () => {
     expect(cache['default:@repro/react-consumer']).toEqual({ value: '@repro/react-consumer' });
     expect(cache['default:@repro/core']).toBeUndefined();
     expect(cache['default:@repro/shared-lib']).toBeUndefined();
+  });
+
+  it('does not seed a cycle member before its unresolved runtime-only prerequisite', async () => {
+    const shareItem = (name: string, importFalse = false) => ({
+      name,
+      from: 'remote',
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^1.0.0',
+        strictVersion: false,
+        ...(importFalse ? { import: false as const } : {}),
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      '@repro/aaa-host-only': shareItem('@repro/aaa-host-only', true),
+      '@repro/zzz-consumer': shareItem('@repro/zzz-consumer'),
+    });
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('@repro/aaa-host-only');
+    mod.addUsedShares('@repro/zzz-consumer');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__host',
+        name: 'host',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'loaded-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+    const attempted: string[] = [];
+    const usedShared = {
+      '@repro/aaa-host-only': {
+        ...shareItem('@repro/aaa-host-only', true),
+        scope: ['default'],
+      },
+      '@repro/zzz-consumer': {
+        ...shareItem('@repro/zzz-consumer'),
+        scope: ['default'],
+        get: async () => () => ({ value: 'must stay blocked' }),
+      },
+    };
+
+    const cache = await new Function(
+      'usedShared',
+      'attempted',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        const mfName = 'host';
+        const __mfGetSharedCacheDescriptor = (pkg, singleton, version, scope) => ({
+          canonical: (Array.isArray(scope) ? scope[0] : scope || 'default') + ':' + pkg
+        });
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const __mfReadTreeShakingSharedSelection = () => undefined;
+        const __mfResolveTreeShakingShared = async () => {};
+        const __mfResolveImportFalseShared = async (pkg) => attempted.push(pkg);
+        ${getRuntimeSeedCode(code)}
+        ${getRuntimeDeferredResolutionCode(code)}
+        return __mfModuleCache.share;
+      })();`
+    )(usedShared, attempted);
+
+    expect(attempted).toEqual(['@repro/aaa-host-only']);
+    expect(cache['default:@repro/aaa-host-only']).toBeUndefined();
+    expect(cache['default:@repro/zzz-consumer']).toBeUndefined();
   });
 
   it('bridges a lazy singleton before evaluating shared modules that capture it', async () => {

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -854,15 +854,30 @@ function generateRuntimeSharedCacheSeedCode(
         ${toSafeJsLiteral(shareStrategy)}
       ));
     };
-    const __mfFirstRuntimeSeedBarrierIndex = __mfSeedKeys.findIndex(
-      __mfNeedsPreInitSeedBarrier
+    const __mfExpandBlockedSeedKeys = (blocked) => {
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const pkg of __mfSeedKeys) {
+          const seedIndex = __mfSeedIndex.get(pkg);
+          if (blocked.has(seedIndex)) continue;
+          if ((__mfSeedPrerequisites[seedIndex] || []).some((dependency) => blocked.has(dependency))) {
+            blocked.add(seedIndex);
+            changed = true;
+          }
+        }
+      }
+      return blocked;
+    };
+    const __mfPreInitBlockedSeedKeys = __mfExpandBlockedSeedKeys(new Set(
+      __mfSeedKeys.filter(__mfNeedsPreInitSeedBarrier).map((pkg) => __mfSeedIndex.get(pkg))
+    ));
+    const __mfImmediateSeedKeys = __mfSeedKeys.filter(
+      (pkg) => !__mfPreInitBlockedSeedKeys.has(__mfSeedIndex.get(pkg))
     );
-    const __mfImmediateSeedKeys = __mfFirstRuntimeSeedBarrierIndex === -1
-      ? __mfSeedKeys
-      : __mfSeedKeys.slice(0, __mfFirstRuntimeSeedBarrierIndex);
-    var __mfDeferredSeedKeys = __mfFirstRuntimeSeedBarrierIndex === -1
-      ? []
-      : __mfSeedKeys.slice(__mfFirstRuntimeSeedBarrierIndex);
+    var __mfDeferredSeedKeys = __mfSeedKeys.filter(
+      (pkg) => __mfPreInitBlockedSeedKeys.has(__mfSeedIndex.get(pkg))
+    );
     await __mfSeedLocalShared(__mfImmediateSeedKeys);`;
 }
 
@@ -2060,10 +2075,6 @@ export function generateRemoteEntry(
     for (const pkg of __mfDeferredSeedKeys) {
       const share = usedShared[pkg];
       const seedIndex = __mfSeedIndex.get(pkg);
-      if ((__mfSeedPrerequisites[seedIndex] || []).some((dependency) => __mfBlockedSeedKeys.has(dependency))) {
-        __mfBlockedSeedKeys.add(seedIndex);
-        continue;
-      }
       if (__mfIsRuntimeOnlySharePending(pkg)) {
         try {
           if (share.treeShaking) {
@@ -2082,10 +2093,12 @@ export function generateRemoteEntry(
       }
       if (__mfIsRuntimeOnlySharePending(pkg)) {
         __mfBlockedSeedKeys.add(seedIndex);
-        continue;
       }
-      __mfReadyDeferredSeedKeys.push(pkg);
     }
+    __mfExpandBlockedSeedKeys(__mfBlockedSeedKeys);
+    __mfReadyDeferredSeedKeys.push(...__mfDeferredSeedKeys.filter(
+      (pkg) => !__mfBlockedSeedKeys.has(__mfSeedIndex.get(pkg))
+    ));
     await __mfSeedLocalShared(__mfReadyDeferredSeedKeys);
     initResolve(initRes)
     return initRes


### PR DESCRIPTION
Handles nameless workspace manifests and transitively blocks unresolved cyclic share dependencies.
