### PR TITLE
fix: derive SSR entry filenames like the browser ones

### DIFF
--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -2,7 +2,11 @@ import * as fs from 'fs';
 import { createHash } from 'node:crypto';
 import * as path from 'node:path';
 import type { Plugin, ResolvedConfig, Rollup } from 'vite';
-import { normalizePathForImport, rebaseImport } from '../utils/buildPaths';
+import {
+  normalizePathForImport,
+  rebaseImport,
+  resolveHashPlaceholderFileName,
+} from '../utils/buildPaths';
 import { findRemoteEntryFile } from '../utils/bundleHelpers';
 import { mapCodeToCodeWithSourcemap } from '../utils/mapCodeToCodeWithSourcemap';
 
@@ -222,15 +226,6 @@ function stripQueryAndHash(file: string) {
 
 function isReactRouterClientRouteInput(file: string) {
   return /[?&]__react-router-build-client-route(?:[=&]|$)/.test(file);
-}
-
-function resolveDevHashEntryFileName(fileName: string) {
-  if (!fileName.includes('[hash')) return fileName;
-
-  const normalized = fileName.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
-  const baseName = path.basename(normalized);
-
-  return path.extname(baseName) ? normalized : `${normalized}.js`;
 }
 
 export function getBuildInput(config: any) {
@@ -803,7 +798,7 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
             next();
             return;
           }
-          const devFileName = resolveDevHashEntryFileName(fileName);
+          const devFileName = resolveHashPlaceholderFileName(fileName);
           if (
             devFileName !== fileName &&
             req.url?.startsWith((viteConfig.base + devFileName).replace(/^\/?/, '/'))

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -29,7 +29,7 @@ import {
   processModuleAssets,
 } from '../utils/cssModuleHelpers';
 import { resolvePublicPath } from '../utils/pathNormalization';
-import { normalizePathForImport } from '../utils/buildPaths';
+import { normalizePathForImport, resolveHashPlaceholderFileName } from '../utils/buildPaths';
 import { DEFAULT_PUBLIC_TYPES_FOLDER } from '../utils/dtsConstants';
 import { normalizeVirtualModuleId } from '../utils/VirtualModule';
 import { getVirtualExposesId } from '../virtualModules/virtualExposes';
@@ -77,15 +77,6 @@ function resolveTypesMeta(dts: ReturnType<typeof getNormalizeModuleFederationOpt
     zip: `${typesFolder}.zip`,
     api: `${typesFolder}.d.ts`,
   };
-}
-
-function resolveDevRemoteEntryFileName(fileName: string): string {
-  if (!fileName.includes('[hash')) return fileName;
-
-  const normalized = fileName.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
-  const baseName = path.basename(normalized);
-
-  return path.extname(baseName) ? normalized : `${normalized}.js`;
 }
 
 function createRemoteEntryAssetMap(fileName: string) {
@@ -290,7 +281,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
        */
       configureServer(server) {
         server.middlewares.use((req, res, next) => {
-          const devRemoteEntryFile = resolveDevRemoteEntryFileName(filename);
+          const devRemoteEntryFile = resolveHashPlaceholderFileName(filename);
           if (
             devRemoteEntryFile !== filename &&
             Object.keys(mfOptions.exposes).length > 0 &&
@@ -415,7 +406,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
         ssrRemoteEntryFile =
           foundSsrRemoteEntryFile ||
           (_command === 'serve'
-            ? getSsrRemoteEntryFileName(resolveDevRemoteEntryFileName(mfOptions.filename))
+            ? getSsrRemoteEntryFileName(resolveHashPlaceholderFileName(mfOptions.filename))
             : expectedSsrRemoteEntryFile);
 
         // Second pass: Collect all CSS assets
@@ -526,7 +517,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
     const { name, varFilename } = options;
     const resolvedRemoteEntryFile =
       _command === 'serve'
-        ? remoteEntryFile || resolveDevRemoteEntryFileName(filename)
+        ? remoteEntryFile || resolveHashPlaceholderFileName(filename)
         : remoteEntryFile;
     const remoteEntry = {
       name: resolvedRemoteEntryFile,
@@ -537,7 +528,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
       name:
         ssrRemoteEntryFile ||
         getSsrRemoteEntryFileName(
-          _command === 'serve' ? resolveDevRemoteEntryFileName(filename) : filename
+          _command === 'serve' ? resolveHashPlaceholderFileName(filename) : filename
         ),
       path: _command === 'serve' ? '/__mf_ssr__/' : '',
       type: 'module',

--- a/src/plugins/pluginProxyRemoteEntry.ts
+++ b/src/plugins/pluginProxyRemoteEntry.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
-import { normalizePathForImport } from '../utils/buildPaths';
+import { normalizePathForImport, resolveHashPlaceholderFileName } from '../utils/buildPaths';
 import { findModuleImportDescriptors, getScannableModuleSource } from '../utils/htmlEntryUtils';
 import {
   addCssAssetsToAllExports,
@@ -29,15 +29,6 @@ interface ProxyRemoteEntryParams {
   remoteEntryId: string;
   virtualExposesId: string;
   getParsePromise?: () => Promise<unknown>;
-}
-
-function resolveDevHashEntryFileName(fileName: string) {
-  if (!fileName.includes('[hash')) return fileName;
-
-  const normalized = fileName.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
-  const baseName = path.basename(normalized);
-
-  return path.extname(baseName) ? normalized : `${normalized}.js`;
 }
 
 function resolveAbsoluteDevRemoteEntryUrl(publicPath: string, fileName: string): string {
@@ -252,7 +243,7 @@ export default function ({
               originalConfigBase
             );
             const devPublicPath = resolvedPublicPath === 'auto' ? '/' : resolvedPublicPath;
-            const remoteEntryFileName = resolveDevHashEntryFileName(options.filename);
+            const remoteEntryFileName = resolveHashPlaceholderFileName(options.filename);
             const isAbsolutePublicPath = /^https?:\/\//i.test(devPublicPath);
             const remoteEntryUrl = JSON.stringify(
               isAbsolutePublicPath

--- a/src/utils/__tests__/buildPaths.test.ts
+++ b/src/utils/__tests__/buildPaths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isAbsoluteUrl, rebaseImport } from '../buildPaths';
+import { isAbsoluteUrl, rebaseImport, resolveHashPlaceholderFileName } from '../buildPaths';
 
 describe('rebaseImport', () => {
   it('strips dir prefix from absolute path and makes relative', () => {
@@ -86,5 +86,40 @@ describe('isAbsoluteUrl', () => {
     expect(isAbsoluteUrl('./hostInit.js')).toBe(false);
     expect(isAbsoluteUrl('/static/js/hostInit.js')).toBe(false);
     expect(isAbsoluteUrl('static/js/hostInit.js')).toBe(false);
+  });
+});
+
+describe('resolveHashPlaceholderFileName', () => {
+  it('returns names without a placeholder unchanged', () => {
+    expect(resolveHashPlaceholderFileName('remoteEntry.js')).toBe('remoteEntry.js');
+    expect(resolveHashPlaceholderFileName('assets/remoteEntry.js')).toBe('assets/remoteEntry.js');
+  });
+
+  it('strips the placeholder along with its separator', () => {
+    expect(resolveHashPlaceholderFileName('remoteEntry-[hash].js')).toBe('remoteEntry.js');
+    expect(resolveHashPlaceholderFileName('remoteEntry.[hash].js')).toBe('remoteEntry.js');
+    expect(resolveHashPlaceholderFileName('remoteEntry_[hash].js')).toBe('remoteEntry.js');
+  });
+
+  it('supports sized placeholders', () => {
+    expect(resolveHashPlaceholderFileName('remote-entry-[hash:8].js')).toBe('remote-entry.js');
+  });
+
+  it('appends .js when stripping leaves no extension', () => {
+    expect(resolveHashPlaceholderFileName('remoteEntry-[hash]')).toBe('remoteEntry.js');
+    expect(resolveHashPlaceholderFileName('mf-[hash:8]')).toBe('mf.js');
+  });
+
+  it('treats a dotted directory as a directory, not an extension', () => {
+    expect(resolveHashPlaceholderFileName('assets/v1.2/remoteEntry-[hash]')).toBe(
+      'assets/v1.2/remoteEntry.js'
+    );
+    expect(resolveHashPlaceholderFileName('static/js.v2/mf-[hash:8]')).toBe('static/js.v2/mf.js');
+  });
+
+  it('is stable across repeated calls (global regex lastIndex)', () => {
+    for (let i = 0; i < 3; i++) {
+      expect(resolveHashPlaceholderFileName('remoteEntry-[hash].js')).toBe('remoteEntry.js');
+    }
   });
 });

--- a/src/utils/__tests__/buildPaths.test.ts
+++ b/src/utils/__tests__/buildPaths.test.ts
@@ -117,6 +117,12 @@ describe('resolveHashPlaceholderFileName', () => {
     expect(resolveHashPlaceholderFileName('static/js.v2/mf-[hash:8]')).toBe('static/js.v2/mf.js');
   });
 
+  it('handles Windows path separators', () => {
+    expect(resolveHashPlaceholderFileName('assets\\v1.2\\remoteEntry-[hash]')).toBe(
+      'assets\\v1.2\\remoteEntry.js'
+    );
+  });
+
   it('is stable across repeated calls (global regex lastIndex)', () => {
     for (let i = 0; i < 3; i++) {
       expect(resolveHashPlaceholderFileName('remoteEntry-[hash].js')).toBe('remoteEntry.js');

--- a/src/utils/buildPaths.ts
+++ b/src/utils/buildPaths.ts
@@ -1,3 +1,5 @@
+import { basename, extname } from 'node:path';
+
 /**
  * Rebase an import path for a bootstrap file that moved from root into `dir`.
  *
@@ -56,4 +58,29 @@ export const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i;
 export function isAbsoluteUrl(src: string): boolean {
   if (/^[a-z]:[\\/]/i.test(src)) return false;
   return EXTERNAL_URL_RE.test(src);
+}
+
+// Matches literal `[hash]` / `[hash:N]` placeholders together with the separator
+// that usually precedes them, so `remoteEntry-[hash].js` collapses to
+// `remoteEntry.js` rather than `remoteEntry-.js`.
+// Only ever used with String.prototype.replace, which resets lastIndex.
+const HASH_PLACEHOLDER_RE = /(?:[._-]?\[hash(?::\d+)?\])/g;
+
+/**
+ * Resolve a bundler `filename` template that still contains `[hash]` placeholders
+ * into the concrete, stable file name Module Federation serves.
+ *
+ * The federation entries are emitted by us rather than hashed by the bundler, so
+ * the placeholder is dropped instead of being substituted. When stripping it also
+ * removes the extension (`mf-[hash:8]` → `mf`), `.js` is appended so the result
+ * stays a loadable module. The extension check deliberately looks at the basename
+ * only — a dotted directory (`assets/v1.2/entry`) must not be mistaken for one.
+ */
+export function resolveHashPlaceholderFileName(fileName: string): string {
+  if (!fileName.includes('[hash')) return fileName;
+
+  const normalized = fileName.replace(HASH_PLACEHOLDER_RE, '');
+  const baseName = basename(normalized);
+
+  return extname(baseName) ? normalized : `${normalized}.js`;
 }

--- a/src/utils/buildPaths.ts
+++ b/src/utils/buildPaths.ts
@@ -1,5 +1,3 @@
-import { basename, extname } from 'node:path';
-
 /**
  * Rebase an import path for a bootstrap file that moved from root into `dir`.
  *
@@ -66,6 +64,15 @@ export function isAbsoluteUrl(src: string): boolean {
 // Only ever used with String.prototype.replace, which resets lastIndex.
 const HASH_PLACEHOLDER_RE = /(?:[._-]?\[hash(?::\d+)?\])/g;
 
+function hasFileExtension(fileName: string): boolean {
+  const baseName = fileName.slice(
+    Math.max(fileName.lastIndexOf('/'), fileName.lastIndexOf('\\')) + 1
+  );
+  const extensionIndex = baseName.lastIndexOf('.');
+
+  return extensionIndex > 0;
+}
+
 /**
  * Resolve a bundler `filename` template that still contains `[hash]` placeholders
  * into the concrete, stable file name Module Federation serves.
@@ -80,7 +87,5 @@ export function resolveHashPlaceholderFileName(fileName: string): string {
   if (!fileName.includes('[hash')) return fileName;
 
   const normalized = fileName.replace(HASH_PLACEHOLDER_RE, '');
-  const baseName = basename(normalized);
-
-  return extname(baseName) ? normalized : `${normalized}.js`;
+  return hasFileExtension(normalized) ? normalized : `${normalized}.js`;
 }

--- a/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntrySSR.test.ts
@@ -95,6 +95,13 @@ describe('virtualRemoteEntrySSR', () => {
       expect(getSsrRemoteEntryFileName('remoteEntry-[hash].js')).not.toContain('[hash');
       expect(getSsrRemoteEntryFileName('mf-[hash:8]')).not.toContain('[hash');
     });
+
+    it('keeps a dotted output directory intact', () => {
+      expect(getSsrRemoteEntryFileName('assets/v1.2/remoteEntry-[hash]')).toBe(
+        'assets/v1.2/remoteEntry.ssr.js'
+      );
+      expect(getSsrRemoteEntryFileName('static/js.v2/mf-[hash:8]')).toBe('static/js.v2/mf.ssr.js');
+    });
   });
 
   describe('getSsrExposesFileName', () => {
@@ -111,6 +118,13 @@ describe('virtualRemoteEntrySSR', () => {
     it('never leaves a literal [hash] in the exposes filename', () => {
       expect(getSsrExposesFileName('remoteEntry-[hash].js')).not.toContain('[hash');
       expect(getSsrExposesFileName('mf-[hash:8]')).not.toContain('[hash');
+    });
+
+    it('keeps a dotted output directory intact', () => {
+      expect(getSsrExposesFileName('assets/v1.2/remoteEntry-[hash]')).toBe(
+        'assets/v1.2/remoteEntry.exposes.js'
+      );
+      expect(getSsrExposesFileName('static/js.v2/mf-[hash:8]')).toBe('static/js.v2/mf.exposes.js');
     });
   });
 

--- a/src/virtualModules/virtualRemoteEntrySSR.ts
+++ b/src/virtualModules/virtualRemoteEntrySSR.ts
@@ -2,6 +2,7 @@ import {
   NormalizedModuleFederationOptions,
   ShareItem,
 } from '../utils/normalizeModuleFederationOptions';
+import { resolveHashPlaceholderFileName } from '../utils/buildPaths';
 import { getVirtualExposesSSRId } from './virtualExposesSSR';
 import { expandSharedPrefixKey, getUsedShares } from './virtualRemoteEntry';
 import { getVirtualModuleScopeKey } from './virtualModuleScope';
@@ -15,29 +16,27 @@ export function getRemoteEntrySSRId(
   return `${REMOTE_ENTRY_SSR_ID}:${getVirtualModuleScopeKey(options)}`;
 }
 
-function stripSsrFilenameHashPlaceholder(filename: string): string {
-  // Strip literal `[hash]` / `[hash:N]` placeholders so SSR companions stay
-  // stable (`remoteEntry-[hash].js` → `remoteEntry.js`). Do not try to mirror
-  // the browser content hash in the SSR filename.
-  if (!filename.includes('[hash')) return filename;
-  filename = filename.replace(/(?:[._-]?\[hash(?::\d+)?\])/g, '');
-  if (!/\.[^.]+$/.test(filename)) {
-    filename = `${filename}.js`;
-  }
-  return filename;
+// Trailing extension of a file name, e.g. `.js` in `remoteEntry.ssr.js`.
+const FILE_EXTENSION_RE = /\.[^.]+$/;
+
+// SSR companions keep a stable name instead of mirroring the browser content
+// hash, so `[hash]` placeholders are stripped rather than substituted. The
+// shared helper is used so the SSR name is derived exactly like the browser
+// one — see resolveHashPlaceholderFileName.
+function getSsrFileNameParts(browserFilename: string): { base: string; ext: string | undefined } {
+  const filename = resolveHashPlaceholderFileName(browserFilename);
+  const ext = FILE_EXTENSION_RE.exec(filename)?.[0];
+  const base = ext ? filename.slice(0, filename.length - ext.length) : filename;
+  return { base, ext };
 }
 
 export function getSsrRemoteEntryFileName(browserFilename: string): string {
-  const filename = stripSsrFilenameHashPlaceholder(browserFilename);
-  const ext = filename.match(/\.[^.]+$/)?.[0] || '.js';
-  const base = filename.slice(0, filename.length - ext.length);
-  return `${base}.ssr${ext}`;
+  const { base, ext } = getSsrFileNameParts(browserFilename);
+  return `${base}.ssr${ext ?? '.js'}`;
 }
 
 export function getSsrExposesFileName(browserFilename: string): string {
-  const filename = stripSsrFilenameHashPlaceholder(browserFilename);
-  const ext = filename.match(/\.[^.]+$/)?.[0];
-  const base = ext ? filename.slice(0, filename.length - ext.length) : filename;
+  const { base } = getSsrFileNameParts(browserFilename);
   return `${base}.exposes.js`;
 }
 


### PR DESCRIPTION
## Summary
`[hash]` placeholder stripping is implemented four times. Three copies are byte-identical under two different names — `resolveDevHashEntryFileName` in `pluginProxyRemoteEntry` and `pluginAddEntry`, `resolveDevRemoteEntryFileName` in `pluginMFManifest`. The fourth, `stripSsrFilenameHashPlaceholder` in `virtualRemoteEntrySSR`, has drifted: it tests `/\.[^.]+$/` against the whole path instead of the basename, so a dotted output directory is mistaken for a file extension and the SSR companion names come out wrong.

| `filename` | SSR entry (before) | exposes (before) |
| --- | --- | --- |
| `assets/v1.2/remoteEntry-[hash]` | `assets/v1.ssr.2/remoteEntry` | `assets/v1.exposes.js` |
| `static/js.v2/mf-[hash:8]` | `static/js.ssr.v2/mf` | `static/js.exposes.js` |

The entry path is mangled and the exposes name loses its directory. This is reachable rather than theoretical: `pluginMFManifest` composes both variants as `getSsrRemoteEntryFileName(resolveDevRemoteEntryFileName(...))`, so the browser and SSR names for the same `filename` can disagree — which is what #1157 and #1216 were about. The logic living in four places is why they can fall out of step again.

Behaviour is unchanged for any `filename` that has an extension or an undotted directory, so all existing tests pass untouched; the only change is that the SSR path now agrees with the browser path in the dotted-directory case.

## Changes
- Add `resolveHashPlaceholderFileName` to `utils/buildPaths` and use it from `pluginProxyRemoteEntry`, `pluginAddEntry` and `pluginMFManifest`, removing the three duplicate definitions.
- Derive the SSR companions through the same helper so `getSsrRemoteEntryFileName` and `getSsrExposesFileName` no longer treat a dotted directory as an extension.
- Name the two patterns involved — `HASH_PLACEHOLDER_RE` and `FILE_EXTENSION_RE` — following the existing `EXTERNAL_URL_RE` / `ASSET_LIKE_IMPORT_RE` convention.
- Cover the helper in `buildPaths.test.ts` (separators, sized placeholders, `.js` fallback, dotted directories, and repeated calls against the `/g` `lastIndex` hazard from #1214) and add dotted-directory regression cases to `virtualRemoteEntrySSR.test.ts`.

## Validation
- `pnpm test`: passed (51 files, 1,272 passed, 1 skipped).
- `pnpm test:integration`: passed (16 files, 94 passed).
- `pnpm typecheck`: passed.
- `pnpm build`: passed.
- `pnpm fmt.check`: passed.

## Follow-ups and open questions
This came out of a static-analysis pass over `src` that I went through by hand, keeping only findings that stand up as bug risk on their own. I'd rather land maintainability work in small reviewable pieces than drop a large one on you, and I'd like your steer before going further — you know which files are about to move.

Written and green, happy to open if useful:
1. **Share a single `escapeRegExp`.** It is defined three times with identical bodies (`utils/bundleHelpers`, `utils/VirtualModule`, `plugins/pluginProxyRemotes`) and inlined a fourth time in `utils/controlChunkSanitizer`. No behaviour change.
2. **Name inline regexes and use `Object.hasOwn`.** Hoist the two patterns in `getRuntimeHelpersImplementation`, and replace `Object.prototype.hasOwnProperty.call` at all 15 sites — target is ES2022, engines require Node >= 20.19, and the test suite already uses it.

Larger, and I would not start either without a ruling from you, since both touch the highest-churn files here and would conflict with in-flight fixes:

3. **Lifting types out of implementation files.** `index.ts` declares a run of local `type`/`interface` blocks (`MutableBundlerOutput`, `RolldownOptionsLike`, `BuilderLike`, `ModulePreloadResolveContext`, `ResolveAliasEntry`, `BundleChunkLike`) inline between functions. A colocated `types.ts` would make the plugin bodies easier to read, but it moves code you may be editing right now.
4. **Splitting the largest files** — `virtualRemoteEntry.ts` (2387 lines), `virtualShared_preBuild.ts` (2273), `index.ts` (2207). There are natural seams, but these change most often, so a split would hurt `git blame` and rebase every open PR. Only worth attempting if you want it and can point at seams you would accept.

For clarity on what I am *not* proposing: no style sweep. The nested ternaries read fine as house dialect, and the `//` comments carry the *why* behind specific bundler and framework quirks — turning those into JSDoc parameter boilerplate would throw that away. Happy to be told otherwise on any of it.
