### PR TITLE
fix: preserve nested multi-scope initialization

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1196,6 +1196,12 @@ describe('virtualRemoteEntry', () => {
     );
 
     expect(code).toContain('const shareScopeNames = Array.isArray(["default","scope1"])');
+    expect(code).toContain(
+      'async function init(shared = {}, initScope = [], remoteEntryInitOptions = {})'
+    );
+    expect(code).toContain(
+      'remoteEntryInitOptions.shareScopeMap?.[scopeName] ?? (true ? (shared?.[scopeName] || {}) : shared)'
+    );
     expect(code).toContain('const getShareScopeName = (pkg, share) =>');
     expect(code).toContain('return [...new Set([...configuredScopes, ...shareScopeNames])]');
     expect(code).toContain('getShareScope(getShareScopeName(pkg, usedShare))');
@@ -1700,13 +1706,17 @@ describe('virtualRemoteEntry', () => {
       const guardStart = code.indexOf('let __mfInitPromise;');
       const guardEnd = code.indexOf('export { __mfGuardedInit', guardStart);
       const guardCode = code.slice(guardStart, guardEnd);
+      expect(guardCode).toContain('init(shared, initScope, remoteEntryInitOptions)');
       const scopedInit = Promise.resolve({ shareScopeMap: { default: {} } });
       const init = vi.fn(() => scopedInit);
       const guardedInit = new Function('init', `${guardCode}; return __mfGuardedInit;`)(init);
+      const initScope: unknown[] = [];
+      const remoteEntryInitOptions = { shareScopeMap: { default: {} } };
 
-      expect(guardedInit({ react: {} }, [])).toBe(scopedInit);
+      expect(guardedInit({ react: {} }, initScope, remoteEntryInitOptions)).toBe(scopedInit);
       expect(guardedInit()).toBe(scopedInit);
       expect(init).toHaveBeenCalledOnce();
+      expect(init).toHaveBeenCalledWith({ react: {} }, initScope, remoteEntryInitOptions);
       expect(guardCode).not.toContain('await ');
     }
   );

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -1254,9 +1254,9 @@ export function generateRemoteEntry(
     return exposesMapPromise
   }
 
-  async function init(shared = {}, initScope = []) {
+  async function init(shared = {}, initScope = [], remoteEntryInitOptions = {}) {
     ${sharedCacheHelperCode}
-    const getShareScope = (scopeName) => ${hasMultipleShareScopes} ? (shared?.[scopeName] || {}) : shared;
+    const getShareScope = (scopeName) => remoteEntryInitOptions.shareScopeMap?.[scopeName] ?? (${hasMultipleShareScopes} ? (shared?.[scopeName] || {}) : shared);
     const getShareScopeNames = (share) => {
       const configuredScopes = Array.isArray(share?.scope) ? share.scope : [share?.scope || shareScopeName];
       if (!${hasMultipleShareScopes}) return configuredScopes;
@@ -2128,9 +2128,9 @@ export function generateRemoteEntry(
   ${
     guardHostAutoInit
       ? `let __mfInitPromise;
-  function __mfGuardedInit(shared, initScope) {
+  function __mfGuardedInit(shared, initScope, remoteEntryInitOptions) {
     if (shared === undefined && __mfInitPromise) return __mfInitPromise;
-    __mfInitPromise = init(shared, initScope);
+    __mfInitPromise = init(shared, initScope, remoteEntryInitOptions);
     return __mfInitPromise;
   }
   export { __mfGuardedInit as init, getExposes as get }`


### PR DESCRIPTION
Closes #1258

Forward runtime share-scope maps through generated and guarded remote initialization.
