### PR TITLE
fix: report current plugin version

### DIFF
--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -14,6 +14,7 @@ import type {
   ResolvedConfig,
 } from 'vite';
 import { callHook } from '../../utils/__tests__/viteHookHelpers';
+import packageJson from '../../../package.json' with { type: 'json' };
 
 import manifestPlugin from '../pluginMFManifest';
 
@@ -297,6 +298,7 @@ describe('pluginMFManifest', () => {
     const stats = JSON.parse(emitted['mf-stats.json']);
 
     expect(manifest).toHaveProperty('metaData');
+    expect(manifest.metaData.pluginVersion).toBe(packageJson.version);
     expect(stats).toHaveProperty('buildOutput');
     expect(
       stats.buildOutput.find((chunk: { fileName: string }) => chunk.fileName === 'remoteEntry.js')
@@ -739,6 +741,7 @@ describe('pluginMFManifest', () => {
     const manifest = JSON.parse(source);
 
     expect(manifest.metaData.remoteEntry.name).toBe('remoteEntry.js');
+    expect(manifest.metaData.pluginVersion).toBe(packageJson.version);
     expect(manifest.metaData.ssrRemoteEntry.name).toBe('remoteEntry.ssr.js');
     expect(manifest.exposes[0].assets.js.sync).toEqual(['remoteEntry.js']);
   });

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { Plugin } from 'vite';
+import packageJson from '../../package.json' with { type: 'json' };
 import {
   getNormalizeModuleFederationOptions,
   getNormalizeShareItem,
@@ -332,7 +333,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
                     : undefined,
                   types: resolveTypesMeta(mfOptions.dts),
                   globalName: name,
-                  pluginVersion: '0.2.5',
+                  pluginVersion: packageJson.version,
                   publicPath,
                 },
               });
@@ -657,7 +658,7 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
         varRemoteEntry,
         types: resolveTypesMeta(options.dts),
         globalName: name,
-        pluginVersion: '0.2.5',
+        pluginVersion: packageJson.version,
         ...(!!getPublicPath ? { getPublicPath } : { publicPath }),
       },
       ...(disableAssetsAnalyze ? {} : { shared }),


### PR DESCRIPTION
Closes #1261

Use package metadata instead of stale hardcoded manifest version.