### PR TITLE
feat: expose first-class ssrEntryLoader strategy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,27 @@ You can specify the place the host initialization file is injected with the **ho
 The **moduleParseTimeout** option allows you to configure the maximum time to wait for module parsing during the build process.
 The **moduleParseIdleTimeout** option is an alternative that resets the timer on every parsed module. It only fires when there has been no module activity for the configured duration, making it suitable for large codebases where the total build time exceeds the fixed timeout.
 
+## SSR entry loading strategy
+
+SSR hosts can choose how HTTP ESM remote entries are evaluated during build and preview:
+
+```ts
+federation({
+  name: "host",
+  remotes: {
+    // ...
+  },
+  ssrEntryLoader: {
+    strategy: "vm",
+  },
+});
+```
+
+- `"temp-file"` (default) fetches the remote graph, rewrites imports to host-resolved shared packages, writes temporary files, and loads them with `import()`.
+- `"vm"` evaluates the graph in memory with `vm.SourceTextModule` and resolves shared packages through the Module Federation share scope.
+
+The `"vm"` strategy requires Node.js to run with `--experimental-vm-modules`. When unavailable, the loader warns once and falls back to `"temp-file"`. Vite 8 development uses `ModuleRunner`; this option primarily affects build and preview SSR entry loading.
+
 ## Runtime capability optimization
 
 Runtime features that a build never uses can be removed at build time:

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3915,3 +3915,86 @@ describe('experiments.externalRuntime / provideExternalRuntime', () => {
     ).toBe(false);
   });
 });
