### PR TITLE
fix(ssr): preserve temp-file module identity in cyclic ESM graphs

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -972,7 +972,12 @@ describe('ssrEntryLoaderPlugin — code transformation', () => {
   it('finishes fetching circular relative import graphs', async () => {
     const fsMock = await import('fs');
     (fsMock.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
-    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+    const written: string[] = [];
+    (fsMock.writeFileSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (_path: unknown, code: unknown) => {
+        written.push(String(code));
+      }
+    );
     const fetch = makeFetchMock({
       'http://localhost:5001/remoteEntry.ssr.js': {
         ok: true,
@@ -999,6 +1004,10 @@ describe('ssrEntryLoaderPlugin — code transformation', () => {
     expectFetchCalled(fetch, 'http://localhost:5001/remoteEntry.ssr.js');
     expectFetchCalled(fetch, 'http://localhost:5001/assets/cycle.js');
     expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
+    // Every generated edge must use the same cache-busting URL as the root
+    // import. Otherwise a cycle back to the root evaluates it a second time.
+    expect(written).toHaveLength(2);
+    expect(written.every((code) => code.includes('?v=unversioned'))).toBe(true);
   });
 
   it('fetches a zero-whitespace relative side-effect import', async () => {

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -783,6 +783,10 @@ function isVitePreloadHelperSpecifier(specifier: string): boolean {
   return specifier.includes('preload-helper');
 }
 
+function getTempFileImportUrl(filePath: string, versionKey: string): string {
+  return `file://${filePath}?v=${encodeURIComponent(versionKey)}`;
+}
+
 /**
  * Fetch an HTTP ESM module, transform it, write it to a temp .js file and
  * return the file path. Recursively does the same for HTTP transitive imports
@@ -875,7 +879,10 @@ async function fetchEsmToTempFile(
             contextKey,
             fetchMaxBytes
           );
-          subMap.set(u, `file://${tmpPath}`);
+          // Keep every generated edge on the same versioned ESM URL as the
+          // root import. Without this query, a cycle back to the root resolves
+          // `file:///.../root.js` separately from `file:///.../root.js?v=...`.
+          subMap.set(u, getTempFileImportUrl(tmpPath, versionKey));
         })
     );
 


### PR DESCRIPTION
## Summary

Make the SSR `temp-file` loader use the same `?v=<versionKey>` query for the root and nested imports. Previously, a cyclic import could make Node evaluate the root as two ESM modules and split the container state.

## Changes

- Added a helper for temporary-file import URLs
- Applied the version query to recursively rewritten HTTP ESM imports
- Strengthened the circular-graph regression test

## Validation

- Unit: 50 files, 1252 passed, 1 skipped
- Integration: 16 files, 94 passed
- `pnpm typecheck`, `pnpm build`, and `pnpm fmt.check`: passed
- Real HTTP reproduction: root evaluation changed from 2 to 1, with the same module instance observed