### PR TITLE
fix: follow directory imports to their index file when walking a shared package's runtime imports

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -29,7 +29,10 @@ const {
   existsSyncMock: vi.fn<(path: string) => boolean>(() => false),
   readFileSyncMock: vi.fn<(path: string) => string>(() => '{}'),
   readdirSyncMock: vi.fn<(dir: string, opts?: unknown) => unknown[]>(() => []),
-  statSyncMock: vi.fn<(file: string) => { size: number }>(() => ({ size: 128 })),
+  statSyncMock: vi.fn<(file: string) => { size: number; isFile: () => boolean }>(() => ({
+    size: 128,
+    isFile: () => true,
+  })),
   addUsedSharesMock: vi.fn<(pkg: string) => void>(),
   refreshHostAutoInitMock: vi.fn<() => void>(),
   writeLoadShareModuleMock: vi.fn(),
@@ -1332,6 +1335,65 @@ describe('pluginProxySharedModule_preBuild', () => {
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
     readdirSyncMock.mockReset().mockReturnValue([]);
+  });
+
+  it('follows a directory import to its index file when walking the shared package runtime imports', async () => {
+    normalizeModuleFederationOptions({ name: 'remote', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) => {
+      if (pkg === 'react') return '/repo/packages/react/index.js';
+      if (pkg === 'vue') return '/repo/apps/remote/node_modules/vue/index.js';
+      return undefined;
+    });
+    // vue's entry is a barrel over a DIRECTORY: `./components` exists on disk, but only its index
+    // file can be read. Stopping at the directory would lose everything the entry re-exports and
+    // turn the vue -> bridge -> vue cycle edge back into loadShare glue.
+    const directory = '/repo/apps/remote/node_modules/vue/components';
+    const files: Record<string, string> = {
+      '/repo/apps/remote/node_modules/vue/package.json':
+        '{"dependencies":{"bridge":"workspace:*"}}',
+      '/repo/apps/remote/node_modules/vue/index.js': "export * from './components';",
+      [`${directory}/index.js`]: "import { title } from 'bridge';\nexport const Button = title;",
+      '/repo/packages/bridge/package.json': '{"name":"bridge"}',
+    };
+    existsSyncMock.mockImplementation((p: string) => p in files || p === directory);
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p === directory) throw Object.assign(new Error('EISDIR'), { code: 'EISDIR' });
+      return files[p] ?? '{}';
+    });
+    statSyncMock.mockImplementation((p: string) => {
+      if (!(p in files) && p !== directory)
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return { size: 128, isFile: () => p !== directory };
+    });
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+    statSyncMock.mockReset().mockImplementation(() => ({ size: 128, isFile: () => true }));
   });
 
   it('walks past a nameless package.json when identifying an unshared workspace package', async () => {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -384,7 +384,14 @@ function resolveLocalRuntimeImport(importer: string, specifier: string): string 
     `${resolved}${extension}`,
     path.join(resolved, `index${extension}`),
   ]);
-  return candidates.find((candidate) => existsSync(candidate));
+  // `./components` names a directory that exists, but only its index file can be scanned.
+  return candidates.find((candidate) => {
+    try {
+      return statSync(candidate).isFile();
+    } catch {
+      return false;
+    }
+  });
 }
 
 function collectReachableRuntimeImports(entry: string, dir: string, into: Set<string>): boolean {


### PR DESCRIPTION
Fixes #1232

## What

`resolveLocalRuntimeImport` (the relative-import step of the runtime-import walk added in #1227 / 409e91a) now accepts a candidate only when `statSync(candidate).isFile()`. Its first candidate is the bare resolved path, and for `./components` that is a directory that exists: `existsSync` accepted it, `readFileSync` threw `EISDIR`, the walk dropped the branch — and since the entry itself had been read, the whole-directory fallback never ran. With the file check the directory is skipped and `components/index.{js,ts,…}` is taken, as intended.

## Why

`export * from './src/components/Foo'` is the default barrel layout of a TypeScript monorepo. On 1.21.4 every such shared package reaches **zero** runtime imports, so every unshared workspace importer inside a real module-level cycle is rewritten back to loadShare glue, the glue evaluates above its fallback in the merged chunk, and the host dies at boot with the #1209 crash (`TypeError: dz is not a function`). Measured on our host: `isSharedPackageRuntimeDependency('@bpinc/lib-ad-ui-kit', '@bpinc/activities-ui')` flipped from `true` (the #1227 branch) to `false` (1.21.4). Details and the repro in #1232.

## Tests

- `follows a directory import to its index file when walking the shared package runtime imports` — vue's entry is `export * from './components'`, the directory exists, only its index imports `bridge`; the bridge → vue edge must stay ordinary. Fails on 1.21.4, passes with the fix. The default `statSync` mock now also reports `isFile()`.
- Repro https://github.com/marksnode/mf-vite-repro-reachable-imports-directory-index: `npm run check` prints `RESULT FAIL` on 1.21.4 and `RESULT OK` with this branch packed and installed; our 300-package host boots again on the packed build.

`pnpm test`: 1252 passed, 1 skipped. `pnpm fmt.check`, `pnpm typecheck` clean.