### PR TITLE
fix: include wildcard shared subpaths in the pending preload list

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1013,6 +1013,26 @@ describe('virtualRemoteEntry', () => {
     expect(hostInit).not.toContain('preloadPendingShares');
   });
 
+  it('lists concrete pending wrappers configured through a shared wildcard', async () => {
+    normalizedSharedMock.mockReturnValue({
+      'react/': {
+        name: 'react/',
+        version: '19.2.4',
+        scope: 'default',
+        shareConfig: { singleton: true, strictVersion: false },
+      },
+    });
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react/jsx-runtime');
+
+    const buildCode = mod.generatePendingSharesCode('build');
+
+    expect(buildCode).toContain(
+      'const __mfPendingShareImports = [["react/jsx-runtime", () => import("virtual:loadShare:react/jsx-runtime")]];'
+    );
+  });
+
   it('orders React package roots before their subpath shares', async () => {
     const share = (name: string) => ({
       name,

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2340,13 +2340,9 @@ export function generatePendingSharesCode(
     command === 'build'
       ? getMaterializedShares(options)
           .filter((pkg) => {
-            const shareItem = resolvedOptions.shared?.[pkg];
-            return (
-              Boolean(shareItem) &&
-              !pkg.endsWith('/') &&
-              shareItem.shareConfig.import !== false &&
-              !shareItem.shareConfig.treeShaking
-            );
+            const shareItem = getShareItemForPreload(pkg, resolvedOptions);
+            if (!shareItem || pkg.endsWith('/')) return false;
+            return shareItem.shareConfig.import !== false && !shareItem.shareConfig.treeShaking;
           })
           .map(
             (pkg) =>


### PR DESCRIPTION
## Summary

Fix concrete subpaths configured through wildcard sharing, such as `shared: { 'react/': ... }`, being omitted from the build bootstrap's pending preload list.

This regression was introduced by [PR #1208](https://github.com/module-federation/vite/pull/1208), which added pending-share preloading but looked up only exact shared keys.

## Changes

- Use `getShareItemForPreload()` so pending-share generation handles both exact and wildcard keys.
- Add a regression test for the `react/` configuration with `react/jsx-runtime`.

## Validation

- `virtualRemoteEntry` tests: 108 passed
- Full test suite: 1253 passed, 1 skipped
- `pnpm typecheck`: passed