+
+describe('ssrEntryLoader strategy injection', () => {
+  const hostRemotes = {
+    remoteApp: {
+      type: 'module' as const,
+      name: 'remoteApp',
+      entry: 'http://localhost:4174/remoteEntry.js',
+      shareScope: 'default',
+    },
+  };
+
+  function injectSsrEntryLoader(overrides: Partial<ModuleFederationOptions> = {}) {
+    const plugins = federation({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      remotes: hostRemotes,
+      ...overrides,
+    }) as Plugin[];
+    const earlyInitPlugin = plugins.find(
+      (plugin) => plugin.name === 'vite:module-federation-early-init'
+    );
+    const optionsPlugin = plugins.find((plugin) => plugin.name === 'module-federation-vite') as
+      | (Plugin & { _options: NormalizedModuleFederationOptions })
+      | undefined;
+    if (!earlyInitPlugin || !optionsPlugin) {
+      throw new Error('module federation plugins not found');
+    }
+
+    const resolverMock = vi.mocked(resolveImportPath);
+    const originalImplementation = resolverMock.getMockImplementation();
+    resolverMock.mockImplementation((id: string) => {
+      if (id === '@module-federation/vite/ssrEntryLoader') {
+        return '/plugin/lib/utils/ssrEntryLoader.js';
+      }
+      return originalImplementation!(id);
+    });
+    try {
+      callHook(
+        earlyInitPlugin.configResolved,
+        {} as MinimalPluginContextWithoutEnvironment,
+        { command: 'build', root: process.cwd() } as ResolvedConfig
+      );
+    } finally {
+      resolverMock.mockImplementation(originalImplementation!);
+    }
+
+    return optionsPlugin._options.runtimePlugins.find((plugin) => {
+      const specifier = typeof plugin === 'string' ? plugin : plugin[0];
+      return specifier === '@module-federation/vite/ssrEntryLoader';
+    });
+  }
+
+  it('injects resolvedShared without strategy when ssrEntryLoader is omitted', () => {
+    const injected = injectSsrEntryLoader();
+    expect(injected).toEqual([
+      '@module-federation/vite/ssrEntryLoader',
+      { resolvedShared: expect.any(Object) },
+    ]);
+    expect((injected as [string, Record<string, unknown>])[1]).not.toHaveProperty('strategy');
+  });
+
+  it('passes strategy with resolvedShared when ssrEntryLoader.strategy is set', () => {
+    const injected = injectSsrEntryLoader({ ssrEntryLoader: { strategy: 'vm' } });
+    expect(injected).toEqual([
+      '@module-federation/vite/ssrEntryLoader',
+      {
+        resolvedShared: expect.any(Object),
+        strategy: 'vm',
+      },
+    ]);
+  });
+
+  it('passes an explicit temp-file strategy with resolvedShared', () => {
+    const injected = injectSsrEntryLoader({ ssrEntryLoader: { strategy: 'temp-file' } });
+    expect(injected).toEqual([
+      '@module-federation/vite/ssrEntryLoader',
+      {
+        resolvedShared: expect.any(Object),
+        strategy: 'temp-file',
+      },
+    ]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ import type {
   PluginExperimentsOptions,
   PluginManifestOptions,
   ShareItem,
+  SsrEntryLoaderConfig,
+  SsrEntryLoaderStrategy,
   TreeShakingConfig,
 } from './utils/normalizeModuleFederationOptions';
 import { normalizeModuleFederationOptions } from './utils/normalizeModuleFederationOptions';
@@ -1010,7 +1012,15 @@ export default __mfShared.default ?? __mfShared;`,
       const ssrEntryLoaderSpecifier = SSR_ENTRY_LOADER_SPECIFIER;
       try {
         resolveImportPath(ssrEntryLoaderSpecifier);
-        options.runtimePlugins.push([ssrEntryLoaderSpecifier, { resolvedShared }]);
+        options.runtimePlugins.push([
+          ssrEntryLoaderSpecifier,
+          {
+            resolvedShared,
+            ...(options.ssrEntryLoader?.strategy
+              ? { strategy: options.ssrEntryLoader.strategy }
+              : {}),
+          },
+        ]);
       } catch {
         // lib/ not built yet — skip silently
       }
@@ -2193,5 +2203,7 @@ export {
   type ModuleFederationOptions,
   type PluginExperimentsOptions,
   type PluginManifestOptions,
+  type SsrEntryLoaderConfig,
+  type SsrEntryLoaderStrategy,
   type TreeShakingConfig,
 };

--- a/src/utils/__tests__/normalizeModuleFederationOption.test.ts
+++ b/src/utils/__tests__/normalizeModuleFederationOption.test.ts
@@ -57,6 +57,7 @@ describe('normalizeModuleFederationOption', () => {
       moduleParseIdleTimeout: undefined,
       target: undefined,
       ssrExternals: undefined,
+      ssrEntryLoader: undefined,
       disableRemote: undefined,
       disableShared: undefined,
       disableSnapshot: undefined,
@@ -85,6 +86,37 @@ describe('normalizeModuleFederationOption', () => {
         ssrExternals: ['sharp'],
       }).ssrExternals
     ).toEqual(['sharp']);
+  });
+
+  it('normalizes ssrEntryLoader.strategy when set', () => {
+    expect(normalizeModuleFederationOptions(minimalOptions).ssrEntryLoader).toBeUndefined();
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        ssrEntryLoader: {},
+      }).ssrEntryLoader
+    ).toBeUndefined();
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        ssrEntryLoader: { strategy: 'vm' },
+      }).ssrEntryLoader
+    ).toEqual({ strategy: 'vm' });
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        ssrEntryLoader: { strategy: 'temp-file' },
+      }).ssrEntryLoader
+    ).toEqual({ strategy: 'temp-file' });
+  });
+
+  it('drops invalid ssrEntryLoader.strategy values', () => {
+    expect(
+      normalizeModuleFederationOptions({
+        ...minimalOptions,
+        ssrEntryLoader: { strategy: 'unknown' as 'vm' },
+      }).ssrEntryLoader
+    ).toBeUndefined();
   });
 
   it('normalizes experiments.ssrMode as an explicit island opt-in', () => {

--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -100,6 +100,53 @@ describe('ssrEntryLoaderPlugin factory', () => {
   });
 });
 
+describe('ssrEntryLoaderPlugin — vm fallback', () => {
+  it('warns once and falls back to temp-file when vm modules are unavailable', async () => {
+    vi.doMock('../ssrVmStrategy', () => ({
+      isVmStrategyAvailable: vi.fn(async () => false),
+      loadViaVmStrategy: vi.fn(),
+    }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const { default: factory } = await freshLoaderModule();
+      const fsMock = await import('fs');
+      const fetch = makeFetchMock({
+        'http://localhost:5001/mf-manifest.json': {
+          ok: true,
+          json: {
+            metaData: {
+              ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '', type: 'module' },
+            },
+          },
+        },
+        'http://localhost:5001/remoteEntry.ssr.js': {
+          ok: true,
+          headers: { 'content-type': 'application/javascript' },
+          text: 'export async function init() {} export async function get() {}',
+        },
+      });
+      global.fetch = fetch as unknown as typeof globalThis.fetch;
+      const plugin = factory({ strategy: 'vm' });
+      const remote = {
+        remoteInfo: { name: 'r', entry: 'http://localhost:5001/remoteEntry.js' },
+      };
+
+      const first = await plugin.loadEntry!(remote);
+      const second = await plugin.loadEntry!(remote);
+
+      expect(first).toBeUndefined();
+      expect(second).toBeUndefined();
+      expect(fsMock.writeFileSync).toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('falling back'));
+    } finally {
+      warn.mockRestore();
+      vi.doUnmock('../ssrVmStrategy');
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Browser guard
 // ---------------------------------------------------------------------------

--- a/src/utils/normalizeModuleFederationOptions.ts
+++ b/src/utils/normalizeModuleFederationOptions.ts
@@ -492,6 +492,14 @@ function normalizeExperiments(
   };
 }
 
+function normalizeSsrEntryLoader(
+  ssrEntryLoader: ModuleFederationOptions['ssrEntryLoader']
+): SsrEntryLoaderConfig | undefined {
+  const strategy = ssrEntryLoader?.strategy;
+  if (strategy !== 'temp-file' && strategy !== 'vm') return undefined;
+  return { strategy };
+}
+
 export type ModuleFederationOptions = {
   exposes?: Record<string, string | { import: string }> | undefined;
   filename?: string;
@@ -599,6 +607,13 @@ export type ModuleFederationOptions = {
    */
   ssrExternals?: string[];
   /**
+   * Options for the auto-injected `@module-federation/vite/ssrEntryLoader`.
+   * When omitted, the loader uses the `'temp-file'` strategy. Set
+   * `strategy: 'vm'` to opt into `vm.SourceTextModule` evaluation while keeping
+   * the computed `resolvedShared` map.
+   */
+  ssrEntryLoader?: SsrEntryLoaderConfig;
+  /**
    * Experimental Module Federation capabilities.
    *
    * @see https://module-federation.io/configure/experiments
@@ -621,6 +636,22 @@ export interface PluginExperimentsOptions {
   /** Generate the React SSR/hydration island capability for eligible exposes. */
   ssrMode?: 'ISLAND';
 }
+
+export type SsrEntryLoaderStrategy = 'temp-file' | 'vm';
+
+export type SsrEntryLoaderConfig = {
+  /**
+   * How the auto-injected `@module-federation/vite/ssrEntryLoader` evaluates
+   * remote SSR entries.
+   *
+   * - `'temp-file'` (default when omitted): fetch the ESM graph, rewrite
+   *   specifiers, write temp files and `import()` them.
+   * - `'vm'`: evaluate the graph with `vm.SourceTextModule`. Requires
+   *   `--experimental-vm-modules`; the loader emits a single warning and
+   *   falls back to `'temp-file'` when that API is unavailable.
+   */
+  strategy?: SsrEntryLoaderStrategy;
+};
 
 export interface NormalizedExperimentsOptions {
   externalRuntime: boolean;
@@ -838,6 +869,7 @@ export function normalizeModuleFederationOptions(
     varFilename: options.varFilename,
     target: options.target,
     ssrExternals: options.ssrExternals,
+    ssrEntryLoader: normalizeSsrEntryLoader(options.ssrEntryLoader),
     disableRemote: options.disableRemote,
     disableShared: options.disableShared,
     disableSnapshot: options.disableSnapshot,


### PR DESCRIPTION
## Description

Exposes a first-class `ssrEntryLoader: { strategy?: 'temp-file' | 'vm' }` option so consumers do not need to post-process the auto-injected `@module-federation/vite/ssrEntryLoader` runtime plugin tuple after `configResolved` while preserving `resolvedShared`.

Fixes #1264

## Changes Made

- Add/normalize `ssrEntryLoader.strategy` in `ModuleFederationOptions` / `normalizeModuleFederationOptions` (omitted, empty, or invalid → `undefined`; `'vm'` / `'temp-file'` preserved)
- Auto-inject pushes `[specifier, { resolvedShared, strategy }]` when strategy is set; keeps `[specifier, { resolvedShared }]` when omitted (default temp-file)
- Existing single warning + temp-file fallback when Node lacks `--experimental-vm-modules` is unchanged

## Testing

- `pnpm test` (src unit): **1318 passed**, 1 skipped
- Targeted normalize + inject cases for omitted / invalid / `vm` / `temp-file`: **5 passed**
