### PR TITLE
fix: stop the installed-package lookup from looping forever on Node c…

### DIFF
--- a/src/utils/__tests__/packageUtils.test.ts
+++ b/src/utils/__tests__/packageUtils.test.ts
@@ -55,6 +55,42 @@ describe('getInstalledPackageJson', () => {
     );
   });
 
+  it('returns undefined for a Node core module instead of walking up from its bare specifier', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-core-module-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    mkdirSync(hostDir, { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+
+    // `require.resolve('readline')` returns 'readline' itself, not a file path
+    expect(getInstalledPackageJson('readline', { cwd: hostDir })).toBeUndefined();
+    expect(getInstalledPackageJson('node:readline', { cwd: hostDir })).toBeUndefined();
+  });
+
+  it('finds an installed package that shares its name with a Node core module', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-core-module-shadow-'));
+    tempDirs.push(root);
+
+    const hostDir = path.join(root, 'apps/host');
+    const packageDir = path.join(hostDir, 'node_modules', 'util');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({ name: 'host' }));
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: 'util', version: '0.12.5', main: './util.js' })
+    );
+    writeFileSync(path.join(packageDir, 'util.js'), 'module.exports = {};');
+
+    // `require.resolve('util')` still prefers the core module, so the lookup must fall back to node_modules
+    const installed = getInstalledPackageJson('util', { cwd: hostDir });
+
+    expect(installed?.packageJson.version).toBe('0.12.5');
+    expect(normalizePathForImport(installed?.path || '')).toContain(
+      '/apps/host/node_modules/util/package.json'
+    );
+  });
+
   it('caches lookups per (cwd, pkg) instead of re-reading the filesystem every call', () => {
     const packageName = 'mf-test-cache-pkg';
     const root = mkdtempSync(path.join(tmpdir(), 'mf-vite-cache-'));

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -443,7 +443,6 @@ function resolveInstalledPackageJson(
   };
   const findPackageInPnpmStore = (startDir: string): InstalledPackageJson | undefined => {
     let currentDir = startDir;
-    const rootDir = path.parse(currentDir).root;
 
     while (true) {
       const pnpmStoreDir = path.join(currentDir, 'node_modules', '.pnpm');
@@ -458,15 +457,15 @@ function resolveInstalledPackageJson(
           }
         } catch {}
       }
-      if (currentDir === rootDir) break;
-      currentDir = path.dirname(currentDir);
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) break;
+      currentDir = parentDir;
     }
   };
 
+  let resolvedPath: string | undefined;
   try {
     const projectRequire = createRequire(pathToFileURL(path.join(cwd, 'package.json')));
-    let resolvedPath: string | undefined;
-
     if (opts?.fromResolvedEntry) {
       resolvedPath = opts.fromResolvedEntry;
     } else {
@@ -476,50 +475,60 @@ function resolveInstalledPackageJson(
         resolvedPath = projectRequire.resolve(packageName);
       }
     }
-
-    let currentDir = path.dirname(resolvedPath);
-    const rootDir = path.parse(currentDir).root;
-    let matchingPackage: InstalledPackageJson | undefined;
-
-    while (true) {
-      const packageJsonPath = path.join(currentDir, 'package.json');
-      if (existsSync(packageJsonPath)) {
-        const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
-        try {
-          const packageJson = JSON.parse(packageJsonContent) as Record<string, unknown>;
-          if (packageJson.name === packageName) {
-            const packageInfo = {
-              path: packageJsonPath,
-              dir: currentDir,
-              packageJson,
-            };
-            if (currentDir.endsWith(path.join('node_modules', packageName))) return packageInfo;
-            matchingPackage ??= packageInfo;
-          }
-        } catch (error) {
-          if (!(error instanceof SyntaxError)) throw error;
-        }
-      }
-      if (currentDir === rootDir) break;
-      currentDir = path.dirname(currentDir);
-    }
-    return matchingPackage;
   } catch {
-    let currentDir = cwd;
-    const rootDir = path.parse(currentDir).root;
-
-    while (true) {
-      const packageJsonPath = path.join(currentDir, 'node_modules', packageName, 'package.json');
-      const directCandidate = tryReadPackageJson(packageJsonPath);
-      if (directCandidate?.packageJson.name === packageName) return directCandidate;
-      if (currentDir === rootDir) break;
-      currentDir = path.dirname(currentDir);
-    }
-
-    return findPackageInPnpmStore(cwd);
+    resolvedPath = undefined;
+  }
+  // A Node core module resolves to its bare specifier (`readline`, `node:readline`), not to a file:
+  // there is no directory to walk up from, so look for an installed package of that name instead.
+  if (resolvedPath !== undefined && !path.isAbsolute(resolvedPath)) {
+    resolvedPath = undefined;
   }
 
