### PR TITLE
fix: invalidate stale SSR ModuleRunner cache on manifest revalidation

### DIFF
--- a/src/utils/__tests__/ssrEntryLoader.test.ts
+++ b/src/utils/__tests__/ssrEntryLoader.test.ts
@@ -1498,6 +1498,61 @@ describe('ssrEntryLoaderPlugin — Vite 8+ ModuleRunner dev-mode path', () => {
     expect((second as unknown as { marker: string }).marker).toBe('v2');
   });
 
+  it('clears the ModuleRunner cache when maxAgeMs detects a manifest version change', async () => {
+    let marker = 'v1';
+    let cachedModule: { init: unknown; get: unknown; marker: string } | undefined;
+    const runner = {
+      import: vi.fn(async () => {
+        cachedModule ??= { init: vi.fn(), get: vi.fn(), marker };
+        return cachedModule;
+      }),
+      clearCache: vi.fn(() => {
+        cachedModule = undefined;
+      }),
+    };
+    const { factory } = await freshLoaderWithRunner(() => runner);
+
+    const responses = {
+      'http://localhost:4175/mf-manifest.json': {
+        ok: true,
+        json: {
+          metaData: {
+            buildInfo: { buildVersion: '1.0.0' },
+            ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '__mf_ssr__/', type: 'module' },
+          },
+        },
+      },
+      'http://localhost:4175/__mf_ssr__/remoteEntry.ssr.js': {
+        ok: true,
+        headers: { 'content-type': 'application/javascript' },
+      },
+    };
+    global.fetch = makeFetchMock(responses) as unknown as typeof globalThis.fetch;
+
+    const plugin = factory({ maxAgeMs: 0 });
+    const first = await plugin.loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:4175/remoteEntry.js' },
+    });
+
+    marker = 'v2';
+    responses['http://localhost:4175/mf-manifest.json'] = {
+      ok: true,
+      json: {
+        metaData: {
+          buildInfo: { buildVersion: '2.0.0' },
+          ssrRemoteEntry: { name: 'remoteEntry.ssr.js', path: '__mf_ssr__/', type: 'module' },
+        },
+      },
+    };
+    const second = await plugin.loadEntry!({
+      remoteInfo: { name: 'r', entry: 'http://localhost:4175/remoteEntry.js' },
+    });
+
+    expect(runner.clearCache).toHaveBeenCalledOnce();
+    expect((first as unknown as { marker: string }).marker).toBe('v1');
+    expect((second as unknown as { marker: string }).marker).toBe('v2');
+  });
+
   it('preserves remote module resolution and isolates runners by host', async () => {
     const hostReactPaths = [
       '/host-a/node_modules/react/index.js',

--- a/src/utils/ssrEntryLoader.ts
+++ b/src/utils/ssrEntryLoader.ts
@@ -623,7 +623,8 @@ async function getSSREntry(
 
   // Stale: re-fetch the manifest and re-resolve. If the version key changed
   // (remote redeployed at the same URL), the new key flows into temp-file
-  // names, so the fresh entry is imported instead of Node's cached module.
+  // names and the ModuleRunner cache is cleared, so the fresh entry is
+  // imported instead of a cached module.
   const previous = await cached.promise.catch(() => null);
   manifestFetchCache.delete(
     makeUrlCacheKey(getManifestUrl(remoteEntryUrl), fetchTimeoutMs, fetchMaxBytes)
@@ -633,6 +634,7 @@ async function getSSREntry(
 
   if (previous && next && previous.versionKey !== next.versionKey) {
     dropRemoteCaches(remoteEntryUrl);
+    await clearRunnerCaches(remoteEntryUrl);
   }
   return record.promise;
 }
@@ -661,7 +663,7 @@ function dropRemoteCaches(remoteEntryUrl: string): void {
   }
 }
 
-function clearRunnerCaches(remoteEntryUrl?: string): void {
+async function clearRunnerCaches(remoteEntryUrl?: string): Promise<void> {
   let remoteOrigin: string | undefined;
   if (remoteEntryUrl) {
     try {
@@ -671,10 +673,17 @@ function clearRunnerCaches(remoteEntryUrl?: string): void {
     }
   }
 
-  for (const cached of runnerCache.values()) {
-    if (remoteOrigin && cached.remoteOrigin !== remoteOrigin) continue;
-    void cached.promise.then((runner) => runner?.clearCache?.()).catch(() => {});
-  }
+  await Promise.all(
+    [...runnerCache.values()]
+      .filter((cached) => !remoteOrigin || cached.remoteOrigin === remoteOrigin)
+      .map(async (cached) => {
+        try {
+          (await cached.promise)?.clearCache?.();
+        } catch {
+          // A failed runner must not prevent another runner from being cleared.
+        }
+      })
+  );
 }
 
 /**
@@ -706,7 +715,7 @@ export function revalidate(remoteEntryUrl?: string): void {
     tempFilePathCache.clear();
   }
 
-  clearRunnerCaches(remoteEntryUrl);
+  void clearRunnerCaches(remoteEntryUrl);
 
   const federation = (
     globalThis as {


### PR DESCRIPTION
## Summary
Fix stale SSR modules returned by Vite 8+ ModuleRunner after a remote is redeployed at the same URL. When `maxAgeMs` revalidation detects a new manifest version, the loader now clears the affected remote's ModuleRunner cache.

## Changes
- Clear and await the origin-scoped ModuleRunner cache when the manifest version changes.
- Preserve the existing synchronous `revalidate()` API behavior.
- Add a regression test covering the SSR module refresh from `v1` to `v2`.

## Validation
- `pnpm exec vitest run src/utils/__tests__/ssrEntryLoader.test.ts src/utils/__tests__/ssrVmStrategy.test.ts --reporter=dot`: 79 passed, 1 skipped
- `pnpm test -- --reporter=dot`: 1,331 passed, 1 skipped
- `pnpm test:integration -- --reporter=dot`: 98 passed
- `pnpm run typecheck`, `pnpm run fmt.check`, `pnpm run build`: passed