### PR TITLE
fix: leave eager shares out of the pending-share seed barrier

### DIFF
--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -1033,6 +1033,38 @@ describe('virtualRemoteEntry', () => {
     );
   });
 
+  it('leaves eager shares out of the build bootstrap: they are already static imports', async () => {
+    const share = (name: string, eager = false) => ({
+      name,
+      version: '1.0.0',
+      scope: 'default',
+      shareConfig: {
+        singleton: true,
+        strictVersion: false,
+        ...(eager ? { eager: true } : {}),
+      },
+    });
+    normalizedSharedMock.mockReturnValue({
+      react: share('react'),
+      'eager-shared': share('eager-shared', true),
+    });
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react');
+    mod.addUsedShares('eager-shared');
+
+    const localMap = mod.generateLocalSharedImportMap();
+    const buildCode = mod.generatePendingSharesCode('build');
+
+    // The import map already imports the eager share statically, so it is evaluated before the entry
+    // either way; seeding it as well would only make it a dynamic entry, and so a chunk of its own.
+    expect(localMap).toContain('from "virtual:prebuild:eager-shared";');
+    expect(buildCode).toContain(
+      'const __mfPendingShareImports = [["react", () => import("virtual:loadShare:react")]];'
+    );
+    expect(buildCode).not.toContain('virtual:loadShare:eager-shared');
+  });
+
   it('orders React package roots before their subpath shares', async () => {
     const share = (name: string) => ({
       name,

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -2365,6 +2365,10 @@ export function generatePendingSharesCode(
           .filter((pkg) => {
             const shareItem = getShareItemForPreload(pkg, resolvedOptions);
             if (!shareItem || pkg.endsWith('/')) return false;
+            // An eager share is already a static import of the local shared import map, so it is
+            // evaluated before the entry either way and the barrier has nothing to seed. Seeding it
+            // anyway is what makes every eager share a dynamic entry, and so a chunk of its own.
+            if (shareItem.shareConfig.eager) return false;
             return shareItem.shareConfig.import !== false && !shareItem.shareConfig.treeShaking;
           })
           .map(


### PR DESCRIPTION
Fixes #1272.

`generatePendingSharesCode()` seeds every materialized share with `() => import(<loadShare module>)`. For an `eager` share that seed is redundant — `generateLocalSharedImportMap()` already imports it statically, so it is evaluated before the entry runs either way — and it is what makes the share a dynamic entry, which the bundler then has to give a chunk of its own.

The change is one condition in the filter; the unit test asserts both halves of the invariant: the eager share still appears as a static `__mfEagerShare_` import in the local shared import map, and no longer appears in `__mfPendingShareImports`.

Repro: https://github.com/marksnode/mf-vite-repro-eager-pending-shares — ten eager shares; `npm run report` prints `shares the seed barrier imports: 10` on 1.21.6 and `0` with this change.

Measured on a real host (275 shares, no provider containers, Vite 8 / Rolldown): `index.html` 91,511 → 27,163 B, modulepreload links 435 → 128, first-paint bytes unchanged at ~9.6 MB, files under 2 KB 272 → 6. Once the shares stop being dynamic entries, Rolldown merges the wrappers on its own.

If you would rather keep the barrier symmetric, the alternative is to import the eager shares statically inside `pendingShares` as well — that removes the dynamic entries too; say the word and I will switch the PR to that shape.

One open question I could not settle from outside the project: whether any `loadShareSync`-style or SSR consumer relies on the seeded cache even when the share is eager. Full unit suite passes (70 files, 1411 tests), and our own app runs clean across 8 entry points.