### PR TITLE
fix: coalesce eager shared wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ The `externalRuntime` rewrite applies to the browser remote graph; SSR remote en
 
 Do not set `build.rollupOptions.output.codeSplitting` or
 `build.rolldownOptions.output.codeSplitting` to `false` — it will be **ignored** (with a warning).
-Module Federation requires chunk splitting so `loadShare` and `runtimeInitStatus` stay isolated for correct bootstrap order.
+Module Federation requires chunk splitting so `runtimeInitStatus` and deferred `loadShare` wrappers stay isolated for correct bootstrap order. Eager `loadShare` wrappers are coalesced into one `loadShare-eager` chunk on Vite 8+ to reduce startup requests.
 
 ### `codeSplitting.groups` (Vite 8+ / Rolldown)
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -110,11 +110,12 @@ function createChunk(fileName: string, code: string): Rollup.OutputBundle[string
   } as unknown as Rollup.OutputBundle[string];
 }
 
-function getEsmShimsPlugin(): FederationPlugin {
+function getEsmShimsPlugin(shared?: ModuleFederationOptions['shared']): FederationPlugin {
   const plugin = (
     federation({
       name: 'host',
       filename: 'remoteEntry.js',
+      shared,
     }) as Plugin[]
   ).find((entry) => entry.name === 'module-federation-esm-shims');
 
@@ -922,6 +923,29 @@ describe('module-federation-esm-shims', () => {
     expect(Array.isArray(config.build.rolldownOptions.output.codeSplitting.groups)).toBe(true);
     expect(config.build.rolldownOptions.output.manualChunks).toBeUndefined();
     expect(mfWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces eager loadShare wrappers without grouping deferred shares', () => {
+    const plugin = getEsmShimsPlugin({
+      react: { eager: true },
+      vue: { eager: true },
+      lodash: { eager: false },
+    });
+    const config: any = { build: { rolldownOptions: { output: {} } } };
+
+    runConfig(plugin, {} as ConfigPluginContext, config, { command: 'build', mode: 'test' });
+
+    const name = federationNameFn(config.build.rolldownOptions.output);
+    expect(name('virtual:mf:host__loadShare__react__loadShare__.js')).toBe('loadShare-eager');
+    expect(name('virtual:mf:host__loadShare__vue__loadShare__.js')).toBe('loadShare-eager');
+    expect(name('virtual:mf:host__loadShare__lodash__loadShare__.js')).toContain(
+      '__loadShare__lodash__loadShare__'
+    );
+    expect(
+      config.build.rollupOptions.output.manualChunks(
+        'virtual:mf:host__loadShare__react__loadShare__.js'
+      )
+    ).toContain('__loadShare__react__loadShare__');
   });
 
   it('keeps user codeSplitting groups below the federation groups', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1586,6 +1586,11 @@ function federation(mfUserOptions: ModuleFederationOptions): any[] {
               return 'runtimeInit';
             }
             if (id.includes(LOAD_SHARE_TAG)) {
+              const pkg = getCachedLoadSharePkg(id);
+              const key = pkg && findSharedKey(pkg, shared);
+              if (useCodeSplitting && key && shared[key].shareConfig.eager === true) {
+                return 'loadShare-eager';
+              }
               // Use the virtual module path as the chunk name
               const match = id.match(/([^/\\]+__loadShare__[^/\\]+)/);
               return match ? match[1] : 'loadShare';


### PR DESCRIPTION
Closes #1265

Groups eager loadShare wrappers into one Rolldown chunk, reducing startup requests while preserving deferred isolation.
