### PR TITLE
fix(ssr): bust unversioned entry cache on revalidation

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -1327,7 +1327,9 @@ type RunnerOptions = {
 };
 
 async function freshLoaderWithRunner(
-  runnerFactory: (options: RunnerOptions) => { import: (id: string) => Promise<unknown> } | null
+  runnerFactory: (
+    options: RunnerOptions
+  ) => { import: (id: string) => Promise<unknown>; clearCache?: () => void } | null
 ) {
   vi.resetModules();
   const runnerModule = {
@@ -1368,8 +1370,8 @@ async function freshLoaderWithRunner(
     return runnerModule;
   });
   vi.doMock('module', () => ({ default: { createRequire }, createRequire }));
-  const { default: factory } = await import('../ssrEntryLoader');
-  return factory;
+  const { default: factory, revalidate } = await import('../ssrEntryLoader');
+  return { factory, revalidate };
 }
 
 describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
@@ -1377,7 +1379,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
     const mockMod = { init: vi.fn(), get: vi.fn() };
     const mockImport = vi.fn().mockResolvedValue(mockMod);
 
-    const factory = await freshLoaderWithRunner(() => ({ import: mockImport }));
+    const { factory } = await freshLoaderWithRunner(() => ({ import: mockImport }));
 
     const fetch = makeFetchMock({
       'http://localhost:4175/mf-manifest.json': {
@@ -1403,6 +1405,52 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
     expect(result).toBe(mockMod);
   });
 
+  it('clears the matching ModuleRunner cache on explicit revalidation', async () => {
+    let marker = 'v1';
+    let cachedModule: { init: unknown; get: unknown; marker: string } | undefined;
+    const runner = {
+      import: vi.fn(async () => {
+        cachedModule ??= { init: vi.fn(), get: vi.fn(), marker };
+        return cachedModule;
+      }),
+      clearCache: vi.fn(() => {
+        cachedModule = undefined;
+      }),
+    };
+    const { factory, revalidate } = await freshLoaderWithRunner(() => runner);
+
+    const fetch = makeFetchMock({
+      'http://localhost:4175/mf-manifest.json': {
+        ok: true,
+        json: {
+          metaData: {
+            ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '__mf_ssr__/', type: 'module' },
+          },
+        },
+      },
+      'http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js': {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+      },
+    });
+    global.fetch = fetch as unknown as typeof globalThis.fetch;
+
+    const plugin = factory();
+    const first = await plugin.loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:4175/remoteEntry.js' },
+    });
+
+    marker = 'v2';
+    revalidate('http://localhost:4175/remoteEntry.js');
+    await vi.waitFor(() => expect(runner.clearCache).toHaveBeenCalledOnce());
+    const second = await plugin.loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:4175/remoteEntry.js' },
+    });
+
+    expect((first as unknown as { marker: string }).marker).toBe('v1');
+    expect((second as unknown as { marker: string }).marker).toBe('v2');
+  });
+
   it('preserves remote module resolution and isolates runners by host', async () => {
     const hostReactPaths = [
       '/host-a/node_modules/react/index.js',
@@ -1410,7 +1458,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
     ];
     const sharedFetchResults: unknown[] = [];
 
-    const factory = await freshLoaderWithRunner((runnerOptions) => ({
+    const { factory } = await freshLoaderWithRunner((runnerOptions) => ({
       import: vi.fn(async () => {
         sharedFetchResults.push(
           await runnerOptions.transport.invoke({
@@ -1466,7 +1514,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
 
   it('falls back to a host shared module when remote resolution fails', async () => {
     const sharedFetchResults: unknown[] = [];
-    const factory = await freshLoaderWithRunner((runnerOptions) => ({
+    const { factory } = await freshLoaderWithRunner((runnerOptions) => ({
       import: vi.fn(async () => {
         sharedFetchResults.push(
           await runnerOptions.transport.invoke({
@@ -1510,7 +1558,7 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
 
   it('does not throw when the runner endpoint returns a JSON primitive', async () => {
     const sharedFetchResults: unknown[] = [];
-    const factory = await freshLoaderWithRunner((runnerOptions) => ({
+    const { factory } = await freshLoaderWithRunner((runnerOptions) => ({
       import: vi.fn(async () => {
         sharedFetchResults.push(
           await runnerOptions.transport.invoke({

--- a/src/utils/__tests__/ssrEntryLoader.unversioned-revalidate.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.unversioned-revalidate.test.ts
@@ -1,0 +1,69 @@
+import { createServer, type Server } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import ssrEntryLoaderPlugin, { revalidate } from '../ssrEntryLoader';
+
+async function startRemote(initialMarker: string): Promise<{
+  server: Server;
+  entryUrl: string;
+  setMarker: (marker: string) => void;
+}> {
+  let marker = initialMarker;
+  const server = createServer((request, response) => {
+    if (request.url !== '/remoteEntry.ssr.js') {
+      response.statusCode = 404;
+      response.end();
+      return;
+    }
+
+    response.setHeader('content-type', 'application/javascript');
+    response.end(`export const marker = ${JSON.stringify(marker)};`);
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('The test server did not expose a TCP address');
+  }
+
+  return {
+    server,
+    entryUrl: `http://127.0.0.1:${address.port}/remoteEntry.js`,
+    setMarker(nextMarker: string) {
+      marker = nextMarker;
+    },
+  };
+}
+
+async function closeRemote(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+}
+
+function getMarker(value: unknown): string {
+  return (value as { marker: string }).marker;
+}
+
+describe('ssrEntryLoaderPlugin — convention entry revalidation', () => {
+  it('loads a fresh module after explicit revalidate()', async () => {
+    const remote = await startRemote('v1');
+    try {
+      const plugin = ssrEntryLoaderPlugin();
+      const first = await plugin.loadEntry!({
+        remoteInfo: { name: 'remote', entry: remote.entryUrl },
+      });
+
+      remote.setMarker('v2');
+      revalidate(remote.entryUrl);
+      const second = await plugin.loadEntry!({
+        remoteInfo: { name: 'remote', entry: remote.entryUrl },
+      });
+
+      expect(getMarker(first)).toBe('v1');
+      expect(getMarker(second)).toBe('v2');
+    } finally {
+      await closeRemote(remote.server);
+    }
+  });
+});

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -62,7 +62,15 @@ const isNodeServer = (): boolean => {
 // shared-module map. The transport closes over resolvedShared, so different
 // hosts (or federation instances) must not reuse a runner configured for
 // another host's filesystem.
-const runnerCache = new Map<string, Promise<unknown>>();
+type CachedModuleRunner = {
+  import: (id: string) => Promise<unknown>;
+  clearCache?: () => void;
+};
+
+const runnerCache = new Map<
+  string,
+  { remoteOrigin: string; promise: Promise<CachedModuleRunner | null> }
+>();
 
 function getSortedRecordEntries(record: Record<string, string>): [string, string][] {
   return Object.entries(record).sort(([left], [right]) => left.localeCompare(right));
@@ -85,7 +93,7 @@ async function getModuleRunnerModule(): Promise<{
       };
     },
     evaluator?: unknown
-  ) => { import: (id: string) => Promise<unknown> };
+  ) => CachedModuleRunner;
   ESModulesEvaluator: new () => unknown;
 } | null> {
   const moduleRunnerId = ['vite', 'module-runner'].join('/');
@@ -151,7 +159,8 @@ async function getOrCreateRunner(
   fetchMaxBytes: number
 ): Promise<unknown> {
   const cacheKey = getRunnerCacheKey(remoteOrigin, resolvedShared, fetchTimeoutMs, fetchMaxBytes);
-  if (runnerCache.has(cacheKey)) return runnerCache.get(cacheKey)!;
+  const cached = runnerCache.get(cacheKey);
+  if (cached) return cached.promise;
   const promise = (async () => {
     const viteRunner = await getModuleRunnerModule();
     if (!viteRunner) return null;
@@ -196,7 +205,7 @@ async function getOrCreateRunner(
       return null;
     }
   })();
-  runnerCache.set(cacheKey, promise);
+  runnerCache.set(cacheKey, { remoteOrigin, promise });
   return promise;
 }
 
@@ -652,6 +661,22 @@ function dropRemoteCaches(remoteEntryUrl: string): void {
   }
 }
 
+function clearRunnerCaches(remoteEntryUrl?: string): void {
+  let remoteOrigin: string | undefined;
+  if (remoteEntryUrl) {
+    try {
+      remoteOrigin = new URL(remoteEntryUrl).origin;
+    } catch {
+      return;
+    }
+  }
+
+  for (const cached of runnerCache.values()) {
+    if (remoteOrigin && cached.remoteOrigin !== remoteOrigin) continue;
+    void cached.promise.then((runner) => runner?.clearCache?.()).catch(() => {});
+  }
+}
+
 /**
  * Drop the loader's caches so the next `loadEntry` re-resolves and re-fetches
  * remote SSR entries. Pass a remote entry URL to scope the invalidation to one
@@ -680,6 +705,8 @@ export function revalidate(remoteEntryUrl?: string): void {
     tempFileCache.clear();
     tempFilePathCache.clear();
   }
+
+  clearRunnerCaches(remoteEntryUrl);
 
   const federation = (
     globalThis as {

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -272,10 +272,21 @@ function parseRunnerInvokeResult(
  * Version key for a resolved SSR entry. Derived from the remote's manifest
  * content so a redeploy at the same URL produces a different key, which in
  * turn produces different temp-file names — busting both our caches and
- * Node's ESM module cache. Convention-resolved entries (no manifest) get a
- * stable placeholder key and cannot be revalidated automatically.
+ * Node's ESM module cache. Convention-resolved entries (no manifest) use a
+ * stable placeholder key for ordinary loads; explicit `revalidate()` calls
+ * advance a process-local generation so the next import is fresh.
  */
 const UNVERSIONED = 'unversioned';
+const unversionedGenerations = new Map<string, number>();
+let unversionedGlobalGeneration = 0;
+
+function getUnversionedVersionKey(remoteEntryUrl: string): string {
+  return `${UNVERSIONED}-${unversionedGlobalGeneration}-${unversionedGenerations.get(remoteEntryUrl) ?? 0}`;
+}
+
+function bumpUnversionedGeneration(remoteEntryUrl: string): void {
+  unversionedGenerations.set(remoteEntryUrl, (unversionedGenerations.get(remoteEntryUrl) ?? 0) + 1);
+}
 
 // FNV-1a — cheap, dependency-free, stable across processes. Not cryptographic;
 // only used to key caches and temp file names.
@@ -495,16 +506,20 @@ function buildSsrEntryCandidates(
     candidates.push({
       url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
       type: 'module',
-      versionKey: UNVERSIONED,
+      versionKey: getUnversionedVersionKey(ctx.entryUrl),
     });
   }
 
   candidates.push(
-    { url: `${base}.ssr.js`, type: 'module', versionKey: UNVERSIONED },
+    {
+      url: `${base}.ssr.js`,
+      type: 'module',
+      versionKey: getUnversionedVersionKey(ctx.entryUrl),
+    },
     {
       url: `${remoteOrigin}/__mf_ssr__/${filename}.ssr.js`,
       type: 'module',
-      versionKey: UNVERSIONED,
+      versionKey: getUnversionedVersionKey(ctx.entryUrl),
     }
   );
 
@@ -528,7 +543,11 @@ async function resolveSSREntryImpl(
   fetchMaxBytes: number
 ): Promise<SsrEntryCandidate | null> {
   if (isSsrEntry(remoteEntryUrl)) {
-    return { url: remoteEntryUrl, type: 'module', versionKey: UNVERSIONED };
+    return {
+      url: remoteEntryUrl,
+      type: 'module',
+      versionKey: getUnversionedVersionKey(remoteEntryUrl),
+    };
   }
 
   // For JS entries, probe the dedicated server build before fetching the manifest.
@@ -539,7 +558,7 @@ async function resolveSSREntryImpl(
       {
         url: `${remoteOrigin}/__mf_server__/${filename}.ssr.js`,
         type: 'module',
-        versionKey: UNVERSIONED,
+        versionKey: getUnversionedVersionKey(remoteEntryUrl),
       },
       fetchTimeoutMs
     );
@@ -645,6 +664,7 @@ function dropRemoteCaches(remoteEntryUrl: string): void {
  */
 export function revalidate(remoteEntryUrl?: string): void {
   if (remoteEntryUrl) {
+    bumpUnversionedGeneration(remoteEntryUrl);
     for (const key of ssrEntryCache.keys()) {
       if (key.endsWith(`::${remoteEntryUrl}`)) ssrEntryCache.delete(key);
     }
@@ -654,6 +674,7 @@ export function revalidate(remoteEntryUrl?: string): void {
     }
     dropRemoteCaches(remoteEntryUrl);
   } else {
+    unversionedGlobalGeneration += 1;
     ssrEntryCache.clear();
     manifestFetchCache.clear();
     tempFileCache.clear();


### PR DESCRIPTION
## Summary
SSR entries without manifest version data always used the same `unversioned` temp-file/import identity. After a remote changed from `v1` to `v2` at the same URL, explicit `revalidate()` could still return the old module from Node's ESM/temp caches, so the loader now adds a process-local generation; this does not detect deployments by itself and only makes explicit revalidation effective.

## Changes
- Advance the generation on explicit per-remote/global `revalidate()` to create a new temp-file/import identity.
- Add HTTP regression coverage that returns `v2` after `v1` for the `remoteEntry.js` convention fallback under explicit revalidation.

## Validation
- `pnpm exec vitest run src/utils/__tests__/ssrEntryLoader.unversioned-revalidate.test.ts`: passed (1 test).
- `pnpm test`: passed (51 files, 1,259 passed, 1 skipped).
- `pnpm typecheck`: passed.
- `pnpm build`: passed.