### PR TITLE
fix: decide unshared workspace cycle edges from runtime imports instead of manifests

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -13,6 +13,8 @@ const {
   hasPackageDependencyMock,
   existsSyncMock,
   readFileSyncMock,
+  readdirSyncMock,
+  statSyncMock,
   addUsedSharesMock,
   refreshHostAutoInitMock,
   writeLoadShareModuleMock,
@@ -26,6 +28,8 @@ const {
   hasPackageDependencyMock: vi.fn<(pkg: string, cwd?: string) => boolean>(),
   existsSyncMock: vi.fn<(path: string) => boolean>(() => false),
   readFileSyncMock: vi.fn<(path: string) => string>(() => '{}'),
+  readdirSyncMock: vi.fn<(dir: string, opts?: unknown) => unknown[]>(() => []),
+  statSyncMock: vi.fn<(file: string) => { size: number }>(() => ({ size: 128 })),
   addUsedSharesMock: vi.fn<(pkg: string) => void>(),
   refreshHostAutoInitMock: vi.fn<() => void>(),
   writeLoadShareModuleMock: vi.fn(),
@@ -49,6 +53,8 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     existsSync: existsSyncMock,
     readFileSync: readFileSyncMock,
+    readdirSync: readdirSyncMock,
+    statSync: statSyncMock,
   };
 });
 
