### PR TITLE
fix: re-negotiate version-first singletons before host preload skip

### DIFF
--- a/integration/fixtures/version-first-singleton-host/entry.js
+++ b/integration/fixtures/version-first-singleton-host/entry.js
@@ -1,0 +1,10 @@
+import sharedLib from 'shared-lib';
+
+window.__host_saw_version__ = sharedLib.getVersion();
+
+const { REMOTE_SHARED_VERSION } = await import('remote1/Module');
+window.__remote_saw_version__ = REMOTE_SHARED_VERSION;
+
+document.querySelector('#app').textContent =
+  `host:${window.__host_saw_version__} remote:${window.__remote_saw_version__}`;
+console.log('__mf_host_entry_evaluated__');

--- a/integration/fixtures/version-first-singleton-host/entry.js
+++ b/integration/fixtures/version-first-singleton-host/entry.js
@@ -2,9 +2,10 @@ import sharedLib from 'shared-lib';
 
 window.__host_saw_version__ = sharedLib.getVersion();
 
-const { REMOTE_SHARED_VERSION } = await import('remote1/Module');
-window.__remote_saw_version__ = REMOTE_SHARED_VERSION;
+import('remote1/Module').then(({ REMOTE_SHARED_VERSION }) => {
+  window.__remote_saw_version__ = REMOTE_SHARED_VERSION;
 
-document.querySelector('#app').textContent =
-  `host:${window.__host_saw_version__} remote:${window.__remote_saw_version__}`;
-console.log('__mf_host_entry_evaluated__');
+  document.querySelector('#app').textContent =
+    `host:${window.__host_saw_version__} remote:${window.__remote_saw_version__}`;
+  console.log('__mf_host_entry_evaluated__');
+});

--- a/integration/fixtures/version-first-singleton-host/index.html
+++ b/integration/fixtures/version-first-singleton-host/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./entry.js"></script>
+  </body>
+</html>

--- a/integration/fixtures/version-first-singleton-host/index.html
+++ b/integration/fixtures/version-first-singleton-host/index.html
@@ -1,5 +1,8 @@
 <!doctype html>
 <html>
+  <head>
+    <link rel="icon" href="data:," />
+  </head>
   <body>
     <div id="app"></div>
     <script type="module" src="./entry.js"></script>

--- a/integration/fixtures/version-first-singleton-host/node_modules/shared-lib/index.js
+++ b/integration/fixtures/version-first-singleton-host/node_modules/shared-lib/index.js
@@ -1,0 +1,8 @@
+// A minimal stand-in for a real npm package. Uses a function (not a bare
+// string constant) to avoid the bundler inlining away this module's
+// identity across builds.
+export default {
+  getVersion() {
+    return '1.0.0';
+  },
+};

--- a/integration/fixtures/version-first-singleton-host/node_modules/shared-lib/package.json
+++ b/integration/fixtures/version-first-singleton-host/node_modules/shared-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "shared-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/integration/fixtures/version-first-singleton-remote/entry.js
+++ b/integration/fixtures/version-first-singleton-remote/entry.js
@@ -1,0 +1,2 @@
+// Minimal app entry — just needs to exist for vite to build.
+console.log('hello world');

--- a/integration/fixtures/version-first-singleton-remote/exposed-module.js
+++ b/integration/fixtures/version-first-singleton-remote/exposed-module.js
@@ -1,0 +1,3 @@
+import sharedLib from 'shared-lib';
+
+export const REMOTE_SHARED_VERSION = sharedLib.getVersion();

--- a/integration/fixtures/version-first-singleton-remote/index.html
+++ b/integration/fixtures/version-first-singleton-remote/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./entry.js"></script>
+  </body>
+</html>

--- a/integration/fixtures/version-first-singleton-remote/node_modules/shared-lib/index.js
+++ b/integration/fixtures/version-first-singleton-remote/node_modules/shared-lib/index.js
@@ -1,0 +1,8 @@
+// A minimal stand-in for a real npm package. Uses a function (not a bare
+// string constant) to avoid the bundler inlining away this module's
+// identity across builds.
+export default {
+  getVersion() {
+    return '1.5.0';
+  },
+};

