### PR TITLE
fix: defer non-eager share wrappers in expose asset closures

### DIFF
--- a/e2e/vite-vite/tests/eager-manifest.spec.ts
+++ b/e2e/vite-vite/tests/eager-manifest.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test('classifies eager and deferred share wrappers in the built manifest', async ({ request }) => {
+  const response = await request.get('/mf-manifest.json');
+  expect(response.ok()).toBe(true);
+
+  const manifest = await response.json();
+  const exposed = manifest.exposes.find(
+    ({ name }: { name: string }) => name === 'EagerManifestFixture'
+  );
+  expect(exposed).toBeDefined();
+
+  const { sync, async } = exposed.assets.js;
+  expect(sync.some((asset: string) => asset.includes('loadShare-eager'))).toBe(true);
+  expect(async.some((asset: string) => asset.includes('__loadShare__vue__loadShare__'))).toBe(true);
+  expect(sync.some((asset: string) => asset.includes('__loadShare__vue__loadShare__'))).toBe(false);
+});

--- a/e2e/vite-vite/tests/host-preview.spec.ts
+++ b/e2e/vite-vite/tests/host-preview.spec.ts
@@ -8,6 +8,28 @@ import { expect, test } from '@playwright/test';
  * shared deps, default imports, named imports, CJS interop, etc.
  */
 test.describe('vite-vite host preview', () => {
+  test('classifies eager and deferred share wrappers in the built manifest', async ({
+    request,
+  }) => {
+    const response = await request.get('/mf-manifest.json');
+    expect(response.ok()).toBe(true);
+
+    const manifest = await response.json();
+    const exposed = manifest.exposes.find(
+      ({ name }: { name: string }) => name === 'EagerManifestFixture'
+    );
+    expect(exposed).toBeDefined();
+
+    const { sync, async } = exposed.assets.js;
+    expect(sync.some((asset: string) => asset.includes('loadShare-eager'))).toBe(true);
+    expect(async.some((asset: string) => asset.includes('__loadShare__vue__loadShare__'))).toBe(
+      true
+    );
+    expect(sync.some((asset: string) => asset.includes('__loadShare__vue__loadShare__'))).toBe(
+      false
+    );
+  });
+
   test('renders host app with React shared dep', async ({ page }) => {
     await page.goto('/');
     const heading = page.getByRole('heading', { name: 'MF HOST Demo', exact: true });

--- a/e2e/vite-vite/tests/host-preview.spec.ts
+++ b/e2e/vite-vite/tests/host-preview.spec.ts
@@ -8,28 +8,6 @@ import { expect, test } from '@playwright/test';
  * shared deps, default imports, named imports, CJS interop, etc.
  */
 test.describe('vite-vite host preview', () => {
-  test('classifies eager and deferred share wrappers in the built manifest', async ({
-    request,
-  }) => {
-    const response = await request.get('/mf-manifest.json');
-    expect(response.ok()).toBe(true);
-
-    const manifest = await response.json();
-    const exposed = manifest.exposes.find(
-      ({ name }: { name: string }) => name === 'EagerManifestFixture'
-    );
-    expect(exposed).toBeDefined();
-
-    const { sync, async } = exposed.assets.js;
-    expect(sync.some((asset: string) => asset.includes('loadShare-eager'))).toBe(true);
-    expect(async.some((asset: string) => asset.includes('__loadShare__vue__loadShare__'))).toBe(
-      true
-    );
-    expect(sync.some((asset: string) => asset.includes('__loadShare__vue__loadShare__'))).toBe(
-      false
-    );
-  });
-
   test('renders host app with React shared dep', async ({ page }) => {
     await page.goto('/');
     const heading = page.getByRole('heading', { name: 'MF HOST Demo', exact: true });

--- a/examples/vite-vite/vite-host/src/EagerManifestFixture.jsx
+++ b/examples/vite-vite/vite-host/src/EagerManifestFixture.jsx
@@ -1,0 +1,7 @@
+import { Button } from 'antd';
+import React from 'react';
+import { version as vueVersion } from 'vue';
+
+export default function EagerManifestFixture() {
+  return React.createElement(Button, null, `eager manifest fixture ${vueVersion}`);
+}

--- a/examples/vite-vite/vite-host/vite.config.js
+++ b/examples/vite-vite/vite-host/vite.config.js
@@ -6,6 +6,9 @@ const treeShakingMode = ['server-calc', 'runtime-infer'].includes(process.env.TR
   ? process.env.TREE_SHAKING_MODE
   : undefined;
 const eagerShared = process.env.EAGER_SHARED === 'true';
+const eagerManifestPort = process.env.EAGER_MANIFEST_PORT
+  ? Number(process.env.EAGER_MANIFEST_PORT)
+  : undefined;
 const externalRuntime = process.env.EXTERNAL_RUNTIME === '1';
 const antdShared = {
   singleton: true,
@@ -102,7 +105,7 @@ export default defineConfig({
     port: 5175,
   },
   preview: {
-    port: 5175,
+    port: eagerManifestPort ?? 5175,
   },
   // base: 'http://localhost:5175',
   plugins: [
@@ -111,6 +114,7 @@ export default defineConfig({
     secondaryFederation,
   ],
   build: {
+    outDir: eagerManifestPort ? 'dist-eager-manifest' : 'dist',
     target: 'chrome89',
     // This host runs on Vite 8 (Rolldown) so it exercises the
     // `codeSplitting.groups` composition path. The plugin installs its

--- a/examples/vite-vite/vite-host/vite.config.js
+++ b/examples/vite-vite/vite-host/vite.config.js
@@ -15,7 +15,7 @@ const antdShared = {
     : {}),
 };
 const shared = {
-  vue: {},
+  vue: eagerShared ? { import: false } : {},
   'react/': {
     singleton: true,
     requiredVersion: '^19.2.4',
@@ -60,6 +60,9 @@ function routeInstanceMarker(plugins, acceptsImporter) {
 const primaryFederation = routeInstanceMarker(
   federation({
     name: 'viteViteHost',
+    exposes: {
+      './EagerManifestFixture': './src/EagerManifestFixture.jsx',
+    },
     remotes: {
       '@namespace/viteViteRemote': 'http://localhost:5176/testbase/mf-manifest.json',
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       timeout: 120_000,
     },
     {
-      command: 'pnpm run preview-vv:ci',
+      command: 'EAGER_SHARED=true pnpm run preview-vv:ci',
       url: 'http://localhost:5175',
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,8 +15,15 @@ export default defineConfig({
       timeout: 120_000,
     },
     {
-      command: 'EAGER_SHARED=true pnpm run preview-vv:ci',
+      command: 'pnpm run preview-vv:ci',
       url: 'http://localhost:5175',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command:
+        'EAGER_SHARED=true EAGER_MANIFEST_PORT=5185 pnpm --filter examples-vite-vite-host run preview',
+      url: 'http://localhost:5185',
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
@@ -62,6 +69,15 @@ export default defineConfig({
       testMatch: 'remote-preview.spec.ts',
       use: {
         baseURL: 'http://localhost:5176',
+        browserName: 'chromium',
+      },
+    },
+    {
+      name: 'vite-vite-eager-manifest',
+      testDir: 'e2e/vite-vite/tests',
+      testMatch: 'eager-manifest.spec.ts',
+      use: {
+        baseURL: 'http://localhost:5185',
         browserName: 'chromium',
       },
     },

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -46,6 +46,11 @@ vi.mock('../../utils/treeShaking', () => ({
 vi.mock('../../virtualModules', () => ({
   getLocalSharedImportMapPath: ({ internalName }: { internalName: string }) =>
     `virtual:mf-localSharedImportMap:${internalName}__mf_owner__1`,
+  getLoadShareModulePath: (
+    pkg: string,
+    _isRolldown: boolean,
+    { internalName }: { internalName: string }
+  ) => `virtual:mf:${internalName}__loadShare__${pkg}__loadShare__.js`,
   getUsedRemotesMap,
   getUsedShares,
   getPreBuildLibImportId,
@@ -1058,6 +1063,57 @@ describe('pluginMFManifest', () => {
       sync: [],
       async: ['shared.js'],
     });
+  });
+
+  it('classifies a non-eager share wrapper in an expose closure as async', async () => {
+    // expandExposeAssets folds the expose's whole static closure into sync, and that
+    // closure carries the per-share __loadShare__ wrappers. A non-eager share resolves
+    // through the host at runtime, so preloading its wrapper fetches a provider the
+    // host is going to supply.
+    const wrapperFile = 'assets/loadShare-vue.js';
+    const exposed = createChunk('assets/exposed.js', ['/src/exposed.js']);
+    exposed.imports = [wrapperFile];
+    const wrapper = createChunk(wrapperFile, [
+      // Rollup prefixes virtual module ids with \0; the plugin normalizes both sides.
+      '\0virtual:mf:basicRemote__loadShare__vue__loadShare__.js',
+    ]);
+
+    const emitted = await runGenerateBundleWithManifest(true, {
+      bundle: { ...makeBundle(), 'assets/exposed.js': exposed, [wrapperFile]: wrapper },
+      exposePaths: { './exposed': { import: './src/exposed.js' } },
+      usedShares: new Set(['vue']),
+      shareItems: {
+        vue: { version: '3.5.0', shareConfig: { requiredVersion: '^3.5.0', eager: false } },
+      },
+    });
+
+    const exposeAssets = JSON.parse(emitted['mf-manifest.json']).exposes[0].assets.js;
+    expect(exposeAssets.sync).not.toContain(wrapperFile);
+    expect(exposeAssets.async).toContain(wrapperFile);
+    // The expose's own chunk is untouched.
+    expect(exposeAssets.sync).toContain('assets/exposed.js');
+  });
+
+  it('keeps an eager share wrapper in an expose closure synchronous', async () => {
+    const wrapperFile = 'assets/loadShare-vue.js';
+    const exposed = createChunk('assets/exposed.js', ['/src/exposed.js']);
+    exposed.imports = [wrapperFile];
+    const wrapper = createChunk(wrapperFile, [
+      '\0virtual:mf:basicRemote__loadShare__vue__loadShare__.js',
+    ]);
+
+    const emitted = await runGenerateBundleWithManifest(true, {
+      bundle: { ...makeBundle(), 'assets/exposed.js': exposed, [wrapperFile]: wrapper },
+      exposePaths: { './exposed': { import: './src/exposed.js' } },
+      usedShares: new Set(['vue']),
+      shareItems: {
+        vue: { version: '3.5.0', shareConfig: { requiredVersion: '^3.5.0', eager: true } },
+      },
+    });
+
+    const exposeAssets = JSON.parse(emitted['mf-manifest.json']).exposes[0].assets.js;
+    expect(exposeAssets.sync).toContain(wrapperFile);
+    expect(exposeAssets.async).not.toContain(wrapperFile);
   });
 
   it('marks unsafe tree-shaking usage as full-bundle-only', async () => {

--- a/src/plugins/__tests__/pluginMFManifest.test.ts
+++ b/src/plugins/__tests__/pluginMFManifest.test.ts
@@ -173,6 +173,7 @@ async function runGenerateBundleWithManifest(
             requiredVersion: string;
             singleton?: boolean;
             eager?: boolean;
+            import?: false;
             treeShaking?: {
               mode?: 'server-calc' | 'runtime-infer';
               usedExports?: string[];
@@ -1108,6 +1109,31 @@ describe('pluginMFManifest', () => {
       usedShares: new Set(['vue']),
       shareItems: {
         vue: { version: '3.5.0', shareConfig: { requiredVersion: '^3.5.0', eager: true } },
+      },
+    });
+
+    const exposeAssets = JSON.parse(emitted['mf-manifest.json']).exposes[0].assets.js;
+    expect(exposeAssets.sync).toContain(wrapperFile);
+    expect(exposeAssets.async).not.toContain(wrapperFile);
+  });
+
+  it('keeps an eager host-provided share wrapper synchronous', async () => {
+    const wrapperFile = 'assets/loadShare-vue.js';
+    const exposed = createChunk('assets/exposed.js', ['/src/exposed.js']);
+    exposed.imports = [wrapperFile];
+    const wrapper = createChunk(wrapperFile, [
+      '\0virtual:mf:basicRemote__loadShare__vue__loadShare__.js',
+    ]);
+
+    const emitted = await runGenerateBundleWithManifest(true, {
+      bundle: { ...makeBundle(), 'assets/exposed.js': exposed, [wrapperFile]: wrapper },
+      exposePaths: { './exposed': { import: './src/exposed.js' } },
+      usedShares: new Set(['vue']),
+      shareItems: {
+        vue: {
+          version: '3.5.0',
+          shareConfig: { requiredVersion: '^3.5.0', eager: true, import: false },
+        },
       },
     });
 

--- a/src/plugins/pluginMFManifest.ts
+++ b/src/plugins/pluginMFManifest.ts
@@ -9,12 +9,14 @@ import {
 } from '../utils/normalizeModuleFederationOptions';
 import { getTreeShakingExportUsage } from '../utils/treeShaking';
 import {
+  getLoadShareModulePath,
   getLocalSharedImportMapPath,
   getUsedRemotesMap,
   getUsedShares,
   TREE_SHAKING_GRAPH_QUERY,
   TREE_SHAKING_PROVIDER_TAG,
 } from '../virtualModules';
+import { getIsRolldown } from '../utils/packageUtils';
 
 import { findRemoteEntryFile } from '../utils/bundleHelpers';
 import {
@@ -112,14 +114,54 @@ function collectImportedCss(chunks: OutputChunkWithViteMetadata[]): string[] {
   return Array.from(css);
 }
 
+/**
+ * Collects the virtual module ids of the `__loadShare__` wrappers belonging to shares
+ * that are not eager.
+ *
+ * Such a wrapper resolves its share through the host at runtime, so it is a deferred
+ * dependency even though the expose statically imports it. Advertising it as a sync
+ * asset makes a preloader fetch a provider the host is going to supply anyway.
+ */
+function collectDeferredShareModules(
+  options: NormalizedModuleFederationOptions,
+  isRolldown: boolean
+): Set<string> {
+  const deferred = new Set<string>();
+  for (const shareKey of getUsedShares(options)) {
+    if (getNormalizeShareItem(shareKey, options)?.shareConfig.eager === true) continue;
+    deferred.add(normalizeVirtualModuleId(getLoadShareModulePath(shareKey, isRolldown, options)));
+  }
+  return deferred;
+}
+
+/**
+ * True when the chunk exists to load a deferred share rather than expose code.
+ *
+ * `chunk.moduleIds` carry Rollup's `\0` virtual-module prefix while
+ * `getLoadShareModulePath` returns the unprefixed id, so both sides are normalized —
+ * the same comparison `isContainerBootstrapChunk` makes.
+ */
+function isDeferredShareChunk(
+  chunk: OutputBundleItem | undefined,
+  deferredShareModules: Set<string>
+): boolean {
+  if (!chunk || chunk.type !== 'chunk' || deferredShareModules.size === 0) return false;
+  return [chunk.facadeModuleId, ...(chunk.moduleIds ?? [])].some(
+    (id) => typeof id === 'string' && deferredShareModules.has(normalizeVirtualModuleId(id))
+  );
+}
+
 function expandExposeAssets(
   filesMap: PreloadMap,
   exposeModules: string[],
   bundle: Record<string, OutputBundleItem>,
   remoteEntryFileName: string | undefined,
-  options: NormalizedModuleFederationOptions
+  options: NormalizedModuleFederationOptions,
+  isRolldown: boolean
 ): void {
   if (exposeModules.length === 0) return;
+
+  const deferredShareModules = collectDeferredShareModules(options, isRolldown);
 
   const containerChunks = remoteEntryFileName
     ? collectStaticChunks(bundle, [remoteEntryFileName])
@@ -166,15 +208,21 @@ function expandExposeAssets(
     const assets = filesMap[exposeModule];
     if (!assets) continue;
 
-    const syncChunks = collectStaticChunks(bundle, assets.js.sync);
+    const allSyncChunks = collectStaticChunks(bundle, assets.js.sync);
+    const syncChunks = allSyncChunks.filter(
+      (chunk) => !isDeferredShareChunk(chunk, deferredShareModules)
+    );
+    const deferredChunks = allSyncChunks.filter((chunk) =>
+      isDeferredShareChunk(chunk, deferredShareModules)
+    );
     const sync = Array.from(
       new Set([...bootstrapAssets, ...syncChunks.map((chunk) => chunk.fileName)])
     );
     const syncSet = new Set(sync);
-    const asyncChunks = collectStaticChunks(bundle, assets.js.async);
-    const async = asyncChunks
-      .map((chunk) => chunk.fileName)
-      .filter((fileName) => !syncSet.has(fileName));
+    const asyncChunks = [...collectStaticChunks(bundle, assets.js.async), ...deferredChunks];
+    const async = Array.from(new Set(asyncChunks.map((chunk) => chunk.fileName))).filter(
+      (fileName) => !syncSet.has(fileName)
+    );
 
     assets.js.sync = sync;
     assets.js.async = async;
@@ -445,7 +493,14 @@ const Manifest = (providedOptions?: NormalizedModuleFederationOptions): Plugin[]
             },
             { root, stripKnownJsExtensions: true }
           );
-          expandExposeAssets(filesMap, exposesModules, bundle, foundRemoteEntryFile, mfOptions);
+          expandExposeAssets(
+            filesMap,
+            exposesModules,
+            bundle,
+            foundRemoteEntryFile,
+            mfOptions,
+            getIsRolldown(this)
+          );
 
           // Process shared modules
           const fileToShareKey = await buildFileToShareKeyMap(


### PR DESCRIPTION
Fixes #1267.

## Problem

`expandExposeAssets` (`src/plugins/pluginMFManifest.ts`, added in #1092, first released in **1.20.8**) folds each expose's entire static-import closure into `assets.js.sync`. That closure carries the per-share `__loadShare__` wrapper chunks.

The wrappers *are* statically imported, so the walk is correct as written. But a wrapper for a share with `eager !== true` resolves through the host at runtime, so advertising it as `sync` gets it modulepreloaded and the remote fetches a provider the host is going to supply. That defeats the point of `eager: false`.

`#1243` does not cover this. With `import: false` the remote bundles no provider, so `filesMap[shareKey]` is empty — every entry in the emitted `shared[]` is `{"sync": [], "async": []}` — and that loop has nothing to act on.

Measured on one real application, Vite 8.2.2 throughout, only the plugin version changing:

| `@module-federation/vite` | `expandExposeAssets` | `./router` js.sync | `./menu` js.sync |
|---|---|---|---|
| 1.16.12 | absent | 1 | 1 |
| 1.21.5 | present | 23 | 12 |
| 1.21.6 | present | 23 | 12 |

The 9 `__loadShare__` chunks exist on disk in every one of those builds. Only their classification changes.

## Change

Partition the static closure in `expandExposeAssets`: a chunk that exists to load a non-eager share goes to `async`, everything else keeps its current classification.

```diff
-    const syncChunks = collectStaticChunks(bundle, assets.js.sync);
+    const allSyncChunks = collectStaticChunks(bundle, assets.js.sync);
+    const syncChunks = allSyncChunks.filter(
+      (chunk) => !isDeferredShareChunk(chunk, deferredShareModules)
+    );
+    const deferredChunks = allSyncChunks.filter((chunk) =>
+      isDeferredShareChunk(chunk, deferredShareModules)
+    );
     const sync = Array.from(
       new Set([...bootstrapAssets, ...syncChunks.map((chunk) => chunk.fileName)])
     );
     const syncSet = new Set(sync);
-    const asyncChunks = collectStaticChunks(bundle, assets.js.async);
-    const async = asyncChunks
-      .map((chunk) => chunk.fileName)
-      .filter((fileName) => !syncSet.has(fileName));
+    const asyncChunks = [...collectStaticChunks(bundle, assets.js.async), ...deferredChunks];
+    const async = Array.from(
+      new Set(asyncChunks.map((chunk) => chunk.fileName))
+    ).filter((fileName) => !syncSet.has(fileName));
```

Two small helpers do the identification. `collectDeferredShareModules` builds the id set from `getUsedShares` + `getLoadShareModulePath`, skipping any share with `shareConfig.eager === true`. `isDeferredShareChunk` tests a chunk's `facadeModuleId` and `moduleIds` against it.

One detail worth calling out: `chunk.moduleIds` carry Rollup's `\0` virtual-module prefix while `getLoadShareModulePath` returns the unprefixed id, so both sides go through `normalizeVirtualModuleId` — the same comparison `isContainerBootstrapChunk` makes a few lines above. Without that normalization the match silently never fires, which is how the first version of this patch passed its unit test and changed nothing in a real build.

- Scoped to non-eager shares — `eager: true` wrappers are untouched
- The expose's own chunks are untouched
- Asset totals are conserved; entries move between arrays rather than disappearing

## Test

Two regression tests in `src/plugins/__tests__/pluginMFManifest.test.ts`:

- `'classifies a non-eager share wrapper in an expose closure as async'` — an expose statically importing a wrapper chunk whose `moduleIds` carry the `\0`-prefixed loadShare id. Asserts the wrapper leaves `sync`, lands in `async`, and the expose's own chunk stays in `sync`.
- `'keeps an eager share wrapper in an expose closure synchronous'` — the same fixture with `eager: true`, guarding against over-correction.

The mock for `../../virtualModules` gains `getLoadShareModulePath`.

Verified locally:

- Full suite: **1315 passed | 1 skipped**
- Same suite with the source reverted and the tests kept: the non-eager test fails as expected, the other **1314 pass** — the test catches the bug and nothing existing regresses
- `pnpm typecheck` and `pnpm fmt --check` clean
- Empirical end-to-end: built `lib/` patched into a real Vite 8 remote's `node_modules`

  | expose | before | after |
  |---|---|---|
  | `./router` | sync 23 / async 28 | **sync 16 / async 35** |
  | `./menu` | sync 12 / async 0 | **sync 9 / async 3** |

  All 7 and 3 `__loadShare__` wrappers respectively move out of `sync`; totals conserved (51 and 12). The remaining `sync` entries are the container bootstrap chunks and the expose's own code, which is what #1092 intends.