@@ -164,8 +170,11 @@ vi.mock('../../utils/VirtualModule', () => ({
 import {
   excludeSharedSubDependencies,
   findSharedKey,
+  getRuntimeImportSpecifiers,
   proxySharedModule,
 } from '../pluginProxySharedModule_preBuild';
+
+const sourceFile = (name: string) => ({ name, isDirectory: () => false, isFile: () => true });
 import {
   getResolvedLocalSharedImportMapId,
   getUsedShares,
@@ -1229,6 +1238,7 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(writeLoadShareModuleMock).toHaveBeenCalled();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('does not proxy shared dependency cycle edges from workspace packages', async () => {
@@ -1269,6 +1279,7 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('does not proxy shared dependency cycle edges from unshared workspace packages', async () => {
@@ -1285,9 +1296,14 @@ describe('pluginProxySharedModule_preBuild', () => {
     );
     readFileSyncMock.mockImplementation((p: string) => {
       if (p.endsWith('/vue/package.json')) return '{"dependencies":{"bridge":"workspace:*"}}';
+      if (p.endsWith('/vue/index.js'))
+        return "import { title } from 'bridge';\nexport const Button = title;";
       if (p.endsWith('/bridge/package.json')) return '{"name":"bridge"}';
       return '{}';
     });
+    readdirSyncMock.mockImplementation((dir: string) =>
+      dir === '/repo/apps/remote/node_modules/vue' ? [sourceFile('index.js')] : []
+    );
 
     const plugins = proxySharedModule({ shared: makeShared() });
     const proxyPlugin = getProxyPlugin(plugins);
@@ -1315,6 +1331,7 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('walks past a nameless package.json when identifying an unshared workspace package', async () => {
@@ -1323,11 +1340,15 @@ describe('pluginProxySharedModule_preBuild', () => {
     const manifests: Record<string, string> = {
       '/repo/apps/remote/node_modules/vue/package.json':
         '{"dependencies":{"bridge":"workspace:*"}}',
+      '/repo/apps/remote/node_modules/vue/index.js': "import { title } from 'bridge';",
       '/repo/packages/bridge/src/package.json': '{"type":"module"}',
       '/repo/packages/bridge/package.json': '{"name":"bridge"}',
     };
     existsSyncMock.mockImplementation((p: string) => p in manifests);
     readFileSyncMock.mockImplementation((p: string) => manifests[p] ?? '{}');
+    readdirSyncMock.mockImplementation((dir: string) =>
+      dir === '/repo/apps/remote/node_modules/vue' ? [sourceFile('index.js')] : []
+    );
 
     const plugins = proxySharedModule({ shared: makeShared() });
     const proxyPlugin = getProxyPlugin(plugins);
@@ -1398,6 +1419,86 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(writeLoadShareModuleMock).toHaveBeenCalled();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
+  });
+
+  it('proxies imports from unshared workspace packages the shared package reaches only through its manifest', async () => {
+    normalizeModuleFederationOptions({ name: 'remote', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'react' ? '/repo/packages/react/index.js' : undefined
+    );
+    // vue -> types-only -> hooks by manifests, but vue's code never evaluates `types-only`: the
+    // manifest closure is not an evaluation cycle, so the import from `hooks` stays on the proxy.
+    // An ordinary edge here would bind `hooks` to the local fallback even when a host provides vue.
+    const files: Record<string, string> = {
+      '/repo/apps/remote/node_modules/vue/package.json':
+        '{"dependencies":{"types-only":"workspace:*"}}',
+      '/repo/apps/remote/node_modules/vue/index.js':
+        "import type { Shape } from 'types-only';\nexport const Button = 'button';",
+      '/repo/packages/types-only/package.json':
+        '{"name":"types-only","dependencies":{"hooks":"workspace:*"}}',
+      '/repo/packages/hooks/package.json': '{"name":"hooks"}',
+    };
+    existsSyncMock.mockImplementation((p: string) => p in files);
+    readFileSyncMock.mockImplementation((p: string) => files[p] ?? '{}');
+    readdirSyncMock.mockImplementation((dir: string) =>
+      dir === '/repo/apps/remote/node_modules/vue' ? [sourceFile('index.js')] : []
+    );
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/hooks/src/use-service.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeDefined();
+    expect(writeLoadShareModuleMock).toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
+  });
+
+  it('collects runtime import specifiers and drops type-only statements', () => {
+    const code = `
+      import type { A } from 'types-a';
+      import { type B, useB } from 'lib-b';
+      import 'side-effect';
+      import * as ns from "@scope/pkg/sub/path";
+      export type { C } from 'types-c';
+      export { d } from './local';
+      // import 'commented-out';
+      /* import 'block-commented'; */
+      const lazy = () => import('lazy-pkg');
+      const legacy = require('legacy-pkg');
+      import { Readable } from 'stream';
+      import fs from 'node:fs';
+      var minified = x ? "from" + " " + getName(y) + "" : require("legacy-pkg/sub");
+    `;
+    expect(getRuntimeImportSpecifiers(code)).toEqual([
+      'lib-b',
+      'side-effect',
+      '@scope/pkg/sub/path',
+      'lazy-pkg',
+      'legacy-pkg',
+      'legacy-pkg/sub',
+    ]);
   });
 
   it('keeps walking the dependency tree past an unresolvable optional peer when detecting cycles', async () => {
@@ -1445,6 +1546,7 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('does not proxy internal imports for wildcard shared package keys during build', async () => {
@@ -1962,6 +2064,7 @@ describe('pluginProxySharedModule_preBuild', () => {
     warnSpy.mockRestore();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('does not exclude shared sub-dependencies in build mode', () => {
@@ -2017,6 +2120,7 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('preserves import false shared sub-dependencies in dev mode without warning', () => {
@@ -2077,6 +2181,7 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('preserves singleton: true shared sub-dependencies in dev mode without warning', () => {
@@ -2137,6 +2242,7 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('still removes non-singleton sub-dependencies when sibling singletons are preserved', () => {
@@ -2201,6 +2307,7 @@ describe('pluginProxySharedModule_preBuild', () => {
     warnSpy.mockRestore();
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
   it('uses auto-detected workspace sources in serve prebuild resolution without null deref', async () => {

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1425,9 +1425,11 @@ describe('pluginProxySharedModule_preBuild', () => {
   it('proxies imports from unshared workspace packages the shared package reaches only through its manifest', async () => {
     normalizeModuleFederationOptions({ name: 'remote', shared: {} });
     hasPackageDependencyMock.mockReturnValue(false);
-    getInstalledPackageEntryMock.mockImplementation((pkg) =>
-      pkg === 'react' ? '/repo/packages/react/index.js' : undefined
-    );
+    getInstalledPackageEntryMock.mockImplementation((pkg) => {
+      if (pkg === 'react') return '/repo/packages/react/index.js';
+      if (pkg === 'vue') return '/repo/apps/remote/node_modules/vue/index.js';
+      return undefined;
+    });
     // vue -> types-only -> hooks by manifests, but vue's code never evaluates `types-only`: the
     // manifest closure is not an evaluation cycle, so the import from `hooks` stays on the proxy.
     // An ordinary edge here would bind `hooks` to the local fallback even when a host provides vue.
@@ -1436,6 +1438,8 @@ describe('pluginProxySharedModule_preBuild', () => {
         '{"dependencies":{"types-only":"workspace:*"}}',
       '/repo/apps/remote/node_modules/vue/index.js':
         "import type { Shape } from 'types-only';\nexport const Button = 'button';",
+      // This file is shipped beside the entry but never imported by it.
+      '/repo/apps/remote/node_modules/vue/unused.js': "import 'hooks';",
       '/repo/packages/types-only/package.json':
         '{"name":"types-only","dependencies":{"hooks":"workspace:*"}}',
       '/repo/packages/hooks/package.json': '{"name":"hooks"}',
@@ -1443,7 +1447,9 @@ describe('pluginProxySharedModule_preBuild', () => {
     existsSyncMock.mockImplementation((p: string) => p in files);
     readFileSyncMock.mockImplementation((p: string) => files[p] ?? '{}');
     readdirSyncMock.mockImplementation((dir: string) =>
-      dir === '/repo/apps/remote/node_modules/vue' ? [sourceFile('index.js')] : []
+      dir === '/repo/apps/remote/node_modules/vue'
+        ? [sourceFile('index.js'), sourceFile('unused.js')]
+        : []
     );
 
     const plugins = proxySharedModule({ shared: makeShared() });
@@ -1478,10 +1484,13 @@ describe('pluginProxySharedModule_preBuild', () => {
   it('collects runtime import specifiers and drops type-only statements', () => {
     const code = `
       import type { A } from 'types-a';
+      import { type A2, /* retained comment */ type A3 as Alias } from 'types-named';
       import { type B, useB } from 'lib-b';
+      import { type as runtimeType } from 'runtime-type-export';
       import 'side-effect';
       import * as ns from "@scope/pkg/sub/path";
       export type { C } from 'types-c';
+      export { type C2 } from 'types-export-named';
       export { d } from './local';
       // import 'commented-out';
       /* import 'block-commented'; */
@@ -1490,14 +1499,21 @@ describe('pluginProxySharedModule_preBuild', () => {
       import { Readable } from 'stream';
       import fs from 'node:fs';
       var minified = x ? "from" + " " + getName(y) + "" : require("legacy-pkg/sub");
+      const importLookingText = "from 'not-an-import'";
+      const requireLookingText = "require('not-a-require')";
+      const regex = /from 'not-an-import'|require('not-a-require')/;
+      const jsx = <section></section>;
+      const jsxLazy = () => import('jsx-lazy');
     `;
     expect(getRuntimeImportSpecifiers(code)).toEqual([
       'lib-b',
-      'side-effect',
+      'runtime-type-export',
       '@scope/pkg/sub/path',
       'lazy-pkg',
+      'jsx-lazy',
       'legacy-pkg',
       'legacy-pkg/sub',
+      'side-effect',
     ]);
   });
 

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, realpathSync } from 'fs';
-import { createRequire } from 'module';
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'fs';
+import type { Dirent } from 'fs';
+import { createRequire, isBuiltin } from 'module';
 import * as path from 'node:path';
 import { pathToFileURL } from 'url';
 import type { Plugin, ResolvedConfig, UserConfig, ViteDevServer } from 'vite';
@@ -323,6 +324,98 @@ export function isSharedPackageDependency(sharedKey: string, dependency: string)
   return reachable.has(dependency);
 }
 
+const sharedRuntimeDependencyCache = new Map<string, Set<string>>();
+const SOURCE_FILE_RE = /\.(?:[cm]?js|[cm]?ts|jsx|tsx)$/;
+const NON_RUNTIME_SOURCE_RE = /(?:\.d\.[cm]?ts|\.(?:test|spec|stories)\.[cm]?[jt]sx?)$/;
+const NON_RUNTIME_DIRS = new Set(['node_modules', '__tests__', 'dist', 'build']);
+/** Bundled artifacts of a published package never import workspace packages; skip them instead of scanning megabytes. */
+const MAX_SCANNED_SOURCE_BYTES = 256 * 1024;
+
+const BARE_PACKAGE_SPECIFIER_RE =
+  /^(?:@[^\s'"`()\/]+\/)?[^\s'"`()\/.@][^\s'"`()\/]*(?:\/[^\s'"`()]*)?$/;
+
+/** Bare specifiers a source file imports at runtime: `import type` / `export type` statements are dropped. */
+export function getRuntimeImportSpecifiers(code: string): string[] {
+  const stripped = code
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '')
+    .replace(
+      /\b(?:import|export)\s+type\s+(?:\{[^}]*\}|\*\s+as\s+\w+|\w+(?:\s*,\s*\{[^}]*\})?)\s*from\s*(['"])[^'"\n]*\1/g,
+      ''
+    );
+  const specifiers: string[] = [];
+  const specifierRe =
+    /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|\bimport\s+)(['"])([^'"\n]+)\1/g;
+  for (const match of stripped.matchAll(specifierRe)) {
+    const specifier = match[2];
+    // Only bare package specifiers name a dependency: paths, virtual ids, Node builtins and the
+    // string fragments a minified bundle happens to place after `import`/`from` do not.
+    if (!BARE_PACKAGE_SPECIFIER_RE.test(specifier) || isBuiltin(specifier)) continue;
+    specifiers.push(specifier);
+  }
+  return specifiers;
+}
+
+function collectRuntimeImports(dir: string, into: Set<string>): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!NON_RUNTIME_DIRS.has(entry.name))
+        collectRuntimeImports(path.join(dir, entry.name), into);
+      continue;
+    }
+    if (!SOURCE_FILE_RE.test(entry.name) || NON_RUNTIME_SOURCE_RE.test(entry.name)) continue;
+    const file = path.join(dir, entry.name);
+    let code: string;
+    try {
+      if (statSync(file).size > MAX_SCANNED_SOURCE_BYTES) continue;
+      code = readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const specifier of getRuntimeImportSpecifiers(code)) into.add(specifier);
+  }
+}
+
+/**
+ * Whether `dependency` is reachable from the shared package through the imports its source files
+ * (and those of the workspace packages they pull in) actually evaluate. Unlike the manifest walk
+ * above this ignores `import type` edges and stops at `node_modules` boundaries, so it approximates
+ * the fallback's evaluation graph rather than the package's declared closure — in a monorepo the
+ * latter covers far more than the module graph ever does.
+ */
+export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: string): boolean {
+  const sharedPackage = getPackageName(sharedKey);
+  let reachable = sharedRuntimeDependencyCache.get(sharedPackage);
+  if (!reachable) {
+    reachable = new Set<string>();
+    const visited = new Set<string>();
+    const queue = [getInstalledPackageJson(sharedPackage, { packageName: sharedPackage })];
+    while (queue.length) {
+      const installed = queue.shift();
+      if (!installed || visited.has(installed.dir)) continue;
+      visited.add(installed.dir);
+      const specifiers = new Set<string>();
+      collectRuntimeImports(installed.dir, specifiers);
+      for (const specifier of specifiers) {
+        const dep = getPackageName(specifier);
+        if (dep === sharedPackage) continue;
+        reachable.add(dep);
+        const manifest = getDependencyManifest(dep, installed.dir);
+        // Only workspace packages get bundled into the fallback; a node_modules package stays a leaf.
+        if (manifest && !isNodeModulePath(manifest.dir)) queue.push(manifest);
+      }
+    }
+    sharedRuntimeDependencyCache.set(sharedPackage, reachable);
+  }
+  return reachable.has(dependency);
+}
+
 export function proxySharedModule(options: {
   shared?: NormalizedShared;
   federationOptions?: NormalizedModuleFederationOptions;
@@ -463,6 +556,7 @@ export function proxySharedModule(options: {
         emittedTreeShakingProviders.clear();
         sharedDependencyCache.clear();
         dependencyManifestCache.clear();
+        sharedRuntimeDependencyCache.clear();
         workspacePackageNameCache.clear();
         const isVinext = hasPackageDependency('vinext');
         const isAstro = hasPackageDependency('astro');
@@ -619,7 +713,20 @@ export function proxySharedModule(options: {
         // cycle) keeps its ordinary edge too. Proxying it would place the loadShare
         // glue inside the package's own evaluation cycle, where the glue's eager
         // export reads run before the fallback body has initialized.
-        if (importerPackage && isSharedPackageDependency(key, importerPackage)) return;
+        // An unshared workspace importer is judged by the imports the shared package
+        // evaluates, not by its manifest closure: in a monorepo that closure reaches
+        // most of the workspace through type-only dependencies, and an ordinary edge
+        // there binds the importer to the local fallback even when a host provides
+        // the singleton.
+        if (importerPackage) {
+          const importerIsUnsharedWorkspacePackage =
+            !isNodeModulePath(importer!) &&
+            !Object.keys(shared).some((sharedKey) => getPackageName(sharedKey) === importerPackage);
+          const keepsOrdinaryEdge = importerIsUnsharedWorkspacePackage
+            ? isSharedPackageRuntimeDependency(key, importerPackage)
+            : isSharedPackageDependency(key, importerPackage);
+          if (keepsOrdinaryEdge) return;
+        }
         if (useDirectReactImport && key === 'react') return;
         if (isAssetLikeImport(source)) return;
         if (isBuildConfigImporter(importer)) return;

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'url';
 import type { Plugin, ResolvedConfig, UserConfig, ViteDevServer } from 'vite';
 import { normalizePathForImport } from '../utils/buildPaths';
+import { findModuleImportDescriptors } from '../utils/htmlEntryUtils';
 import { mfWarn } from '../utils/logger';
 import {
   getNormalizeModuleFederationOptions,
@@ -334,29 +335,21 @@ const MAX_SCANNED_SOURCE_BYTES = 256 * 1024;
 const BARE_PACKAGE_SPECIFIER_RE =
   /^(?:@[^\s'"`()\/]+\/)?[^\s'"`()\/.@][^\s'"`()\/]*(?:\/[^\s'"`()]*)?$/;
 
-/** Bare specifiers a source file imports at runtime: `import type` / `export type` statements are dropped. */
-export function getRuntimeImportSpecifiers(code: string): string[] {
-  const stripped = code
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/^[ \t]*\/\/.*$/gm, '')
-    .replace(
-      /\b(?:import|export)\s+type\s+(?:\{[^}]*\}|\*\s+as\s+\w+|\w+(?:\s*,\s*\{[^}]*\})?)\s*from\s*(['"])[^'"\n]*\1/g,
-      ''
-    );
-  const specifiers: string[] = [];
-  const specifierRe =
-    /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|\bimport\s+)(['"])([^'"\n]+)\1/g;
-  for (const match of stripped.matchAll(specifierRe)) {
-    const specifier = match[2];
-    // Only bare package specifiers name a dependency: paths, virtual ids, Node builtins and the
-    // string fragments a minified bundle happens to place after `import`/`from` do not.
-    if (!BARE_PACKAGE_SPECIFIER_RE.test(specifier) || isBuiltin(specifier)) continue;
-    specifiers.push(specifier);
-  }
-  return specifiers;
+/** Module specifiers evaluated by a source file. */
+function getRuntimeModuleSpecifiers(code: string): string[] {
+  return findModuleImportDescriptors(code)
+    .filter(({ typeOnly }) => !typeOnly)
+    .map(({ source }) => source);
 }
 
-function collectRuntimeImports(dir: string, into: Set<string>): void {
+/** Bare specifiers a source file imports at runtime. */
+export function getRuntimeImportSpecifiers(code: string): string[] {
+  return getRuntimeModuleSpecifiers(code).filter(
+    (specifier) => BARE_PACKAGE_SPECIFIER_RE.test(specifier) && !isBuiltin(specifier)
+  );
+}
+
+function collectAllRuntimeImports(dir: string, into: Set<string>): void {
   let entries: Dirent[];
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -366,7 +359,7 @@ function collectRuntimeImports(dir: string, into: Set<string>): void {
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (!NON_RUNTIME_DIRS.has(entry.name))
-        collectRuntimeImports(path.join(dir, entry.name), into);
+        collectAllRuntimeImports(path.join(dir, entry.name), into);
       continue;
     }
     if (!SOURCE_FILE_RE.test(entry.name) || NON_RUNTIME_SOURCE_RE.test(entry.name)) continue;
@@ -382,6 +375,47 @@ function collectRuntimeImports(dir: string, into: Set<string>): void {
   }
 }
 
+const SOURCE_EXTENSIONS = ['', '.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.jsx', '.tsx'];
+
+function resolveLocalRuntimeImport(importer: string, specifier: string): string | undefined {
+  if (!specifier.startsWith('.')) return;
+  const resolved = path.resolve(path.dirname(importer), specifier);
+  const candidates = SOURCE_EXTENSIONS.flatMap((extension) => [
+    `${resolved}${extension}`,
+    path.join(resolved, `index${extension}`),
+  ]);
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function collectReachableRuntimeImports(entry: string, dir: string, into: Set<string>): boolean {
+  const visited = new Set<string>();
+  const queue = [entry];
+  let scanned = false;
+  while (queue.length) {
+    const file = queue.shift()!;
+    const relative = path.relative(dir, file);
+    if (relative.startsWith('..') || path.isAbsolute(relative) || visited.has(file)) continue;
+    visited.add(file);
+    let code: string;
+    try {
+      if (statSync(file).size > MAX_SCANNED_SOURCE_BYTES) continue;
+      code = readFileSync(file, 'utf-8');
+      scanned = true;
+    } catch {
+      continue;
+    }
+    for (const specifier of getRuntimeModuleSpecifiers(code)) {
+      if (BARE_PACKAGE_SPECIFIER_RE.test(specifier) && !isBuiltin(specifier)) {
+        into.add(specifier);
+        continue;
+      }
+      const local = resolveLocalRuntimeImport(file, specifier);
+      if (local) queue.push(local);
+    }
+  }
+  return scanned;
+}
+
 /**
  * Whether `dependency` is reachable from the shared package through the imports its source files
  * (and those of the workspace packages they pull in) actually evaluate. Unlike the manifest walk
@@ -391,27 +425,42 @@ function collectRuntimeImports(dir: string, into: Set<string>): void {
  */
 export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: string): boolean {
   const sharedPackage = getPackageName(sharedKey);
-  let reachable = sharedRuntimeDependencyCache.get(sharedPackage);
+  let reachable = sharedRuntimeDependencyCache.get(sharedKey);
   if (!reachable) {
     reachable = new Set<string>();
     const visited = new Set<string>();
-    const queue = [getInstalledPackageJson(sharedPackage, { packageName: sharedPackage })];
+    const queue = [
+      {
+        request: sharedKey,
+        installed: getInstalledPackageJson(sharedPackage, { packageName: sharedPackage }),
+      },
+    ];
     while (queue.length) {
-      const installed = queue.shift();
-      if (!installed || visited.has(installed.dir)) continue;
-      visited.add(installed.dir);
+      const { request, installed } = queue.shift()!;
+      if (!installed) continue;
+      const visitKey = `${installed.dir}\0${request}`;
+      if (visited.has(visitKey)) continue;
+      visited.add(visitKey);
       const specifiers = new Set<string>();
-      collectRuntimeImports(installed.dir, specifiers);
+      const entry = getInstalledPackageEntry(request, {
+        cwd: installed.dir,
+        packageName: getPackageName(request),
+      });
+      if (!entry || !collectReachableRuntimeImports(entry, installed.dir, specifiers)) {
+        collectAllRuntimeImports(installed.dir, specifiers);
+      }
       for (const specifier of specifiers) {
         const dep = getPackageName(specifier);
         if (dep === sharedPackage) continue;
         reachable.add(dep);
         const manifest = getDependencyManifest(dep, installed.dir);
         // Only workspace packages get bundled into the fallback; a node_modules package stays a leaf.
-        if (manifest && !isNodeModulePath(manifest.dir)) queue.push(manifest);
+        if (manifest && !isNodeModulePath(manifest.dir)) {
+          queue.push({ request: specifier, installed: manifest });
+        }
       }
     }
-    sharedRuntimeDependencyCache.set(sharedPackage, reachable);
+    sharedRuntimeDependencyCache.set(sharedKey, reachable);
   }
   return reachable.has(dependency);
 }

--- a/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
+++ b/src/virtualModules/__tests__/virtualShared_preBuild.test.ts
@@ -3684,7 +3684,7 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       '__mfSubscribeSharedCache(__mfModuleCache.share, {"canonical":"default:workspace-cycle-a","aliases":["workspace-cycle-a"]}, __mfApplyEagerShareExports);'
     );
-    expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
+    expect(generatedCode).toContain('__mfApplyEagerShareExportsWhenReady(exportModule);');
     expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).not.toContain('await ');
     expect(generatedCode).toContain('Promise.resolve().then');
@@ -3738,11 +3738,164 @@ describe('writeLoadShareModule', () => {
     expect(generatedCode).toContain(
       '__mfSubscribeSharedCache(__mfModuleCache.share, {"canonical":"default:workspace-producer","aliases":["workspace-producer"]}, __mfApplyEagerShareExports);'
     );
-    expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
+    expect(generatedCode).toContain('__mfApplyEagerShareExportsWhenReady(exportModule);');
     expect(generatedCode).toContain('export { __mf_0 as useProducer, __mf_1 as createProducer };');
     expect(generatedCode).not.toContain('export { useProducer, createProducer } from');
     expect(generatedCode).not.toContain('initPromise.then');
     expect(generatedCode).toContain('Promise.resolve().then');
+  });
+
+  it('leaves eager exports unassigned while the local fallback is still evaluating and applies them afterwards', async () => {
+    // A merged chunk can place the eager wrapper above its own fallback body (a package-level cycle
+    // through an unshared workspace importer): `__mfLocalShare` is still undefined when the wrapper
+    // evaluates. The wrapper must not throw there; the deferred cache write applies the exports once
+    // the fallback has initialized, and a host-provided copy still replaces them through the cache.
+    normalizeModuleFederationOptions({
+      name: 'host',
+      shared: {
+        'workspace-producer': { singleton: true },
+        'workspace-producer/extra': { singleton: true },
+        'workspace-consumer': { singleton: true },
+      },
+    });
+    const mockShareItem: ShareItem = {
+      name: 'workspace-producer',
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule('workspace-producer', mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    const runnable = generatedCode
+      .replace(/^\s*import \* as __mfLocalShare from .*;$/m, 'var __mfLocalShare;')
+      .replace(/^\s*export \{[^\n]*$/gm, '');
+    const previousCache = (globalThis as Record<string, unknown>).__mf_module_cache__;
+    delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+    try {
+      const wrapper = new Function(
+        `${runnable}
+        return {
+          set local(value) { __mfLocalShare = value; },
+          get useProducer() { return __mf_0; },
+          get default() { return __mf_default; },
+          cache: __mfModuleCache.share,
+          descriptor: __mfGetSharedCacheDescriptor("workspace-producer", true, "1.0.0", "default"),
+          write: __mfWriteSharedCache,
+        };`
+      )() as {
+        local: unknown;
+        useProducer: unknown;
+        default: unknown;
+        cache: Record<string, unknown>;
+        descriptor: unknown;
+        write: (cache: unknown, descriptor: unknown, value: unknown, owner: string) => void;
+      };
+
+      // Evaluated above its fallback: nothing assigned yet, and no TypeError from reading `undefined`.
+      expect(wrapper.useProducer).toBeUndefined();
+
+      const localProducer = () => 'local';
+      const localNamespace = Object.freeze(
+        Object.assign(Object.create(null), {
+          useProducer: localProducer,
+          createProducer: () => 'local',
+        })
+      );
+      wrapper.local = localNamespace;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(wrapper.useProducer).toBe(localProducer);
+      expect(wrapper.cache['default:workspace-producer']).toMatchObject({
+        useProducer: localProducer,
+      });
+
+      const hostProducer = () => 'host';
+      wrapper.write(
+        wrapper.cache,
+        wrapper.descriptor,
+        { useProducer: hostProducer, createProducer: () => 'host' },
+        'host'
+      );
+      expect(wrapper.useProducer).toBe(hostProducer);
+    } finally {
+      if (previousCache === undefined)
+        delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+      else (globalThis as Record<string, unknown>).__mf_module_cache__ = previousCache;
+    }
+  });
+
+  it('does not publish an uninitialized local fallback from the deferred cache write', async () => {
+    // With top-level await in the merged chunk the deferred write can run before the fallback body has
+    // evaluated: writing `undefined` would fan out to every subscriber. The write is skipped and the
+    // seed step of `init()` (or a host copy) publishes the share later.
+    normalizeModuleFederationOptions({
+      name: 'host',
+      shared: {
+        'workspace-producer': { singleton: true },
+        'workspace-producer/extra': { singleton: true },
+        'workspace-consumer': { singleton: true },
+      },
+    });
+    const mockShareItem: ShareItem = {
+      name: 'workspace-producer',
+      from: '',
+      version: '1.0.0',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+      },
+      scope: 'default',
+    };
+
+    writeLoadShareModule('workspace-producer', mockShareItem, 'build', false);
+
+    const generatedCode = writeSyncSpy.mock.calls.at(-1)?.[0] as string;
+    const runnable = generatedCode
+      .replace(/^\s*import \* as __mfLocalShare from .*;$/m, 'var __mfLocalShare;')
+      .replace(/^\s*export \{[^\n]*$/gm, '');
+    const previousCache = (globalThis as Record<string, unknown>).__mf_module_cache__;
+    delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+    try {
+      const wrapper = new Function(
+        `${runnable}
+        return {
+          set local(value) { __mfLocalShare = value; },
+          get useProducer() { return __mf_0; },
+          cache: __mfModuleCache.share,
+          descriptor: __mfGetSharedCacheDescriptor("workspace-producer", true, "1.0.0", "default"),
+          write: __mfWriteSharedCache,
+        };`
+      )() as {
+        local: unknown;
+        useProducer: unknown;
+        cache: Record<string, unknown>;
+        descriptor: unknown;
+        write: (cache: unknown, descriptor: unknown, value: unknown, owner: string) => void;
+      };
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(wrapper.useProducer).toBeUndefined();
+      expect('default:workspace-producer' in wrapper.cache).toBe(false);
+
+      const seededProducer = () => 'seeded';
+      const seededNamespace = { useProducer: seededProducer, createProducer: () => 'seeded' };
+      wrapper.local = seededNamespace;
+      wrapper.write(wrapper.cache, wrapper.descriptor, seededNamespace, 'host');
+      expect(wrapper.useProducer).toBe(seededProducer);
+    } finally {
+      if (previousCache === undefined)
+        delete (globalThis as Record<string, unknown>).__mf_module_cache__;
+      else (globalThis as Record<string, unknown>).__mf_module_cache__ = previousCache;
+    }
   });
 
   it('emits eager local exports for an explicitly eager leaf workspace singleton', () => {
@@ -3774,7 +3927,7 @@ describe('writeLoadShareModule', () => {
       'import * as __mfLocalShare from "/repo/packages/workspace-producer/src/index.ts";'
     );
     expect(generatedCode).toContain('const __mfApplyEagerShareExports = (mod) => {');
-    expect(generatedCode).toContain('__mfApplyEagerShareExports(exportModule);');
+    expect(generatedCode).toContain('__mfApplyEagerShareExportsWhenReady(exportModule);');
     expect(generatedCode).not.toContain('initPromise.then');
     // The eager export block declares `exportModule` itself; the module body must not declare it again.
     expect(generatedCode.match(/\blet exportModule\b/g)).toHaveLength(1);

--- a/src/virtualModules/virtualShared_preBuild.ts
+++ b/src/virtualModules/virtualShared_preBuild.ts
@@ -1698,6 +1698,12 @@ function getSharedCacheReadExpression(cacheDescriptor: string, treeShakingConsum
     : `__mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor})`;
 }
 
+/**
+ * Eager workspace singleton wrapper: reads the shared cache synchronously and falls back to the local
+ * namespace. Inside the fallback's own evaluation cycle that namespace is not initialized yet (undefined in
+ * a merged chunk, TDZ bindings otherwise), so the exports stay unassigned until the deferred cache write
+ * re-applies them; a host-provided copy re-applies them through the cache subscription as before.
+ */
 function generateEagerWorkspaceSingletonExports(
   namedExports: string[],
   importSource: string,
@@ -1730,8 +1736,10 @@ function generateEagerWorkspaceSingletonExports(
     let exportModule = ${getSharedCacheReadExpression(cacheDescriptor, treeShakingConsumer)};
     if (exportModule === undefined) {
       Promise.resolve().then(() => {
-        if (__mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor}) === undefined) {
-          __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfNormalizeShareModule(__mfLocalShare), ${cacheOwner});
+        if (__mfReadSharedCache(__mfModuleCache.share, ${cacheDescriptor}) !== undefined) return;
+        const localShare = __mfInitializedLocalShare(__mfLocalShare);
+        if (localShare !== undefined) {
+          __mfWriteSharedCache(__mfModuleCache.share, ${cacheDescriptor}, localShare, ${cacheOwner});
         }
       });
       exportModule = __mfLocalShare;
@@ -1740,8 +1748,16 @@ function generateEagerWorkspaceSingletonExports(
     const __mfApplyEagerShareExports = (mod) => {
       ${assignments}
     };
+    const __mfApplyEagerShareExportsWhenReady = (mod) => {
+      if (mod === undefined) return;
+      try {
+        __mfApplyEagerShareExports(mod);
+      } catch (error) {
+        if (!(error instanceof ReferenceError)) throw error;
+      }
+    };
     __mfSubscribeSharedCache(__mfModuleCache.share, ${cacheDescriptor}, __mfApplyEagerShareExports);
-    __mfApplyEagerShareExports(exportModule);
+    __mfApplyEagerShareExportsWhenReady(exportModule);
     export { __mf_default as default };${namedExportLine}${mutableExportLine}`;
 }
 function generateLazyWorkspaceSingletonExports(
@@ -1929,6 +1945,15 @@ const normalizeLocalShareModuleCode = `const __mfNormalizeShareModule = (mod) =>
       return normalized && Object.getPrototypeOf(normalized) === null
         ? Object.assign({}, normalized)
         : normalized;
+    };`;
+const initializedLocalShareModuleCode = `const __mfInitializedLocalShare = (mod) => {
+      if (mod === undefined) return undefined;
+      try {
+        return __mfNormalizeShareModule(mod);
+      } catch (error) {
+        if (error instanceof ReferenceError) return undefined;
+        throw error;
+      }
     };`;
 
 export function writeLoadShareModule(
@@ -2228,6 +2253,7 @@ export function writeLoadShareModule(
     ${importLine}
     ${sharedCacheHelperCode}
     ${normalizeLocalShareModuleCode}
+    ${initializedLocalShareModuleCode}
     ${exportLine}
   `
     : `


### PR DESCRIPTION
Fixes #1226

**What**

- `proxyPreBuildShared:resolve-shared-loadShare`: an importer that is an *unshared workspace package* (the case #1210 added) now keeps its ordinary edge only when the shared package reaches it through the imports its code evaluates — `isSharedPackageRuntimeDependency` walks the shared package's source files and those of the workspace packages they import (`import type` / `export type` dropped, Node builtins and non-package specifiers ignored, `node_modules` packages treated as leaves, files over 256 KB skipped as bundled artifacts). Shared and `node_modules` importers keep the manifest-based `isSharedPackageDependency` as before.
- The eager workspace singleton wrapper is hardened for the merged-chunk case: `__mfApplyEagerShareExportsWhenReady` skips the synchronous copy while `__mfLocalShare` is `undefined` or in TDZ, and the deferred cache write (`__mfInitializedLocalShare`) never publishes an uninitialized namespace — writing `undefined` fanned out to every subscriber as `TypeError: Cannot read properties of undefined (reading '…')`.

**Why**

`isSharedPackageDependency` walks the shared package's manifest closure. In a monorepo that closure is not the module graph: type-only packages, page packages and tooling all sit in `dependencies`, so a singleton "reaches" most of the workspace on paper (175 of 289 packages in our host) while its code evaluates a handful. Since #1210 every unshared workspace importer of such a singleton got an ordinary edge to the **remote's local fallback**, so a remote embedded in a host that provides the singleton ran two copies of it (`Service "localSettings" is not registered in the container`). The ordinary edge is still required for genuine evaluation cycles (#1209: a merged chunk places the wrapper above its fallback, and module-scope calls need the hoisted local binding), so the cycle test has to look at what the fallback actually evaluates.

**Tests**

- `pluginProxySharedModule_preBuild.test.ts`: the #1210/#1221 cases now provide the shared package's source (`import 'bridge'`) and still expect the ordinary edge; new cases cover a manifest-only chain (`vue → types-only → hooks`, proxied) and `getRuntimeImportSpecifiers` (type-only statements, builtins and minified string fragments dropped).
- `virtualShared_preBuild.test.ts`: two runtime tests evaluate the generated eager wrapper with `__mfLocalShare` undefined; on `main` they fail with the #1209 signature.
- `vitest run --dir src`: 1246 passed (the one failing `packageUtils` case fails on clean `main` on macOS too); `vitest run integration`: 93/94 (same pre-existing failure as `main`, `dev-singleton-react` green); `oxfmt --check`, `tsc` clean.
- Repro https://github.com/marksnode/mf-vite-repro-unshared-importer-glued-to-local-singleton: `RESULT OK`, the widget chunk imports through the `aaa-runtime` wrapper. The #1209 repro still prints `directly from the aaa-ui fallback` and boots. Agent Desktop (315 shares, 8 apps): full layout builds and boots; the embedded calendar reads the host container again.

**Note** — while wiring the scan I hit an unrelated hang: `getInstalledPackageJson('stream')` (a Node builtin name) loops forever because `require.resolve` returns the bare name and the `path.dirname` walk never reaches a root. The scanner filters builtins so it cannot trigger it; the loop itself is left for a separate change.