### PR TITLE
fix: skip another container's consume-only stub when bridging a shared provider

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -2900,6 +2900,48 @@ describe('virtualRemoteEntry', () => {
     expect(materializedBridgeCode).toContain('if (usedShare.canLiveRebind === false) return;');
   });
 
+  it("never bridges onto another container's consume-only stub", async () => {
+    optionsMock.shareStrategy = 'loaded-first';
+    const mod = await import('../virtualRemoteEntry');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__provider',
+        name: 'provider',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: {},
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'loaded-first',
+      } as any,
+      'virtual:exposes',
+      'serve'
+    );
+
+    // A host's `import: false` share registers a scope entry whose get() throws "must be provided by
+    // host". Selected as the same-version provider (first registrant wins), it must be skipped before
+    // its get() runs, in both bridge passes — otherwise every provider init logs "Failed to bridge".
+    const guard = 'if (provider?.shareConfig?.import === false) return;';
+    const materializedBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeMaterializedProvider ='),
+      code.indexOf('const __mfBridgeExternalSharedProvider =')
+    );
+    const externalBridgeCode = code.slice(
+      code.indexOf('const __mfBridgeExternalSharedProvider ='),
+      code.indexOf('for (const batch of __mfMaterializedShareBatches) await Promise.all(')
+    );
+    expect(materializedBridgeCode).toContain(guard);
+    expect(materializedBridgeCode.indexOf(guard)).toBeLessThan(
+      materializedBridgeCode.indexOf('const { version } = providerEntry;')
+    );
+    expect(externalBridgeCode).toContain(guard);
+    expect(externalBridgeCode.indexOf(guard)).toBeLessThan(
+      externalBridgeCode.indexOf('await __mfLoadPinnedRuntimeShare(')
+    );
+  });
+
   it('keeps the remote registry intact while pre-seeding version-first shares', async () => {
     optionsMock.shareStrategy = 'version-first';
     const mod = await import('../virtualRemoteEntry');

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1723,6 +1723,8 @@ export function generateRemoteEntry(
         const providerEntry = __mfFindSharedProviderEntry(versionMap, provider);
         if (!providerEntry) return;
         if (usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)) return;
+        // Another container's consume-only stub has nothing to bridge to: its get() throws by construction.
+        if (provider?.shareConfig?.import === false) return;
         const { version } = providerEntry;
         if (!singleton && version !== usedShare.version) return;
         if (
@@ -1845,6 +1847,8 @@ export function generateRemoteEntry(
         };
         if (usedShare.canLiveRebind === false) return;
         if (usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)) return;
+        // Another container's consume-only stub has nothing to bridge to: its get() throws by construction.
+        if (provider?.shareConfig?.import === false) return;
         // Preserve a singleton already selected by another container. The bridge may
         // only replace the provisional local fallback seeded by this container.
         if (cachedShare !== undefined && cachedShareOwner !== mfName) return;


### PR DESCRIPTION
Fixes #1229

## What

Both bridge passes in the generated remote entry — `__mfBridgeMaterializedProvider` and `__mfBridgeExternalSharedProvider` — now return before touching a selected provider whose `shareConfig.import === false`. Such a scope entry is another container's consume-only stub: its `get()` throws `must be provided by host` by construction, so there is nothing to bridge onto and the attempt can only end in the `catch` → `console.error('Failed to bridge external shared module …')`.

The guard sits next to the existing one for the container's **own** stub (`usedShare.shareConfig?.import === false && __mfMatchesSharedProvider(provider, usedShare)`), which is the same rule restricted to one owner; `__mfResolveImportFalseShared` already treats any `shareConfig.import === false` entry as a stub (`__mfIsOwnStub`).

## Why

A Vite host that consumes `react` / `react-dom` with `import: false` registers first, so the same-version scope entry is its stub. When a Vite provider remote that really provides both initialises, `__mfSelectExternalSharedProvider` picks that stub (first registrant wins the tie), `__mfLoadPinnedRuntimeShare` calls its `get()`, and every page load logs

```
[Module Federation] Failed to bridge external shared module "react-dom" Error: [Module Federation] Shared module 'react-dom' must be provided by host
```

The app keeps working — the host's `__mfResolveImportFalseShared` later bridges the stub onto the provider's module — but it is a deterministic `console.error` for the most ordinary consume-only host + provider topology, indistinguishable at a glance from the real failures in #952 / #1064 / #1176. Details and a three-part reproduction (Vite host with `import: false`, Vite provider, webpack consumer) in #1229.

## Tests

- `never bridges onto another container's consume-only stub` (virtualRemoteEntry.test.ts): both generated bridge functions carry the guard, ahead of the provider-entry version read and of `__mfLoadPinnedRuntimeShare` respectively.
- Reproduction (https://github.com/marksnode/mf-vite-repro-foreign-consume-only-stub-bridge): `npm run check` prints `RESULT FAIL` (bridge error in the console) on 1.21.3 and on `main` @ 82013b2, `RESULT OK` with this branch packed and installed; the webpack widget renders in both load orders throughout.

`pnpm test`: 1242 passed, 1 skipped, 1 failed (`ignores copied package metadata beside the resolved entry` fails the same way on a clean `main` on macOS). `pnpm fmt.check`, `pnpm typecheck` clean.