### PR TITLE
fix: respect export conditions during runtime dependency scans

### DIFF
--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -38,7 +38,17 @@ const {
   writeLoadShareModuleMock: vi.fn(),
   writeLocalSharedImportMapMock: vi.fn<() => void>(),
   writePreBuildLibPathMock: vi.fn(),
-  getInstalledPackageEntryMock: vi.fn<(pkg: string) => string | undefined>(() => undefined),
+  getInstalledPackageEntryMock: vi.fn<
+    (
+      pkg: string,
+      opts?: {
+        cwd?: string;
+        packageName?: string;
+        conditions?: string[];
+        resolveSubpathWithRequire?: boolean;
+      }
+    ) => string | undefined
+  >(() => undefined),
   hasTreeShakingSharedProviderMock: vi.fn<(pkg: string, shareItem?: unknown) => boolean>(
     () => false
   ),
@@ -1332,6 +1342,137 @@ describe('pluginProxySharedModule_preBuild', () => {
 
     expect(resolution).toBeUndefined();
     expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
+  });
+
+  it('uses SSR export conditions when scanning shared runtime dependencies', async () => {
+    normalizeModuleFederationOptions({ name: 'remote', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg, opts) => {
+      if (pkg !== 'react') return undefined;
+      return opts?.conditions?.includes('node')
+        ? '/repo/apps/remote/node_modules/react/node.js'
+        : '/repo/apps/remote/node_modules/react/browser.js';
+    });
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/react/package.json' ||
+        p === '/repo/packages/bridge/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('/react/package.json')) return '{"dependencies":{"bridge":"workspace:*"}}';
+      if (p.endsWith('/react/node.js'))
+        return "import { title } from 'bridge';\nexport const Button = title;";
+      if (p.endsWith('/react/browser.js')) return "export const Button = 'button';";
+      if (p.endsWith('/bridge/package.json')) return '{"name":"bridge"}';
+      return '{}';
+    });
+
+    const plugins = proxySharedModule({ shared: makeShared() });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const clientResolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'react',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false, ssr: false }
+    );
+
+    expect(clientResolution).toBeDefined();
+    writeLoadShareModuleMock.mockClear();
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'react',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false, ssr: true }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(getInstalledPackageEntryMock).toHaveBeenCalledWith(
+      'react',
+      expect.objectContaining({ conditions: expect.arrayContaining(['node']) })
+    );
+    expect(writeLoadShareModuleMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset().mockReturnValue('{}');
+    readdirSyncMock.mockReset().mockReturnValue([]);
+  });
+
+  it('uses the importing subpath when scanning wildcard shared runtime dependencies', async () => {
+    normalizeModuleFederationOptions({ name: 'remote', shared: {} });
+    hasPackageDependencyMock.mockReturnValue(false);
+    getInstalledPackageEntryMock.mockImplementation((pkg, opts) => {
+      if (pkg !== 'react/jsx-runtime') return undefined;
+      return opts?.resolveSubpathWithRequire === false && opts.conditions?.includes('node')
+        ? '/repo/apps/remote/node_modules/react/jsx-runtime.node.js'
+        : '/repo/apps/remote/node_modules/react/jsx-runtime.browser.js';
+    });
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p === '/repo/apps/remote/node_modules/react/package.json' ||
+        p === '/repo/packages/bridge/package.json'
+    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('/react/package.json')) return '{}';
+      if (p.endsWith('/react/jsx-runtime.node.js'))
+        return "import { title } from 'bridge';\nexport const jsx = title;";
+      if (p.endsWith('/react/jsx-runtime.browser.js')) return 'export const jsx = true;';
+      if (p.endsWith('/bridge/package.json')) return '{"name":"bridge"}';
+      return '{}';
+    });
+
+    const shared: NormalizedShared = {
+      'react/': {
+        ...makeShared().react,
+        name: 'react/',
+      },
+    };
+    const plugins = proxySharedModule({ shared });
+    const proxyPlugin = getProxyPlugin(plugins);
+    const sharedResolvePlugin = getSharedResolvePlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+
+    const resolution = await callHook(
+      sharedResolvePlugin.resolveId,
+      { resolve: async (id: string) => ({ id: `/resolved/${id}` }) } as any,
+      'react/jsx-runtime',
+      '/repo/packages/bridge/src/title.js',
+      { isEntry: false, ssr: true }
+    );
+
+    expect(resolution).toBeUndefined();
+    expect(getInstalledPackageEntryMock).toHaveBeenCalledWith(
+      'react/jsx-runtime',
+      expect.objectContaining({
+        conditions: expect.arrayContaining(['node']),
+        resolveSubpathWithRequire: false,
+      })
+    );
     existsSyncMock.mockReset().mockReturnValue(false);
     readFileSyncMock.mockReset().mockReturnValue('{}');
     readdirSyncMock.mockReset().mockReturnValue([]);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -37,6 +37,7 @@ import {
   setPackageDetectionCwd,
 } from '../utils/packageUtils';
 import { PromiseStore } from '../utils/PromiseStore';