-  return undefined;
+  if (resolvedPath !== undefined) {
+    try {
+      let currentDir = path.dirname(resolvedPath);
+      let matchingPackage: InstalledPackageJson | undefined;
+
+      while (true) {
+        const packageJsonPath = path.join(currentDir, 'package.json');
+        if (existsSync(packageJsonPath)) {
+          const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
+          try {
+            const packageJson = JSON.parse(packageJsonContent) as Record<string, unknown>;
+            if (packageJson.name === packageName) {
+              const packageInfo = {
+                path: packageJsonPath,
+                dir: currentDir,
+                packageJson,
+              };
+              if (currentDir.endsWith(path.join('node_modules', packageName))) return packageInfo;
+              matchingPackage ??= packageInfo;
+            }
+          } catch (error) {
+            if (!(error instanceof SyntaxError)) throw error;
+          }
+        }
+        const parentDir = path.dirname(currentDir);
+        if (parentDir === currentDir) break;
+        currentDir = parentDir;
+      }
+      return matchingPackage;
+    } catch {
+      // Unreadable tree: fall through to the node_modules lookup below.
+    }
+  }
+
+  let currentDir = cwd;
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'node_modules', packageName, 'package.json');
+    const directCandidate = tryReadPackageJson(packageJsonPath);
+    if (directCandidate?.packageJson.name === packageName) return directCandidate;
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+
+  return findPackageInPnpmStore(cwd);
 }
 
 export function getInstalledPackageEntry(


### PR DESCRIPTION
Fixes #1225

## What

`resolveInstalledPackageJson()` walked up from `path.dirname(require.resolve(pkg))` and terminated on `currentDir === path.parse(currentDir).root`. For a Node core module `require.resolve()` returns the bare specifier (`readline`, `node:readline`), so `path.dirname()` yields `'.'`, whose root is `''` — the loop never terminates and the build hangs with no output.

- When the resolved path is not absolute, the lookup now skips the walk-up and falls through to the `node_modules` / pnpm-store lookup (an npm package can legitimately shadow a core module name — `util`, `buffer`, `events`, `punycode` are all real packages — and `require.resolve()` prefers the core module, so it has to be found on disk instead).
- All three upward walks terminate structurally (`path.dirname(dir) === dir`) instead of comparing against the filesystem root, so no other odd input can loop them either.

## Why

Since 1.21.3, `isSharedPackageDependency()` walks a shared package's whole transitive manifest graph and asks `getInstalledPackageJson()` about every dependency the `node_modules` walk-up misses. A dependency named after a core module that is not installed (e.g. a peer `buffer` or a `readline` optional dependency) is enough to hang the build — #1225 has the numbers and a minimal repro.

## Tests

- `returns undefined for a Node core module instead of walking up from its bare specifier` — `readline` and `node:readline` return `undefined` promptly (on `main` this test never finishes).
- `finds an installed package that shares its name with a Node core module` — a `node_modules/util` package is found even though `require.resolve('util')` resolves to the core module.

`pnpm test`: 1243 passed, 1 skipped, 1 failed (`ignores copied package metadata beside the resolved entry` fails the same way on a clean `main` on macOS). `pnpm fmt.check`, `pnpm typecheck` clean.