### PR TITLE
refactor: share a single escapeRegExp helper

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { escapeRegExp } from '../../utils/regexEscape';
 import type {
   ConfigEnv,
   ConfigPluginContext,
@@ -1526,9 +1527,7 @@ describe('pluginAddEntry', () => {
     if (typeof result !== 'string') throw new Error('transformIndexHtml should return html string');
 
     const proxyPrefix = toViteEncodedId('virtual:mf-html-entry-proxy?');
-    const proxyIdMatch = result.match(
-      new RegExp(`src="(${proxyPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*)"`)
-    );
+    const proxyIdMatch = result.match(new RegExp(`src="(${escapeRegExp(proxyPrefix)}[^"]*)"`));
     expect(proxyIdMatch).not.toBeNull();
 
     const proxyId = decodeURIComponent(proxyIdMatch![1]).replace(/&amp;/g, '&');
@@ -1597,9 +1596,7 @@ describe('pluginAddEntry', () => {
 
     // Extract the proxy module ID from the rewritten HTML and load it
     const proxyPrefix = toViteEncodedId('virtual:mf-html-entry-proxy?');
-    const proxyIdMatch = result.match(
-      new RegExp(`src="(${proxyPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*)"`)
-    );
+    const proxyIdMatch = result.match(new RegExp(`src="(${escapeRegExp(proxyPrefix)}[^"]*)"`));
     expect(proxyIdMatch).not.toBeNull();
     const proxyId = decodeURIComponent(proxyIdMatch![1]).replace(/&amp;/g, '&');
     const code = await runLoad(servePlugin, proxyId);

--- a/src/plugins/pluginProxyRemotes.ts
+++ b/src/plugins/pluginProxyRemotes.ts
@@ -5,6 +5,7 @@ import { resolveRemoteConsumer } from '../utils/remoteConsumerTarget';
 import { getSsrCapabilities } from '../utils/ssrCapabilities';
 import { getInstalledPackageEntry } from '../utils/packageUtils';
 import { filterId } from '../utils/pathNormalization';
+import { escapeRegExp } from '../utils/regexEscape';
 import {
   getReactIslandImportRemoteId,
   getReactIslandServerImportId,
@@ -15,10 +16,6 @@ import { addUsedRemote, getRemoteVirtualModule, refreshHostAutoInit } from '../v
 
 function isNodeModulesImporter(importer?: string) {
   return importer?.includes('/node_modules/') || importer?.includes('\\node_modules\\');
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function appendAlias(config: Record<string, any>, alias: { find: RegExp; replacement: string }) {

--- a/src/utils/VirtualModule.ts
+++ b/src/utils/VirtualModule.ts
@@ -1,6 +1,7 @@
 import { basename } from 'node:path';
 import { packageNameDecode, packageNameEncode } from '../utils/packageUtils';
 import { createModuleFederationError } from './logger';
+import { escapeRegExp } from './regexEscape';
 import { getNormalizeModuleFederationOptions } from './normalizeModuleFederationOptions';
 
 export function getSuffix(name: string): string {
@@ -35,10 +36,6 @@ export const VITE_ENCODED_NULL_BYTE_PREFIX = `${VITE_ID_PREFIX}${VITE_NULL_BYTE_
 // Separates a federation instance's internalName from its per-generation
 // owner id inside scoped virtual module names.
 export const MF_OWNER_INFIX = '__mf_owner__';
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 export function createViteEncodedIdPrefixRegExp(sourcePrefix = ''): RegExp {
   return new RegExp(`^(?:${escapeRegExp(VITE_ENCODED_NULL_BYTE_PREFIX)})?${sourcePrefix}`);

--- a/src/utils/__tests__/regexEscape.test.ts
+++ b/src/utils/__tests__/regexEscape.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { escapeRegExp } from '../regexEscape';
+
+describe('escapeRegExp', () => {
+  it('leaves plain values untouched', () => {
+    expect(escapeRegExp('remoteEntry')).toBe('remoteEntry');
+  });
+
+  it('escapes every regex metacharacter', () => {
+    expect(escapeRegExp('.*+?^${}()|[]\\')).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\');
+  });
+
+  it('matches a scoped package name literally', () => {
+    const specifier = '@scope/pkg-1.2.x';
+    expect(new RegExp(`^${escapeRegExp(specifier)}$`).test(specifier)).toBe(true);
+    expect(new RegExp(`^${escapeRegExp(specifier)}$`).test('@scopeXpkg-1a2ax')).toBe(false);
+  });
+
+  it('matches a hashed chunk file name literally', () => {
+    const fileName = 'assets/remoteEntry-a1b2c3.js';
+    expect(new RegExp(escapeRegExp(fileName)).test(fileName)).toBe(true);
+    expect(new RegExp(escapeRegExp(fileName)).test('assets/remoteEntry-a1b2c3Xjs')).toBe(false);
+  });
+
+  it('keeps a virtual module id with a null-byte prefix matchable', () => {
+    const id = '\0virtual:mf-REMOTE_ENTRY_ID:host__remoteEntry.js';
+    expect(new RegExp(`^${escapeRegExp(id)}`).test(id)).toBe(true);
+  });
+});

--- a/src/utils/bundleHelpers.ts
+++ b/src/utils/bundleHelpers.ts
@@ -1,4 +1,5 @@
 import type { OutputBundleItem } from './cssModuleHelpers';
+import { escapeRegExp } from './regexEscape';
 
 type BundleChunkLike = { type: 'chunk'; fileName: string; code: string };
 type BundleAssetLike = { type: 'asset'; fileName: string };
@@ -14,10 +15,6 @@ type SystemProxyInfo = {
 
 function isOutputChunk(chunk: BundleLike[string]): chunk is BundleChunkLike {
   return chunk.type === 'chunk';
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/src/utils/controlChunkSanitizer.ts
+++ b/src/utils/controlChunkSanitizer.ts
@@ -1,4 +1,5 @@
 import { isIdentifierReferenced } from './bundleHelpers';
+import { escapeRegExp } from './regexEscape';
 
 const FEDERATION_CONTROL_CHUNK_HINTS = [
   'hostInit',
@@ -87,7 +88,7 @@ export function sanitizeFederationControlChunk(
 
   if (fileName.includes('localSharedImportMap')) {
     const remoteEntryImportRegex = new RegExp(
-      `import\\s*["'][^"']*${filename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']\\s*;?`,
+      `import\\s*["'][^"']*${escapeRegExp(filename)}["']\\s*;?`,
       'g'
     );
     nextCode = nextCode.replace(remoteEntryImportRegex, '');

--- a/src/utils/regexEscape.ts
+++ b/src/utils/regexEscape.ts
@@ -1,0 +1,14 @@
+// Characters that carry meaning inside a regular expression and must be
+// escaped when a runtime value is interpolated into a `new RegExp(...)` source.
+const REGEXP_SPECIAL_CHARS_RE = /[.*+?^${}()|[\]\\]/g;
+
+/**
+ * Escape `value` so it matches literally when interpolated into a regex source.
+ *
+ * Federation interpolates user-controlled strings — package names, chunk file
+ * names, virtual module ids — into generated matchers. Those routinely contain
+ * `.`, `+`, `[` and `\`, which would otherwise change what the pattern matches.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(REGEXP_SPECIAL_CHARS_RE, '\\$&');
+}


### PR DESCRIPTION
## Summary
`escapeRegExp` is defined three times with byte-identical bodies — in `utils/bundleHelpers`, `utils/VirtualModule` and `plugins/pluginProxyRemotes` — and inlined a fourth time in `utils/controlChunkSanitizer`, plus twice more in `pluginAddEntry`'s test. Each copy is the same `value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`.

The escape set matters because federation interpolates user-controlled strings into generated matchers — package names, chunk file names, virtual module ids — and those routinely contain `.`, `+`, `[` and `\`. Having the set written out in four places means a correction to one would silently miss the others.

No behaviour change: the pattern is unchanged at every call site, and a unit test now pins it.

## Changes
- Add `utils/regexEscape` exporting `escapeRegExp`, with the character class as a named `REGEXP_SPECIAL_CHARS_RE` constant.
- Import it from `utils/bundleHelpers`, `utils/VirtualModule`, `utils/controlChunkSanitizer` and `plugins/pluginProxyRemotes`, deleting the three local definitions and the inline copy.
- Use it for the two copies in `pluginAddEntry`'s test as well, so no duplicate of the class remains in `src`.
- Add `utils/__tests__/regexEscape.test.ts` covering the full metacharacter set and the three real interpolation shapes: a scoped package name, a hashed chunk file name, and a null-byte-prefixed virtual module id.

## Validation
- `pnpm test`: passed (52 files, 1,279 passed, 1 skipped).
- `pnpm test:integration`: passed (17 files, 95 passed).
- `pnpm typecheck`: passed.
- `pnpm build`: passed.
- `pnpm fmt.check`: passed.