+import { getSharedExportConditions } from '../utils/sharedExportConditions';
 import VirtualModule, { assertModuleFound } from '../utils/VirtualModule';
 import {
   collectTreeShakingImports,
@@ -430,9 +431,14 @@ function collectReachableRuntimeImports(entry: string, dir: string, into: Set<st
  * the fallback's evaluation graph rather than the package's declared closure — in a monorepo the
  * latter covers far more than the module graph ever does.
  */
-export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: string): boolean {
+export function isSharedPackageRuntimeDependency(
+  sharedKey: string,
+  dependency: string,
+  conditions?: readonly string[]
+): boolean {
   const sharedPackage = getPackageName(sharedKey);
-  let reachable = sharedRuntimeDependencyCache.get(sharedKey);
+  const cacheKey = `${sharedKey}\0${JSON.stringify(conditions ?? null)}`;
+  let reachable = sharedRuntimeDependencyCache.get(cacheKey);
   if (!reachable) {
     reachable = new Set<string>();
     const visited = new Set<string>();
@@ -452,6 +458,8 @@ export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: 
       const entry = getInstalledPackageEntry(request, {
         cwd: installed.dir,
         packageName: getPackageName(request),
+        resolveSubpathWithRequire: false,
+        ...(conditions !== undefined ? { conditions: [...conditions] } : {}),
       });
       if (!entry || !collectReachableRuntimeImports(entry, installed.dir, specifiers)) {
         collectAllRuntimeImports(installed.dir, specifiers);
@@ -467,7 +475,7 @@ export function isSharedPackageRuntimeDependency(sharedKey: string, dependency: 
         }
       }
     }
-    sharedRuntimeDependencyCache.set(sharedKey, reachable);
+    sharedRuntimeDependencyCache.set(cacheKey, reachable);
   }
   return reachable.has(dependency);
 }
@@ -482,6 +490,10 @@ export function proxySharedModule(options: {
   let _command = 'serve';
   let useDirectReactImport = false;
   let useRolldown = false;
+  let isProduction = false;
+  let rootResolveConditions: string[] | undefined;
+  let ssrResolveConditions: string[] | undefined;
+  let ssrTarget: 'node' | 'webworker' = 'node';
   const savePrebuild = new PromiseStore<string>();
   let devServer: ViteDevServer | undefined;
   // resolveId fires once per importing module. The loadShare virtual module,
@@ -494,9 +506,43 @@ export function proxySharedModule(options: {
   const hasAnalyzableShares = Object.values(shared).some((share) =>
     shouldAnalyzeSharedExports(share)
   );
+  type RuntimeDependencyContext = {
+    environment?: {
+      name?: string;
+      config?: {
+        consumer?: string;
+        build?: { ssr?: boolean | string };
+        isProduction?: boolean;
+        resolve?: { conditions?: string[] };
+      };
+    };
+  };
+  const getEnvironmentConfig = (context: unknown) =>
+    (context as RuntimeDependencyContext).environment?.config;
   const getEnvironmentConditions = (context: unknown): string[] | undefined =>
-    (context as { environment?: { config?: { resolve?: { conditions?: string[] } } } }).environment
-      ?.config?.resolve?.conditions;
+    getEnvironmentConfig(context)?.resolve?.conditions;
+  const getRuntimeDependencyConditions = (
+    context: unknown,
+    resolveOptions: { ssr?: boolean }
+  ): string[] => {
+    const environment = (context as RuntimeDependencyContext).environment;
+    const environmentConfig = environment?.config;
+    const isSsr =
+      resolveOptions.ssr === true ||
+      Boolean(_config?.build?.ssr) ||
+      environmentConfig?.consumer === 'server' ||
+      Boolean(environmentConfig?.build?.ssr) ||
+      environment?.name === 'ssr' ||
+      environment?.name === 'server';
+    return getSharedExportConditions({
+      environmentConditions: environmentConfig?.resolve?.conditions,
+      isProduction: environmentConfig?.isProduction ?? isProduction,
+      isSsr,
+      rootConditions: rootResolveConditions,
+      ssrConditions: ssrResolveConditions,
+      ssrTarget,
+    });
+  };
   const refreshTreeShakingForEnvironment = (context: unknown) =>
     refreshTreeShakingModules(
       federationOptions,
@@ -626,6 +672,14 @@ export function proxySharedModule(options: {
       },
       configResolved(config) {
         _config = config;
+        isProduction = config.isProduction;
+        rootResolveConditions = config.resolve?.conditions
+          ? [...config.resolve.conditions]
+          : undefined;
+        ssrResolveConditions = config.ssr?.resolve?.conditions
+          ? [...config.ssr.resolve.conditions]
+          : undefined;
+        ssrTarget = config.ssr?.target ?? 'node';
 
         // Write virtual module files and register provider metadata eagerly.
         // Materialization stays tied to imports observed by resolveId below.
@@ -778,8 +832,14 @@ export function proxySharedModule(options: {
           const importerIsUnsharedWorkspacePackage =
             !isNodeModulePath(importer!) &&
             !Object.keys(shared).some((sharedKey) => getPackageName(sharedKey) === importerPackage);
+          const runtimeDependencyRequest =
+            key.endsWith('/') && matchesSharedSource(source, key) ? source : key;
           const keepsOrdinaryEdge = importerIsUnsharedWorkspacePackage
-            ? isSharedPackageRuntimeDependency(key, importerPackage)
+            ? isSharedPackageRuntimeDependency(
+                runtimeDependencyRequest,
+                importerPackage,
+                getRuntimeDependencyConditions(this, resolveOptions)
+              )
             : isSharedPackageDependency(key, importerPackage);
           if (keepsOrdinaryEdge) return;
         }


### PR DESCRIPTION
## Summary

This regression originated in the runtime-import-based cycle edge detection introduced by [#1227](https://github.com/module-federation/vite/pull/1227). Make shared package runtime dependency scans use the same conditions as Vite's client and SSR export resolution to prevent conditional exports and wildcard shared subpaths from misclassifying dependency cycles and inserting an incorrect `loadShare` proxy.

[#1233](https://github.com/module-federation/vite/pull/1233) was a follow-up that improved directory-import/index handling in the same scanner; the regression was originally introduced by #1227.

## Problem

- The scanner introduced by #1227 did not use Vite's actual client/SSR resolver conditions, so it could inspect a different entry and import graph from the one that would execute for a conditional export.
- A scan calculated for the client could be reused during SSR, mixing runtime dependency graphs across environments.
- For wildcard shared keys such as `react/`, the scanner received the configured key prefix instead of the actual import, such as `react/jsx-runtime`, and could miss the subpath entry.

This could incorrectly remove the cycle edge between an unshared workspace package and a shared package, causing an ordinary import to be handled through a `loadShare` proxy.

## Fix

- Pass Vite's client/SSR export conditions into runtime dependency scans and subpath resolution.
- Include conditions in the cache key so client and SSR scan results remain isolated.
- For wildcard shared entries, scan the actual imported subpath instead of the configured `pkg/` prefix and disable the `require` fallback for that subpath lookup.

## Review focus

- Verify that runtime scan conditions match the `resolveId` environment, including the SSR target and user-provided `resolve.conditions`.
- Verify that scan results from different conditions cannot be reused from the same cache entry.
- Verify both ordinary and wildcard shared keys, including directory/index resolution and unresolved-entry fallback.
- Verify that `loadShare` is not injected when the runtime graph requires the ordinary cycle edge to be preserved.

## Changes

- Separate scan caches by client/SSR conditions and pass export conditions to subpath resolution.
- Scan the actual import subpath for wildcard shared keys instead of the configured `pkg/` prefix.
- Add regression coverage for SSR conditions and wildcard subpaths.

## Validation

- `pnpm build`
- `pnpm test` (50 files, 1255 passed, 1 skipped)
- `pnpm test:integration` (16 files, 94 passed)
- `pnpm e2e` (27 passed)
- `pnpm typecheck`
- `pnpm fmt.check`