### PR TITLE
fix: keep React DOM fallbacks coherent

### DIFF
--- a/src/plugins/__tests__/pluginAddEntry.test.ts
+++ b/src/plugins/__tests__/pluginAddEntry.test.ts
@@ -907,6 +907,14 @@ describe('pluginAddEntry', () => {
 
     expect(internalResult).toBeUndefined();
 
+    const localMapResult = await runTransform(
+      buildPlugin,
+      "const requiredExport = 'createRoot';",
+      '\0virtual:mf-localSharedImportMap:__mfe_internal__host__mf_owner__1'
+    );
+
+    expect(localMapResult).toBeUndefined();
+
     const entryResult = (await runTransform(
       buildPlugin,
       'import { hydrateRoot } from "react-dom/client";\nhydrateRoot(document, app);',

--- a/src/plugins/pluginAddEntry.ts
+++ b/src/plugins/pluginAddEntry.ts
@@ -679,7 +679,9 @@ for (const __mfRemoteEntryPrefetchUrl of __mfRemoteEntryPrefetchUrls) {
   function isFederationInternalVirtualId(id: string) {
     const normalized = decodeViteId(id).replace(/^\0+/, '');
     return (
-      normalized.includes('virtual:mf:') || /__(?:loadShare|prebuild|loadRemote)__/.test(normalized)
+      normalized.includes('virtual:mf:') ||
+      normalized.startsWith('virtual:mf-') ||
+      /__(?:loadShare|prebuild|loadRemote)__/.test(normalized)
     );
   }
 

--- a/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
+++ b/src/virtualModules/__tests__/virtualRemoteEntry.test.ts
@@ -673,6 +673,83 @@ describe('virtualRemoteEntry', () => {
     );
   });
 
+  it('reuses a cached singleton family before importing its local fallback', async () => {
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react-dom/client');
+
+    const hostRenderer = { marker: 'host-react-dom', createRoot: () => undefined };
+    const previousCache = (globalThis as any).__mf_module_cache__;
+    (globalThis as any).__mf_module_cache__ = {
+      share: {
+        'default:react': { version: '19.2.8' },
+        'default:react-dom': hostRenderer,
+      },
+      remote: {},
+    };
+    let localLoads = 0;
+    const code = mod
+      .generateLocalSharedImportMap()
+      .replace(
+        'import {loadShare} from "@module-federation/runtime";',
+        'const loadShare = () => {};'
+      )
+      .replace('import("virtual:prebuild:react-dom/client")', 'loadLocal()')
+      .replace(/export \{\s*usedShared,\s*usedRemotes\s*\}/, 'return { usedShared, usedRemotes }');
+
+    try {
+      const generated = new Function('loadLocal', code)(async () => {
+        localLoads++;
+        return { marker: 'local-react-dom-client' };
+      });
+      const factory = await generated.usedShared['react-dom/client'].get();
+
+      expect(factory()).toBe(hostRenderer);
+      expect(localLoads).toBe(0);
+    } finally {
+      if (previousCache === undefined) delete (globalThis as any).__mf_module_cache__;
+      else (globalThis as any).__mf_module_cache__ = previousCache;
+    }
+  });
+
+  it('does not use cached react-dom as react-dom/client', async () => {
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react-dom/client');
+
+    const previousCache = (globalThis as any).__mf_module_cache__;
+    (globalThis as any).__mf_module_cache__ = {
+      share: {
+        'default:react': { version: '19.2.8' },
+        'default:react-dom': { marker: 'host-react-dom' },
+      },
+      remote: {},
+    };
+    let localLoads = 0;
+    const code = mod
+      .generateLocalSharedImportMap()
+      .replace(
+        'import {loadShare} from "@module-federation/runtime";',
+        'const loadShare = () => {};'
+      )
+      .replace('import("virtual:prebuild:react-dom/client")', 'loadLocal()')
+      .replace(/export \{\s*usedShared,\s*usedRemotes\s*\}/, 'return { usedShared, usedRemotes }');
+
+    try {
+      const generated = new Function('loadLocal', code)(async () => {
+        localLoads++;
+        return { marker: 'local-react-dom-client' };
+      });
+      const factory = await generated.usedShared['react-dom/client'].get();
+
+      expect(factory()).toEqual({ marker: 'local-react-dom-client' });
+      expect(localLoads).toBe(1);
+    } finally {
+      if (previousCache === undefined) delete (globalThis as any).__mf_module_cache__;
+      else (globalThis as any).__mf_module_cache__ = previousCache;
+    }
+  });
+
   it('materializes direct React for vinext RSC hosts', async () => {
     hasPackageDependencyMock.mockImplementation((pkg: string) => pkg === 'vinext');
     const mod = await import('../virtualRemoteEntry');
@@ -2695,6 +2772,75 @@ describe('virtualRemoteEntry', () => {
     expect(orderedRuntimeSeed).toBeGreaterThan(globalBridgeEnd);
   });
 
+  it('seeds a materialized external singleton without loading its local fallback', async () => {
+    const shared = {
+      name: 'react-dom/client',
+      from: 'remote',
+      version: '19.2.8',
+      scope: 'default',
+      shareConfig: { singleton: true, requiredVersion: '^19.0.0' },
+    };
+    normalizedSharedMock.mockReturnValue({ 'react-dom/client': shared });
+    const mod = await import('../virtualRemoteEntry');
+    mod.getUsedShares().clear();
+    mod.addUsedShares('react-dom/client');
+
+    const code = mod.generateRemoteEntry(
+      {
+        internalName: '__mfe_internal__remote',
+        name: 'remote',
+        filename: 'remoteEntry.js',
+        exposes: {},
+        remotes: {},
+        shared: normalizedSharedMock(),
+        runtimePlugins: [],
+        shareScope: 'default',
+        shareStrategy: 'version-first',
+      } as any,
+      'virtual:exposes',
+      'build'
+    );
+    const hostRenderer = { marker: 'host-react-dom-client' };
+    const externalProvider = { from: 'host', lib: () => hostRenderer };
+    const state = { localLoads: 0 };
+    const usedShared = {
+      'react-dom/client': {
+        ...shared,
+        scope: ['default'],
+        get: async () => {
+          state.localLoads++;
+          return () => ({ marker: 'local-react-dom-client' });
+        },
+      },
+    };
+
+    const cached = await new Function(
+      'usedShared',
+      'state',
+      'externalProvider',
+      `return (async () => {
+        const __mfModuleCache = { share: {} };
+        const mfName = 'remote';
+        const initialShared = { 'react-dom/client': { '19.2.8': externalProvider } };
+        const __mfGetSharedCacheDescriptor = (pkg) => ({ canonical: 'default:' + pkg });
+        const __mfReadSharedCache = (cache, descriptor) => cache[descriptor.canonical];
+        const __mfReadSharedCacheOwner = () => undefined;
+        const __mfWriteSharedCache = (cache, descriptor, value) => {
+          cache[descriptor.canonical] = value;
+        };
+        const __mfReadTreeShakingSharedSelection = () => undefined;
+        const __mfSelectExternalSharedProvider = () => externalProvider;
+        const __mfGetExternalSharedProvider = () => externalProvider;
+        ${getRuntimeSeedCode(code)}
+        await __mfSeedLocalShared(['react-dom/client']);
+        return __mfModuleCache.share['default:react-dom/client'];
+      })();`
+    )(usedShared, state, externalProvider);
+
+    expect(state.localLoads).toBe(0);
+    expect(cached).toBe(hostRenderer);
+  });
+
   it('seeds a root host singleton before version-first remote initialization', async () => {
     const hostReactShare = {
       name: 'react',
@@ -3633,7 +3779,7 @@ describe('virtualRemoteEntry', () => {
       'if (__mfGetPendingExternalSharedProvider(pkg, usedShare)) return;'
     );
     expect(code).toContain(
-      "const pendingExternalProvider = typeof __mfGetPendingExternalSharedProvider === 'function'"
+      "const externalProvider = typeof __mfGetExternalSharedProvider === 'function'"
     );
     expect(code).toContain(
       'if (__mfGetPendingExternalSharedProvider(pkg, share, initialShared[pkg])) return;'

--- a/src/virtualModules/virtualRemoteEntry.ts
+++ b/src/virtualModules/virtualRemoteEntry.ts
@@ -171,6 +171,23 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
     import {loadShare} from "@module-federation/runtime";
     ${eagerImports}
     ${normalizeRuntimeShareCode}
+    const __mfGetCachedReactFamily = (keys, reactKeys, localVersion, requiredExport) => {
+      const cache = globalThis.__mf_module_cache__?.share;
+      const react = reactKeys.map((key) => cache?.[key]).find((value) => value !== undefined);
+      const reactVersion = react?.version ?? react?.default?.version;
+      const actual = String(reactVersion || '').split(/[^0-9]+/).map(Number);
+      const expected = String(localVersion || '').split(/[^0-9]+/).map(Number);
+      for (let index = 0; index < Math.max(actual.length, expected.length); index++) {
+        if ((actual[index] || 0) < (expected[index] || 0)) return undefined;
+        if ((actual[index] || 0) > (expected[index] || 0)) break;
+      }
+      for (const key of keys) {
+        const cached = cache?.[key];
+        if (cached === undefined) continue;
+        if (!requiredExport || typeof cached?.[requiredExport] === 'function' || typeof cached?.default?.[requiredExport] === 'function') return cached;
+      }
+      return undefined;
+    };
     const importMap = {
       ${orderedShares
         .map((pkg, index) => {
@@ -196,6 +213,17 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
         .map((key) => {
           const shareItem = getNormalizeShareItem(key, resolvedOptions);
           if (!shareItem) return null;
+          const isReactFamily = key.startsWith('react/') || key === 'react-dom/client';
+          const cacheKeys = [key, ...(key === 'react-dom/client' ? ['react-dom'] : [])].flatMap(
+            (pkg) => {
+              const descriptor = getSharedCacheDescriptor(pkg, shareItem);
+              return [descriptor.canonical, ...(descriptor.aliases ?? [])];
+            }
+          );
+          const reactCacheKeys = ['react'].flatMap((pkg) => {
+            const descriptor = getSharedCacheDescriptor(pkg, shareItem);
+            return [descriptor.canonical, ...(descriptor.aliases ?? [])];
+          });
           const detectedNamedExports = getSharedNamedExports(key, shareItem);
           const canLiveRebind =
             shareItem.shareConfig.import === false || detectedNamedExports !== undefined;
@@ -246,6 +274,18 @@ export function generateLocalSharedImportMap(options?: NormalizedModuleFederatio
             async get () {
               if (${shareItem.shareConfig.import === false}) {
                 throw new Error(\`[Module Federation] Shared module '\${${toSafeJsLiteral(key)}}' must be provided by host\`);
+              }
+              const cachedSingleton = ${shareItem.shareConfig.singleton && isReactFamily}
+                ? __mfGetCachedReactFamily(
+                    ${toSafeJsLiteral(cacheKeys)},
+                    ${toSafeJsLiteral(reactCacheKeys)},
+                    ${toSafeJsLiteral(shareItem.version)},
+                    ${toSafeJsLiteral(key === 'react-dom/client' ? 'createRoot' : undefined)}
+                  )
+                : undefined
+              if (cachedSingleton !== undefined) {
+                usedShared[${toSafeJsLiteral(key)}].loaded = true
+                return function () { return cachedSingleton }
               }
               usedShared[${toSafeJsLiteral(key)}].loaded = true
               const {${toSafeJsLiteral(key)}: pkgDynamicImport} = importMap
@@ -793,10 +833,26 @@ function generateRuntimeSharedCacheSeedCode(
           );
           return;
         }
-        const pendingExternalProvider = typeof __mfGetPendingExternalSharedProvider === 'function'
-          ? __mfGetPendingExternalSharedProvider(pkg, share)
+        const externalProvider = typeof __mfGetExternalSharedProvider === 'function'
+          ? __mfGetExternalSharedProvider(pkg, share)
           : undefined;
-        if (pendingExternalProvider && !pendingExternalProvider.lib && !pendingExternalProvider.loaded) {
+        if (externalProvider) {
+          let externalFactory = externalProvider.lib;
+          if (!externalFactory && externalProvider.loading) externalFactory = await externalProvider.loading;
+          if (!externalFactory && externalProvider.loaded && typeof externalProvider.get === 'function') {
+            externalFactory = await externalProvider.get();
+          }
+          if (externalFactory) {
+            const externalModule = typeof externalFactory === "function" ? externalFactory() : externalFactory;
+            const externalResolved = await Promise.resolve(externalModule);
+            ${normalizeRuntimeShareCode}
+            __mfWriteSharedCache(
+              __mfModuleCache.share,
+              cacheDescriptor,
+              __mfNormalizeRuntimeShare(externalResolved),
+              externalProvider.from
+            );
+          }
           return;
         }
         const providerKey = cacheDescriptor.canonical;
@@ -1379,28 +1435,32 @@ export function generateRemoteEntry(
       const parts = pkg.split('/');
       return pkg.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
     };
-    const __mfGetPendingExternalSharedProvider = (pkg, share, versionMap) => {
+    const __mfGetExternalSharedProvider = (pkg, share, versionMap, includePackage) => {
       if (typeof __mfSelectExternalSharedProvider !== 'function') return undefined;
       const packageName = __mfGetSharePackageName(pkg);
-      const candidates = packageName === pkg
+      const candidates = !includePackage || packageName === pkg
         ? [[pkg, share]]
         : [[pkg, share], [packageName, usedShared[packageName]]];
       for (const [candidatePkg, candidateShare] of candidates) {
         if (!candidateShare) continue;
         const candidateVersionMap = versionMap
           ? (candidatePkg === pkg ? versionMap : initialShared[candidatePkg])
-          : ${hasMultipleShareScopes ? 'getShareVersions(candidatePkg, candidateShare)' : 'shared[candidatePkg]'};
+          : (initialShared[candidatePkg] ?? ${hasMultipleShareScopes ? 'getShareVersions(candidatePkg, candidateShare)' : 'shared[candidatePkg]'});
         const provider = __mfSelectExternalSharedProvider(
           candidateVersionMap,
           candidatePkg,
           candidateShare,
           '${options.shareStrategy}'
         );
-        if (provider && isWebpackProvider(provider) && !provider.lib && !provider.loaded) {
-          return provider;
-        }
+        if (provider) return provider;
       }
       return undefined;
+    };
+    const __mfGetPendingExternalSharedProvider = (pkg, share, versionMap) => {
+      const provider = __mfGetExternalSharedProvider(pkg, share, versionMap, true);
+      return provider && isWebpackProvider(provider) && !provider.lib && !provider.loaded
+        ? provider
+        : undefined;
     };
     // handling circular init calls before an external provider can re-enter this container
     ${


### PR DESCRIPTION
Closes #1274
Preserve #1173, #1177;

Defers local singleton-family materialization, reuses host cache, and preserves shared-package self-imports.
 