### PR TITLE
fix: preserve shared cycles when runtime dependency scanning is incomplete

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1484,6 +1484,59 @@ describe('pluginProxySharedModule_preBuild', () => {
     readdirSyncMock.mockReset().mockReturnValue([]);
   });
 
+  it('keeps ordinary edges when a shared entry exceeds the runtime scan limit', async () => {
+    normalizeModuleFederationOptions({ name: 'host', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'vue' ? '/repo/apps/remote/node_modules/vue/index.js' : undefined
+    );
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/vue/package.json' ||
+        p === '/repo/apps/remote/node_modules/vue/index.js' ||
+        p === '/repo/packages/bridge/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p === '/repo/apps/remote/node_modules/vue/index.js') return "import 'bridge';";
+      if (p === '/repo/packages/bridge/package.json') return '{"name":"bridge"}';
+      return '{}';
+    });
+    readdirSyncMock.mockImplementation((dir: string) =>
+      dir === '/repo/apps/remote/node_modules/vue' ? [sourceFile('index.js')] : []
+    );
+    statSyncMock.mockImplementation((p: string) => ({
+      size: p.endsWith('/index.js') ? 300 * 1024 : 128,
+      isFile: () => true,
+    }));
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeUndefined();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
+    statSyncMock.mockReset().mockImplementation(() => ({ size: 128, isFile: () => true }));
+  });
+
   it('proxies imports from unshared workspace packages the shared package reaches only through its manifest', async () => {
     normalizeModuleFederationOptions({ name: 'remote', shared: {} });
     hasPackageDependencyMock.mockReturnValue(false);

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -1537,6 +1537,54 @@ describe('pluginProxySharedModule_preBuild', () => {
     statSyncMock.mockReset().mockImplementation(() => ({ size: 128, isFile: () => true }));
   });
 
+  it('proxies unrelated workspace imports when a reachable module exceeds the runtime scan limit', async () => {
+    normalizeModuleFederationOptions({ name: 'host', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg) =>
+      pkg === 'vue' ? '/repo/apps/remote/node_modules/vue/index.js' : undefined
+    );
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/vue/package.json' ||
+        p === '/repo/packages/widgets/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('/vue/index.js')) return "import './runtime';";
+      if (p.endsWith('/widgets/package.json')) return '{"name":"widgets"}';
+      return '{}';
+    });
+    statSyncMock.mockImplementation((p: string) => ({
+      size: p.endsWith('/runtime.js') ? 300 * 1024 : 128,
+      isFile: () => true,
+    }));
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'vue',
+      '/repo/packages/widgets/src/panel.js',
+      { isEntry: false }
+    );
+
+    expect(resolution).toBeDefined();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+    statSyncMock.mockReset().mockImplementation(() => ({ size: 128, isFile: () => true }));
+  });
+
   it('proxies imports from unshared workspace packages the shared package reaches only through its manifest', async () => {
     normalizeModuleFederationOptions({ name: 'remote', shared: {} });
     hasPackageDependencyMock.mockReturnValue(false);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -325,14 +325,11 @@ export function isSharedPackageDependency(sharedKey: string, dependency: string)
   return reachable.has(dependency);
 }
 
-const sharedRuntimeDependencyCache = new Map<
-  string,
-  { dependencies: Set<string>; complete: boolean }
->();
+const sharedRuntimeDependencyCache = new Map<string, Set<string>>();
 const SOURCE_FILE_RE = /\.(?:[cm]?js|[cm]?ts|jsx|tsx)$/;
 const NON_RUNTIME_SOURCE_RE = /(?:\.d\.[cm]?ts|\.(?:test|spec|stories)\.[cm]?[jt]sx?)$/;
 const NON_RUNTIME_DIRS = new Set(['node_modules', '__tests__', 'dist', 'build']);
-/** Bundled artifacts of a published package never import workspace packages; skip them instead of scanning megabytes. */
+/** Keep local runtime walks bounded without skipping the package entry itself. */
 const MAX_SCANNED_SOURCE_BYTES = 256 * 1024;
 
 const BARE_PACKAGE_SPECIFIER_RE =
@@ -399,17 +396,21 @@ function resolveLocalRuntimeImport(importer: string, specifier: string): string 
 
 function collectReachableRuntimeImports(entry: string, dir: string, into: Set<string>): boolean {
   const visited = new Set<string>();
-  const queue = [entry];
+  const queue = [{ file: entry, isEntry: true }];
   let scanned = false;
   let complete = true;
   while (queue.length) {
-    const file = queue.shift()!;
+    const { file, isEntry } = queue.shift()!;
     const relative = path.relative(dir, file);
     if (relative.startsWith('..') || path.isAbsolute(relative) || visited.has(file)) continue;
     visited.add(file);
     let code: string;
     try {
-      if (statSync(file).size > MAX_SCANNED_SOURCE_BYTES) {
+      // The package entry must be scanned even when it is a large bundled file:
+      // its direct imports are the only evidence available for detecting a cycle
+      // back into an unshared workspace package. Keep the limit for files reached
+      // through local imports so one large bundle cannot make the whole walk expensive.
+      if (!isEntry && statSync(file).size > MAX_SCANNED_SOURCE_BYTES) {
         complete = false;
         continue;
       }
@@ -425,7 +426,7 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
         continue;
       }
       const local = resolveLocalRuntimeImport(file, specifier);
-      if (local) queue.push(local);
+      if (local) queue.push({ file: local, isEntry: false });
     }
   }
   return scanned && complete;
@@ -440,11 +441,10 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
  */
 export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: string): boolean {
   const cached = sharedRuntimeDependencyCache.get(sharedKey);
-  if (cached) return !cached.complete || cached.dependencies.has(dependency);
+  if (cached) return cached.has(dependency);
 
   const sharedPackage = getPackageName(sharedKey);
   const reachable = new Set<string>();
-  let complete = true;
   const visited = new Set<string>();
   const queue = [
     {
@@ -455,7 +455,6 @@ export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: 
   while (queue.length) {
     const { request, installed } = queue.shift()!;
     if (!installed) {
-      complete = false;
       continue;
     }
     const visitKey = `${installed.dir}\0${request}`;
@@ -469,7 +468,6 @@ export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: 
     if (!entry) {
       collectAllRuntimeImports(installed.dir, specifiers);
     } else if (!collectReachableRuntimeImports(entry, installed.dir, specifiers)) {
-      complete = false;
       collectAllRuntimeImports(installed.dir, specifiers);
     }
     for (const specifier of specifiers) {
@@ -483,12 +481,8 @@ export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: 
       }
     }
   }
-  const result = { dependencies: reachable, complete };
-  sharedRuntimeDependencyCache.set(sharedKey, result);
-  // An incomplete scan cannot prove that the dependency is absent. Keep the
-  // ordinary edge in that case so a missed cycle never gets a loadShare glue
-  // module inserted into the fallback evaluation graph.
-  return !complete || reachable.has(dependency);
+  sharedRuntimeDependencyCache.set(sharedKey, reachable);
+  return reachable.has(dependency);
 }
 
 export function proxySharedModule(options: {

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -325,7 +325,10 @@ export function isSharedPackageDependency(sharedKey: string, dependency: string)
   return reachable.has(dependency);
 }
 
-const sharedRuntimeDependencyCache = new Map<string, Set<string>>();
+const sharedRuntimeDependencyCache = new Map<
+  string,
+  { dependencies: Set<string>; complete: boolean }
+>();
 const SOURCE_FILE_RE = /\.(?:[cm]?js|[cm]?ts|jsx|tsx)$/;
 const NON_RUNTIME_SOURCE_RE = /(?:\.d\.[cm]?ts|\.(?:test|spec|stories)\.[cm]?[jt]sx?)$/;
 const NON_RUNTIME_DIRS = new Set(['node_modules', '__tests__', 'dist', 'build']);
@@ -398,6 +401,7 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
   const visited = new Set<string>();
   const queue = [entry];
   let scanned = false;
+  let complete = true;
   while (queue.length) {
     const file = queue.shift()!;
     const relative = path.relative(dir, file);
@@ -405,10 +409,14 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
     visited.add(file);
     let code: string;
     try {
-      if (statSync(file).size > MAX_SCANNED_SOURCE_BYTES) continue;
+      if (statSync(file).size > MAX_SCANNED_SOURCE_BYTES) {
+        complete = false;
+        continue;
+      }
       code = readFileSync(file, 'utf-8');
       scanned = true;
     } catch {
+      complete = false;
       continue;
     }
     for (const specifier of getRuntimeModuleSpecifiers(code)) {
@@ -420,7 +428,7 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
       if (local) queue.push(local);
     }
   }
-  return scanned;
+  return scanned && complete;
 }
 
 /**
@@ -431,45 +439,56 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
  * latter covers far more than the module graph ever does.
  */
 export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: string): boolean {
+  const cached = sharedRuntimeDependencyCache.get(sharedKey);
+  if (cached) return !cached.complete || cached.dependencies.has(dependency);
+
   const sharedPackage = getPackageName(sharedKey);
-  let reachable = sharedRuntimeDependencyCache.get(sharedKey);
-  if (!reachable) {
-    reachable = new Set<string>();
-    const visited = new Set<string>();
-    const queue = [
-      {
-        request: sharedKey,
-        installed: getInstalledPackageJson(sharedPackage, { packageName: sharedPackage }),
-      },
-    ];
-    while (queue.length) {
-      const { request, installed } = queue.shift()!;
-      if (!installed) continue;
-      const visitKey = `${installed.dir}\0${request}`;
-      if (visited.has(visitKey)) continue;
-      visited.add(visitKey);
-      const specifiers = new Set<string>();
-      const entry = getInstalledPackageEntry(request, {
-        cwd: installed.dir,
-        packageName: getPackageName(request),
-      });
-      if (!entry || !collectReachableRuntimeImports(entry, installed.dir, specifiers)) {
-        collectAllRuntimeImports(installed.dir, specifiers);
-      }
-      for (const specifier of specifiers) {
-        const dep = getPackageName(specifier);
-        if (dep === sharedPackage) continue;
-        reachable.add(dep);
-        const manifest = getDependencyManifest(dep, installed.dir);
-        // Only workspace packages get bundled into the fallback; a node_modules package stays a leaf.
-        if (manifest && !isNodeModulePath(manifest.dir)) {
-          queue.push({ request: specifier, installed: manifest });
-        }
+  const reachable = new Set<string>();
+  let complete = true;
+  const visited = new Set<string>();
+  const queue = [
+    {
+      request: sharedKey,
+      installed: getInstalledPackageJson(sharedPackage, { packageName: sharedPackage }),
+    },
+  ];
+  while (queue.length) {
+    const { request, installed } = queue.shift()!;
+    if (!installed) {
+      complete = false;
+      continue;
+    }
+    const visitKey = `${installed.dir}\0${request}`;
+    if (visited.has(visitKey)) continue;
+    visited.add(visitKey);
+    const specifiers = new Set<string>();
+    const entry = getInstalledPackageEntry(request, {
+      cwd: installed.dir,
+      packageName: getPackageName(request),
+    });
+    if (!entry) {
+      collectAllRuntimeImports(installed.dir, specifiers);
+    } else if (!collectReachableRuntimeImports(entry, installed.dir, specifiers)) {
+      complete = false;
+      collectAllRuntimeImports(installed.dir, specifiers);
+    }
+    for (const specifier of specifiers) {
+      const dep = getPackageName(specifier);
+      if (dep === sharedPackage) continue;
+      reachable.add(dep);
+      const manifest = getDependencyManifest(dep, installed.dir);
+      // Only workspace packages get bundled into the fallback; a node_modules package stays a leaf.
+      if (manifest && !isNodeModulePath(manifest.dir)) {
+        queue.push({ request: specifier, installed: manifest });
       }
     }
-    sharedRuntimeDependencyCache.set(sharedKey, reachable);
   }
-  return reachable.has(dependency);
+  const result = { dependencies: reachable, complete };
+  sharedRuntimeDependencyCache.set(sharedKey, result);
+  // An incomplete scan cannot prove that the dependency is absent. Keep the
+  // ordinary edge in that case so a missed cycle never gets a loadShare glue
+  // module inserted into the fallback evaluation graph.
+  return !complete || reachable.has(dependency);
 }
 
 export function proxySharedModule(options: {


### PR DESCRIPTION
## Summary

Fix the runtime dependency scanner from incorrectly treating a large shared entry as having no dependency and inserting a `loadShare` proxy inside a cycle.

This regression was introduced by [PR #1227](https://github.com/module-federation/vite/pull/1227), which added runtime-import-based cycle detection. Files larger than 256KB were skipped by both the reachable scan and its fallback, so actual runtime dependencies could be missed.

## Changes

- Track whether runtime import scanning completed successfully.
- Preserve the ordinary edge when an entry or reachable local module cannot be analyzed instead of assuming the dependency is absent.
- Add a regression test for a 256KB+ shared entry importing an unshared workspace package in a cycle.

## Validation

- Related plugin tests: 79 passed
- Full test suite: 1253 passed, 1 skipped
- `pnpm typecheck`: passed