### PR TITLE
fix: keep lazy shared providers deferred

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -2180,6 +2180,11 @@ describe('pluginAddEntry', () => {
         name: '_virtual_mf___app__prebuild__antd__prebuild__',
         fileName: 'assets/chunk-_virtual_mf___app__prebuild__antd__prebuild__.js',
       },
+      'assets/chunk-_virtual_mf___app__loadShare__antd__loadShare__.js': {
+        type: 'chunk',
+        name: '_virtual_mf___app__loadShare__antd__loadShare__',
+        fileName: 'assets/chunk-_virtual_mf___app__loadShare__antd__loadShare__.js',
+      },
       'assets/chunk-index.B_.js': {
         type: 'chunk',
         name: 'index',
@@ -2233,6 +2238,7 @@ describe('pluginAddEntry', () => {
       '<link rel="modulepreload" crossorigin href="/app/assets/chunk-_virtual_mf-localSharedImportMap___app.Bl.js">'
     );
     expect(html).not.toContain('chunk-_virtual_mf___app__prebuild__antd__prebuild__.js');
+    expect(html).not.toContain('chunk-_virtual_mf___app__loadShare__antd__loadShare__.js');
     expect(html.match(/chunk-index\.B_\.js/g)?.length).toBe(1);
     expect(html).not.toContain('index.AA.css');
   });

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -166,6 +166,7 @@ async function runGenerateBundleWithManifest(
           shareConfig: {
             requiredVersion: string;
             singleton?: boolean;
+            eager?: boolean;
             treeShaking?: {
               mode?: 'server-calc' | 'runtime-infer';
               usedExports?: string[];
@@ -1033,6 +1034,27 @@ describe('pluginMFManifest', () => {
     const sharedAssets = manifest.shared[0].assets.js;
     expect([...sharedAssets.sync, ...sharedAssets.async]).toContain('antd-full.js');
     expect([...sharedAssets.sync, ...sharedAssets.async]).not.toContain('antd-tree.js');
+  });
+
+  it('classifies non-eager shared provider assets as async', async () => {
+    const bundle = makeBundle();
+    bundle['shared.js'] = createChunk('shared.js', ['/node_modules/vue/index.js']);
+
+    const emitted = await runGenerateBundleWithManifest(true, {
+      bundle,
+      usedShares: new Set(['vue']),
+      shareItems: {
+        vue: {
+          version: '3.5.0',
+          shareConfig: { requiredVersion: '^3.5.0', eager: false },
+        },
+      },
+    });
+
+    expect(JSON.parse(emitted['mf-manifest.json']).shared[0].assets.js).toEqual({
+      sync: [],
+      async: ['shared.js'],
+    });
   });
 
   it('marks unsafe tree-shaking usage as full-bundle-only', async () => {

--- a/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
+++ b/src/plugins/__tests__/pluginProxySharedModule_preBuild.test.ts
@@ -2055,6 +2055,57 @@ describe('pluginProxySharedModule_preBuild', () => {
     expect(addUsedSharesMock).not.toHaveBeenCalled();
   });
 
+  it('does not materialize unused providers during build setup', () => {
+    const plugins = proxySharedModule({
+      shared: makeShared(),
+      federationOptions: { exposes: {} } as any,
+    });
+    const proxyPlugin = getProxyPlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+    callHook(
+      proxyPlugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      { experimental: { rolldownDev: false } } as unknown as ResolvedConfig
+    );
+
+    expect(addUsedSharesMock).not.toHaveBeenCalled();
+  });
+
+  it('materializes configured providers for exposing builds', () => {
+    const shared = makeShared();
+    const plugins = proxySharedModule({
+      shared,
+      federationOptions: { exposes: { './App': { import: './src/App' } } } as any,
+    });
+    const proxyPlugin = getProxyPlugin(plugins);
+
+    callHook(
+      proxyPlugin.config,
+      {
+        meta: createPluginMeta(),
+        resolve: async (id: string) => ({ id: `/resolved/${id}` }),
+      } as unknown as ConfigPluginContext,
+      { resolve: { alias: [] } },
+      { command: 'build', mode: 'production' } as ConfigEnv
+    );
+    callHook(
+      proxyPlugin.configResolved,
+      {} as MinimalPluginContextWithoutEnvironment,
+      { experimental: { rolldownDev: false } } as unknown as ResolvedConfig
+    );
+
+    expect(addUsedSharesMock).toHaveBeenCalledTimes(Object.keys(shared).length);
+  });
+
   it('keeps common shared subpaths when resolving node_modules paths', async () => {
     hasPackageDependencyMock.mockReturnValue(false);
 

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -55,12 +55,13 @@ interface AddEntryOptions {
 // Tree-shaken shares deliberately keep their complete provider as a lazy
 // fallback. Preloading every virtual MF chunk would fetch that fallback
 // before runtime provider selection has a chance to choose the optimized
-// provider — so `__prebuild__` chunks are always excluded.
+// provider — so provider chunks are always excluded. `__loadShare__` chunks
+// perform their own materialization check before loading a provider.
 // Virtual MF chunk file names vary in their underscore prefix depending on
 // how the bundler sanitizes the virtual id (`_virtual_mf…`, `virtual_mf…`,
 // `__virtual_mf…`), so match by substring.
 const isPreloadableVirtualMfChunk = (name: string) =>
-  name.includes('virtual_mf') && !name.includes('__prebuild__');
+  name.includes('virtual_mf') && !name.includes('__prebuild__') && !name.includes('__loadShare__');
 
 const HOST_INIT_PRELOAD_CHUNKS: ReadonlyArray<(name: string) => boolean> = [
   (name) => name === 'hostInit',

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -472,6 +472,14 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
             fileToShareKey.get(modulePath)
           );
 
+          for (const shareKey of getUsedShares(mfOptions)) {
+            const shareItem = getNormalizeShareItem(shareKey, mfOptions);
+            const assets = filesMap[shareKey];
+            if (!assets || shareItem?.shareConfig.eager === true) continue;
+            assets.js.async.push(...assets.js.sync.splice(0));
+            assets.css.async.push(...assets.css.sync.splice(0));
+          }
+
           // Add all CSS assets to every export if bundleAllCSS is enabled
           if (mfOptions.bundleAllCSS) {
             addCssAssetsToAllExports(filesMap, allCssAssets);

--- a/src/plugins/pluginProxySharedModule_preBuild.ts
+++ b/src/plugins/pluginProxySharedModule_preBuild.ts
@@ -722,10 +722,11 @@ export function proxySharedModule(options: {
         // in the config hook (createEarlyVirtualModulesPlugin), so Vite
         // pre-bundles them upfront without triggering re-optimization.
         const isRolldown = getIsRolldown(this);
-        // Build output can emit the shared map before every consumer has been
-        // transformed, so retain its established eager seed set. Dev resolves
-        // imports incrementally and can distinguish configured from consumed.
-        const registerConfiguredShare = _command === 'serve' ? addConfiguredShare : addUsedShares;
+        const resolvedOptions = federationOptions ?? getNormalizeModuleFederationOptions();
+        const registerConfiguredShare =
+          _command === 'build' && Object.keys(resolvedOptions.exposes).length > 0
+            ? addUsedShares
+            : addConfiguredShare;
         Object.keys(shared).forEach((key) => {
           if (key.endsWith('/')) return;
           if (useDirectReactImport && key === 'react') {


### PR DESCRIPTION
Closes #1241

Classify non-eager shared assets as asynchronous and avoid preloading unused providers, while preserving provider materialization for exposing builds.