--- a/integration/fixtures/version-first-singleton-remote/node_modules/shared-lib/package.json
+++ b/integration/fixtures/version-first-singleton-remote/node_modules/shared-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "shared-lib",
+  "version": "1.5.0",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/integration/version-first-singleton-browser.test.ts
+++ b/integration/version-first-singleton-browser.test.ts
@@ -1,0 +1,194 @@
+import { chromium } from '@playwright/test';
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { federation } from '../src';
+import { setPackageDetectionCwd } from '../src/utils/packageUtils';
+import { FIXTURES } from './helpers/build';
+
+type StaticServer = {
+  origin: string;
+  close: () => Promise<void>;
+};
+
+async function serveDirectory(root: string): Promise<StaticServer> {
+  const server = createServer(async (request, response) => {
+    const pathname = decodeURIComponent(new URL(request.url ?? '/', 'http://localhost').pathname);
+    const relativePath = pathname === '/' ? 'index.html' : pathname.replace(/^\//, '');
+    const filePath = path.resolve(root, relativePath);
+
+    if (filePath !== root && !filePath.startsWith(`${root}${path.sep}`)) {
+      response.writeHead(403).end();
+      return;
+    }
+
+    try {
+      const content = await readFile(filePath);
+      const contentType = filePath.endsWith('.html')
+        ? 'text/html'
+        : filePath.endsWith('.js')
+          ? 'application/javascript'
+          : 'application/octet-stream';
+      response.writeHead(200, {
+        'access-control-allow-origin': '*',
+        'content-type': contentType,
+      });
+      response.end(content);
+    } catch {
+      response.writeHead(404).end();
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Static server did not bind');
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function buildFixtureTo(
+  fixture: string,
+  outDir: string,
+  mfOptions: Parameters<typeof federation>[0]
+): Promise<void> {
+  // federation() resolves each shared package's version synchronously (via
+  // the process-wide package-detection cwd) before Vite's own config hook
+  // would otherwise point that detection at this fixture's root, so it must
+  // be set explicitly first whenever more than one fixture with its own
+  // same-named shared dependency is built within a single process.
+  setPackageDetectionCwd(path.resolve(FIXTURES, fixture));
+  const result = await build({
+    root: path.resolve(FIXTURES, fixture),
+    logLevel: 'silent',
+    build: {
+      outDir,
+      emptyOutDir: true,
+      target: 'chrome91',
+    },
+    plugins: [federation(mfOptions)],
+  });
+
+  if (Array.isArray(result)) throw new Error('Expected a single Rollup output');
+}
+
+async function createBrowser() {
+  return chromium.launch({ channel: 'chrome', headless: true });
+}
+
+const remoteOptions = {
+  name: 'remoteApp',
+  filename: 'remoteEntry.js',
+  exposes: {
+    './Module': path.resolve(FIXTURES, 'version-first-singleton-remote', 'exposed-module.js'),
+  },
+  shareStrategy: 'version-first',
+  shared: {
+    'shared-lib': { singleton: true },
+  },
+  dts: false,
+} satisfies Parameters<typeof federation>[0];
+
+function hostOptions(remoteEntry: string) {
+  return {
+    name: 'hostApp',
+    filename: 'remoteEntry.js',
+    remotes: {
+      remote1: {
+        name: 'remote1',
+        entry: remoteEntry,
+        type: 'module',
+      },
+    },
+    shareStrategy: 'version-first',
+    shared: {
+      'shared-lib': { singleton: true },
+    },
+    hostInitInjectLocation: 'html',
+    dts: false,
+  } satisfies Parameters<typeof federation>[0];
+}
+
+describe('version-first singleton static import browser bootstrap', () => {
+  it('resolves both host and remote static imports to the higher negotiated version', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'mf-version-first-singleton-browser-'));
+    let remoteServer: StaticServer | undefined;
+    let hostServer: StaticServer | undefined;
+    let browser: Awaited<ReturnType<typeof createBrowser>> | undefined;
+
+    try {
+      const remoteOutDir = path.join(workspace, 'remote');
+      const hostOutDir = path.join(workspace, 'host');
+      // remote declares shared-lib@1.5.0 — the higher of the two versions.
+      await buildFixtureTo('version-first-singleton-remote', remoteOutDir, remoteOptions);
+      remoteServer = await serveDirectory(remoteOutDir);
+      // host declares shared-lib@1.0.0 — the lower of the two versions.
+      await buildFixtureTo(
+        'version-first-singleton-host',
+        hostOutDir,
+        hostOptions(`${remoteServer.origin}/remoteEntry.js`)
+      );
+      hostServer = await serveDirectory(hostOutDir);
+
+      browser = await createBrowser();
+      const page = await browser.newPage();
+      const pageErrors: string[] = [];
+      const consoleErrors: string[] = [];
+      page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
+      page.on('console', (message) => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+      });
+
+      await page.goto(hostServer.origin, { waitUntil: 'domcontentloaded' });
+      try {
+        await page.waitForFunction(
+          () => document.querySelector('#app')?.textContent?.startsWith('host:'),
+          undefined,
+          { timeout: 15_000 }
+        );
+      } catch (error) {
+        throw new Error(
+          JSON.stringify(
+            {
+              cause: String(error),
+              pageErrors,
+              consoleErrors,
+              content: await page.content(),
+            },
+            null,
+            2
+          )
+        );
+      }
+
+      const [hostSaw, remoteSaw] = await Promise.all([
+        page.evaluate(() => (window as any).__host_saw_version__),
+        page.evaluate(() => (window as any).__remote_saw_version__),
+      ]);
+
+      // Under shareStrategy: 'version-first' with singleton: true, both the
+      // host's and the remote's static import of the shared singleton must
+      // resolve to the higher of the two negotiated versions, regardless of
+      // which side declared it.
+      expect(hostSaw).toBe('1.5.0');
+      expect(remoteSaw).toBe('1.5.0');
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await browser?.close();
+      await hostServer?.close();
+      await remoteServer?.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/integration/version-first-singleton-browser.test.ts
+++ b/integration/version-first-singleton-browser.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { build } from 'vite';
 import { describe, expect, it } from 'vitest';
 import { federation } from '../src';
-import { setPackageDetectionCwd } from '../src/utils/packageUtils';
+import { getPackageDetectionCwd, setPackageDetectionCwd } from '../src/utils/packageUtils';
 import { FIXTURES } from './helpers/build';
 
 type StaticServer = {
@@ -122,6 +122,7 @@ function hostOptions(remoteEntry: string) {
 
 describe('version-first singleton static import browser bootstrap', () => {
   it('resolves both host and remote static imports to the higher negotiated version', async () => {
+    const originalPackageDetectionCwd = getPackageDetectionCwd();
     const workspace = await mkdtemp(path.join(tmpdir(), 'mf-version-first-singleton-browser-'));
     let remoteServer: StaticServer | undefined;
     let hostServer: StaticServer | undefined;
@@ -184,11 +185,13 @@ describe('version-first singleton static import browser bootstrap', () => {
       expect(hostSaw).toBe('1.5.0');
       expect(remoteSaw).toBe('1.5.0');
       expect(pageErrors).toEqual([]);
+      expect(consoleErrors).toEqual([]);
     } finally {
       await browser?.close();
       await hostServer?.close();
       await remoteServer?.close();
       await rm(workspace, { recursive: true, force: true });
+      setPackageDetectionCwd(originalPackageDetectionCwd);
     }
   }, 60_000);
 });

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2205,8 +2205,14 @@ export function generateHostAutoInitCode(
               const cacheDescriptor = __mfGetSharedCacheDescriptor(pkg, share.shareConfig?.singleton, share.version, share.scope);
               if (
                 __mfReadSharedCache(__mfModuleCache.share, cacheDescriptor) !== undefined &&
-                __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) ${
-                  _command === 'serve' ? '!== undefined' : `=== ${cacheOwner}`
+                ${
+                  _command === 'serve'
+                    ? `__mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) !== undefined`
+                    : // A singleton negotiates against every remote under this strategy, so the
+                      // pre-init seed above can only ever record this container's own provisional
+                      // guess for it. Re-run loadShare() to let the runtime confirm or upgrade that
+                      // guess once remotes have registered, instead of treating it as final.
+                      `(!share.shareConfig?.singleton && __mfReadSharedCacheOwner(__mfModuleCache.share, cacheDescriptor) === ${cacheOwner})`
                 }
               ) return;
               // An import:false share has nothing to load until a foreign provider


### PR DESCRIPTION
Fixes #1247

## Bug

With `shareStrategy: 'version-first'` and a `singleton: true` shared package, a static `import` of that package resolved to the host's own declared version instead of the negotiated highest version across host + remote(s), with no console warning to surface the mismatch.

## Root cause

`hostAutoInit`'s shared-cache preload loop (`generateHostAutoInitCode`) skips calling `runtime.loadShare()` for a package whenever the cache already holds a value owned by the current container, to avoid redundant work:

```js
if (
  __mfReadSharedCache(...) !== undefined &&
  __mfReadSharedCacheOwner(...) === cacheOwner   // build mode
) return;
```

Separately, the container's own `init()` (called by `hostAutoInit` before this loop runs) unconditionally seeds the shared cache with its **local** fallback the moment it's needed, before remotes have been checked — this seed always writes with `owner: <this container>`.

For a `version-first` singleton, by the time the preload loop above runs, the cache is therefore *always* already populated and self-owned, so the skip condition is always true. The one code path that actually performs full, hook-respecting negotiation (`runtime.loadShare()`) never gets a chance to run and correct the premature local guess — even though the runtime's share scope has, by then, already registered the remote's higher version.

## Fix

A singleton negotiates against every remote under any strategy other than `'loaded-first'`, so the pre-init seed can only ever be a provisional guess for it. This bypasses the self-owned skip specifically for singleton shares, so `loadShare()` always gets to confirm or upgrade that guess once remotes have registered. Non-singleton shares, and the dev/serve-mode skip condition, are unchanged.

## Testing

- New integration test (`integration/version-first-singleton-browser.test.ts`) builds a real host + remote pair with `shareStrategy: 'version-first'` and a `singleton: true` shared package declared at two different versions, serves them, and asserts both sides' static imports resolve to the higher version in a real browser. Verified this test fails without the fix and passes with it.
- Full existing unit (1265 passed) and integration (95 passed) suites pass.
- Full e2e Playwright suite (`vite-vite-host`, `vite-vite-remote`, `multi-example`, `vite-runtime-register` — 27 tests, including the singleton-specific "shared-lib is initialized exactly once" and "does not download shared dependency payloads when dynamic remote hits cache" tests) passes, confirming no duplicate-load regression from removing the self-owned skip for singletons.
- Manually reproduced and verified against the minimal repro linked in the issue.
